### PR TITLE
Move StIdx to a tuple struct.

### DIFF
--- a/lrtable/src/lib/mod.rs
+++ b/lrtable/src/lib/mod.rs
@@ -55,20 +55,18 @@ pub use statetable::{Action, StateTable, StateTableError, StateTableErrorKind};
 /// StIdx is a wrapper for a 32-bit state index.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct StIdx {
-    // The biggest grammars I'm currently aware of have just over 1000 states, so in practise it
-    // looks like a u16 is always big enough to store state indexes. So, for as long as we can get
-    // away with it, we only store u16. Nevertheless, we tell the world we only deal in u32 so that
-    // we can change our storage to u32 later transparently.
-    v: u16
-}
+// The biggest grammars I'm currently aware of have just over 1000 states, so in practise it
+// looks like a u16 is always big enough to store state indexes. So, for as long as we can get
+// away with it, we only store u16. Nevertheless, we tell the world we only deal in u32 so that
+// we can change our storage to u32 later transparently.
+pub struct StIdx(u16);
 
 impl From<u32> for StIdx {
     fn from(v: u32) -> Self {
         if v > u32::from(u16::max_value()) {
             panic!("Overflow");
         }
-        StIdx{v: v as u16}
+        StIdx(v as u16)
     }
 }
 
@@ -77,19 +75,19 @@ impl From<usize> for StIdx {
         if v > usize::from(u16::max_value()) {
             panic!("Overflow");
         }
-        StIdx{v: v as u16}
+        StIdx(v as u16)
     }
 }
 
 impl From<StIdx> for usize {
     fn from(st: StIdx) -> Self {
-        st.v as usize
+        st.0 as usize
     }
 }
 
 impl From<StIdx> for u32 {
     fn from(st: StIdx) -> Self {
-        st.v as u32
+        st.0 as u32
     }
 }
 

--- a/lrtable/src/lib/pager.rs
+++ b/lrtable/src/lib/pager.rs
@@ -311,7 +311,7 @@ fn gc<StorageT: Eq + Hash + PrimInt>
     // First of all, do a simple pass over all states. All state indexes reachable from the
     // start state will be inserted into the 'seen' set.
     let mut todo = HashSet::new();
-    todo.insert(StIdx::from(0u32));
+    todo.insert(StIdx(0));
     let mut seen = HashSet::new();
     while !todo.is_empty() {
         // XXX This is the clumsy way we're forced to do what we'd prefer to be:
@@ -432,12 +432,12 @@ mod test {
         assert_eq!(sg.all_states_len(), 10);
         assert_eq!(sg.all_edges_len(), 10);
 
-        assert_eq!(sg.closed_state(StIdx::from(0u32)).items.len(), 3);
-        state_exists(&grm, &sg.closed_state(StIdx::from(0u32)), "^", 0, 0, vec!["$"]);
-        state_exists(&grm, &sg.closed_state(StIdx::from(0u32)), "S", 0, 0, vec!["$", "b"]);
-        state_exists(&grm, &sg.closed_state(StIdx::from(0u32)), "S", 1, 0, vec!["$", "b"]);
+        assert_eq!(sg.closed_state(StIdx(0)).items.len(), 3);
+        state_exists(&grm, &sg.closed_state(StIdx(0)), "^", 0, 0, vec!["$"]);
+        state_exists(&grm, &sg.closed_state(StIdx(0)), "S", 0, 0, vec!["$", "b"]);
+        state_exists(&grm, &sg.closed_state(StIdx(0)), "S", 1, 0, vec!["$", "b"]);
 
-        let s1 = sg.edge(StIdx::from(0u32), Symbol::Nonterm(grm.nonterm_idx("S").unwrap())).unwrap();
+        let s1 = sg.edge(StIdx(0), Symbol::Nonterm(grm.nonterm_idx("S").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s1).items.len(), 2);
         state_exists(&grm, &sg.closed_state(s1), "^", 0, 1, vec!["$"]);
         state_exists(&grm, &sg.closed_state(s1), "S", 0, 1, vec!["$", "b"]);
@@ -446,7 +446,7 @@ mod test {
         assert_eq!(sg.closed_state(s2).items.len(), 1);
         state_exists(&grm, &sg.closed_state(s2), "S", 0, 2, vec!["$", "b"]);
 
-        let s3 = sg.edge(StIdx::from(0u32), Symbol::Term(grm.term_idx("b").unwrap())).unwrap();
+        let s3 = sg.edge(StIdx(0), Symbol::Term(grm.term_idx("b").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s3).items.len(), 4);
         state_exists(&grm, &sg.closed_state(s3), "S", 1, 1, vec!["$", "b", "c"]);
         state_exists(&grm, &sg.closed_state(s3), "A", 0, 0, vec!["a"]);
@@ -508,16 +508,16 @@ mod test {
         assert_eq!(sg.all_edges_len(), 27);
 
         // State 0
-        assert_eq!(sg.closed_state(StIdx::from(0u32)).items.len(), 7);
-        state_exists(&grm, &sg.closed_state(StIdx::from(0u32)), "^", 0, 0, vec!["$"]);
-        state_exists(&grm, &sg.closed_state(StIdx::from(0u32)), "X", 0, 0, vec!["$"]);
-        state_exists(&grm, &sg.closed_state(StIdx::from(0u32)), "X", 1, 0, vec!["$"]);
-        state_exists(&grm, &sg.closed_state(StIdx::from(0u32)), "X", 2, 0, vec!["$"]);
-        state_exists(&grm, &sg.closed_state(StIdx::from(0u32)), "X", 3, 0, vec!["$"]);
-        state_exists(&grm, &sg.closed_state(StIdx::from(0u32)), "X", 4, 0, vec!["$"]);
-        state_exists(&grm, &sg.closed_state(StIdx::from(0u32)), "X", 5, 0, vec!["$"]);
+        assert_eq!(sg.closed_state(StIdx(0)).items.len(), 7);
+        state_exists(&grm, &sg.closed_state(StIdx(0)), "^", 0, 0, vec!["$"]);
+        state_exists(&grm, &sg.closed_state(StIdx(0)), "X", 0, 0, vec!["$"]);
+        state_exists(&grm, &sg.closed_state(StIdx(0)), "X", 1, 0, vec!["$"]);
+        state_exists(&grm, &sg.closed_state(StIdx(0)), "X", 2, 0, vec!["$"]);
+        state_exists(&grm, &sg.closed_state(StIdx(0)), "X", 3, 0, vec!["$"]);
+        state_exists(&grm, &sg.closed_state(StIdx(0)), "X", 4, 0, vec!["$"]);
+        state_exists(&grm, &sg.closed_state(StIdx(0)), "X", 5, 0, vec!["$"]);
 
-        let s1 = sg.edge(StIdx::from(0u32), Symbol::Term(grm.term_idx("a").unwrap())).unwrap();
+        let s1 = sg.edge(StIdx(0), Symbol::Term(grm.term_idx("a").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s1).items.len(), 7);
         state_exists(&grm, &sg.closed_state(s1), "X", 0, 1, vec!["a", "d", "e", "$"]);
         state_exists(&grm, &sg.closed_state(s1), "X", 1, 1, vec!["a", "d", "e", "$"]);
@@ -527,7 +527,7 @@ mod test {
         state_exists(&grm, &sg.closed_state(s1), "Z", 0, 0, vec!["c"]);
         state_exists(&grm, &sg.closed_state(s1), "T", 0, 0, vec!["a", "d", "e", "$"]);
 
-        let s7 = sg.edge(StIdx::from(0u32), Symbol::Term(grm.term_idx("b").unwrap())).unwrap();
+        let s7 = sg.edge(StIdx(0), Symbol::Term(grm.term_idx("b").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s7).items.len(), 7);
         state_exists(&grm, &sg.closed_state(s7), "X", 3, 1, vec!["a", "d", "e", "$"]);
         state_exists(&grm, &sg.closed_state(s7), "X", 4, 1, vec!["a", "d", "e", "$"]);
@@ -588,7 +588,7 @@ mod test {
         // Ommitted successors from the graph in Fig.3
 
         // X-successor of S0
-        let s0x = sg.edge(StIdx::from(0u32), Symbol::Nonterm(grm.nonterm_idx("X").unwrap())).unwrap();
+        let s0x = sg.edge(StIdx(0), Symbol::Nonterm(grm.nonterm_idx("X").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s0x), "^", 0, 1, vec!["$"]);
 
         // Y-successor of S1 (and it's d-successor)
@@ -656,7 +656,7 @@ mod test {
         let sg = pager_stategraph(&grm);
 
         // State 0
-        assert_eq!(sg.core_state(StIdx::from(0u32)).items.len(), 1);
-        state_exists(&grm, &sg.core_state(StIdx::from(0u32)), "^", 0, 0, vec!["$"]);
+        assert_eq!(sg.core_state(StIdx(0)).items.len(), 1);
+        state_exists(&grm, &sg.core_state(StIdx(0)), "^", 0, 0, vec!["$"]);
     }
 }

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -249,7 +249,7 @@ mod test {
         assert_eq!(sg.all_edges_len(), 9);
 
         // This follows the (not particularly logical) ordering of state numbers in the paper.
-        let s0 = StIdx::from(0u32);
+        let s0 = StIdx(0);
         sg.edge(s0, Symbol::Nonterm(grm.nonterm_idx("A").unwrap())).unwrap(); // s1
         let s2 = sg.edge(s0, Symbol::Term(grm.term_idx("a").unwrap())).unwrap();
         let s3 = sg.edge(s0, Symbol::Term(grm.term_idx("b").unwrap())).unwrap();

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -431,7 +431,7 @@ mod test {
         let sg = pager_stategraph(&grm);
         assert_eq!(sg.all_states_len(), 9);
 
-        let s0 = StIdx::from(0u32);
+        let s0 = StIdx(0);
         let s1 = sg.edge(s0, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
         let s2 = sg.edge(s0, Symbol::Nonterm(grm.nonterm_idx("Term").unwrap())).unwrap();
         let s3 = sg.edge(s0, Symbol::Nonterm(grm.nonterm_idx("Factor").unwrap())).unwrap();
@@ -511,7 +511,7 @@ mod test {
         assert_eq!(st.actions.len(), 8);
 
         // We only extract the states necessary to test those rules affected by the reduce/reduce.
-        let s0 = StIdx::from(0u32);
+        let s0 = StIdx(0);
         let s4 = sg.edge(s0, Symbol::Term(grm.term_idx("a").unwrap())).unwrap();
 
         assert_eq!(st.action(s4, grm.term_idx("x").unwrap()).unwrap(),
@@ -531,7 +531,7 @@ mod test {
         let st = StateTable::new(&grm, &sg).unwrap();
         assert_eq!(st.actions.len(), 15);
 
-        let s0 = StIdx::from(0u32);
+        let s0 = StIdx(0);
         let s1 = sg.edge(s0, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
         let s3 = sg.edge(s1, Symbol::Term(grm.term_idx("+").unwrap())).unwrap();
         let s4 = sg.edge(s1, Symbol::Term(grm.term_idx("*").unwrap())).unwrap();
@@ -560,7 +560,7 @@ mod test {
             ").unwrap();
         let sg = pager_stategraph(&grm);
         let st = StateTable::new(&grm, &sg).unwrap();
-        let s0 = StIdx::from(0u32);
+        let s0 = StIdx(0);
         let s1 = sg.edge(s0, Symbol::Term(grm.term_idx("a").unwrap())).unwrap();
         let s2 = sg.edge(s0, Symbol::Term(grm.term_idx("b").unwrap())).unwrap();
 
@@ -585,7 +585,7 @@ mod test {
         let st = StateTable::new(&grm, &sg).unwrap();
         assert_eq!(st.actions.len(), 15);
 
-        let s0 = StIdx::from(0u32);
+        let s0 = StIdx(0);
         let s1 = sg.edge(s0, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
         let s3 = sg.edge(s1, Symbol::Term(grm.term_idx("+").unwrap())).unwrap();
         let s4 = sg.edge(s1, Symbol::Term(grm.term_idx("*").unwrap())).unwrap();
@@ -624,7 +624,7 @@ mod test {
         let st = StateTable::new(&grm, &sg).unwrap();
         assert_eq!(st.actions.len(), 24);
 
-        let s0 = StIdx::from(0u32);
+        let s0 = StIdx(0);
         let s1 = sg.edge(s0, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
         let s3 = sg.edge(s1, Symbol::Term(grm.term_idx("+").unwrap())).unwrap();
         let s4 = sg.edge(s1, Symbol::Term(grm.term_idx("*").unwrap())).unwrap();
@@ -680,7 +680,7 @@ mod test {
         let st = StateTable::new(&grm, &sg).unwrap();
         assert_eq!(st.actions.len(), 34);
 
-        let s0 = StIdx::from(0u32);
+        let s0 = StIdx(0);
         let s1 = sg.edge(s0, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
         let s3 = sg.edge(s1, Symbol::Term(grm.term_idx("+").unwrap())).unwrap();
         let s4 = sg.edge(s1, Symbol::Term(grm.term_idx("*").unwrap())).unwrap();


### PR DESCRIPTION
As a happy coincidence, we can also rely on rustc's better type inference these days to remove most concrete types in the tests, making it easier to change this type in the future.