### PR TITLE
Better builder API

### DIFF
--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -31,6 +31,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 use std::collections::{HashMap, HashSet};
+use std::error::Error;
 use std::fmt;
 
 use indexmap::IndexMap;
@@ -84,6 +85,8 @@ pub struct GrammarValidationError {
     pub kind: GrammarValidationErrorKind,
     pub sym: Option<Symbol>
 }
+
+impl Error for GrammarValidationError {}
 
 impl fmt::Display for GrammarValidationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -34,7 +34,7 @@ use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::fmt;
 
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 
 use yacc::Precedence;
 
@@ -46,7 +46,7 @@ pub struct GrammarAST {
     // map from a rule name to indexes into prods
     pub rules: IndexMap<String, Vec<usize>>,
     pub prods: Vec<Production>,
-    pub tokens: HashSet<String>,
+    pub tokens: IndexSet<String>,
     pub precs: HashMap<String, Precedence>,
     pub implicit_tokens: Option<HashSet<String>>
 }
@@ -126,7 +126,7 @@ impl GrammarAST {
             rules:  IndexMap::new(), // Using an IndexMap means that we retain the order
                                      // of rules as they're found in the input file.
             prods:  Vec::new(),
-            tokens: HashSet::new(),
+            tokens: IndexSet::new(),
             precs:  HashMap::new(),
             implicit_tokens: None
         }

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -32,6 +32,7 @@
 
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::error::Error;
 use std::fmt;
 
 use num_traits::{self, AsPrimitive, PrimInt, Unsigned};
@@ -874,6 +875,8 @@ pub enum YaccGrammarError {
     YaccParserError(YaccParserError),
     GrammarValidationError(GrammarValidationError)
 }
+
+impl Error for YaccGrammarError {}
 
 impl From<YaccParserError> for YaccGrammarError {
     fn from(err: YaccParserError) -> YaccGrammarError {

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -33,6 +33,7 @@
 // Note: this is the parser for both YaccKind::Original and YaccKind::Eco yacc kinds.
 
 use std::collections::HashSet;
+use std::error::Error;
 use std::fmt;
 
 extern crate regex;
@@ -67,6 +68,8 @@ pub struct YaccParserError {
     line: usize,
     col: usize
 }
+
+impl Error for YaccParserError {}
 
 impl fmt::Display for YaccParserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/lrlex/examples/calclex/build.rs
+++ b/lrlex/examples/calclex/build.rs
@@ -6,5 +6,6 @@ fn main() {
     // Note that we specify the integer type (u8) we'll use for token IDs (this type *must* be big
     // enough to fit all IDs in) as well as the input file (which must end in ".l").
     LexerBuilder::<u8>::new()
-                       .process_file_in_src("calc.l", None).unwrap();
+                       .process_file_in_src("calc.l")
+                       .unwrap();
 }

--- a/lrlex/examples/calclex/build.rs
+++ b/lrlex/examples/calclex/build.rs
@@ -1,9 +1,10 @@
 extern crate lrlex;
 
-use lrlex::process_file_in_src;
+use lrlex::LexerBuilder;
 
 fn main() {
     // Note that we specify the integer type (u8) we'll use for token IDs (this type *must* be big
     // enough to fit all IDs in) as well as the input file (which must end in ".l").
-    process_file_in_src::<u8>("calc.l", None).unwrap();
+    LexerBuilder::<u8>::new()
+                       .process_file_in_src("calc.l", None).unwrap();
 }

--- a/lrlex/src/lib/builder.rs
+++ b/lrlex/src/lib/builder.rs
@@ -36,6 +36,7 @@ use std::env::{current_dir, var};
 use std::error::Error;
 use std::fmt::Debug;
 use std::fs::{File, read_to_string};
+use std::marker::PhantomData;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
@@ -48,111 +49,126 @@ const LEX_SUFFIX: &str = "_l";
 const LEX_FILE_EXT: &str = "l";
 const RUST_FILE_EXT: &str = "rs";
 
-/// Given the filename `x.l` as input, it will statically compile the file `src/x.l` into a Rust
-/// module which can then be imported using `lrlex_mod!(x_l)`. This is a convenience function
-/// around [`process_file`](fn.process_file.html) which makes it easier to compile `.l` files
-/// stored in a project's `src/` directory. Note that leaf names must be unique within a single
-/// project, even if they are in different directories: in other words, `a.l` and `x/a.l` will both
-/// be mapped to the same module `a_l` (and it is undefined what the resulting Rust module will
-/// contain).
-///
-/// See [`process_file`](fn.process_file.html)'s documentation for information about the
-/// `rule_ids_map` argument and the returned tuple.
-///
-/// # Panics
-///
-/// If the input filename does not end in `.l`.
-pub fn process_file_in_src<StorageT>(srcp: &str,
-                                  rule_ids_map: Option<HashMap<String, StorageT>>)
-                               -> Result<(Option<HashSet<String>>, Option<HashSet<String>>),
-                                         Box<Error>>
-                            where StorageT: Copy + Debug + Eq + TryFrom<usize> + TypeName
-{
-    let mut inp = current_dir()?;
-    inp.push("src");
-    inp.push(srcp);
-    if Path::new(srcp).extension().unwrap().to_str().unwrap() != LEX_FILE_EXT {
-        panic!("File name passed to process_file_in_src must have extension '{}'.", LEX_FILE_EXT);
-    }
-    let mut leaf = inp.file_stem().unwrap().to_str().unwrap().to_owned();
-    leaf.push_str(&LEX_SUFFIX);
-    let mut outp = PathBuf::new();
-    outp.push(var("OUT_DIR").unwrap());
-    outp.push(leaf);
-    outp.set_extension(RUST_FILE_EXT);
-    process_file::<StorageT, _, _>(inp, outp, rule_ids_map)
+pub struct LexerBuilder<StorageT=u32> {
+    phantom: PhantomData<StorageT>
 }
 
-/// Statically compile the `.l` file `inp` into Rust, placing the output into `outp`. The latter
-/// defines a module with a function `lexerdef()`, which returns a
-/// [`LexerDef`](struct.LexerDef.html) that can then be used as normal.
-///
-/// If `None` is passed to `rule_ids_map` is ignored: lexing rules have arbitrary, but distinct,
-/// IDs. If `Some(x)` is passed to `rule_ids_map` then the semantics of this parameter, and the
-/// returned tuple are the same as [`set_rule_ids`](struct.LexerDef.html#method.set_rule_ids) (in
-/// other words, `rule_ids_map` can be used to synchronise a lexer and parser, and to check that
-/// all rules are used by both parts).
-pub fn process_file<StorageT, P, Q>(inp: P,
-                                 outp: Q,
-                                 rule_ids_map: Option<HashMap<String, StorageT>>)
-                              -> Result<(Option<HashSet<String>>, Option<HashSet<String>>),
-                                        Box<Error>>
-                           where StorageT: Copy + Debug + Eq + TryFrom<usize> + TypeName,
-                                 P: AsRef<Path>,
-                                 Q: AsRef<Path>
+impl<StorageT> LexerBuilder<StorageT>
+where StorageT: Copy + Debug + Eq + TryFrom<usize> + TypeName
 {
-    let inc = read_to_string(&inp).unwrap();
-    let mut lexerdef = parse_lex::<StorageT>(&inc)?;
-    let (missing_from_lexer, missing_from_parser) = match rule_ids_map {
-        Some(ref rim) => {
-            // Convert from HashMap<String, _> to HashMap<&str, _>
-            let owned_map = rim.iter()
-                               .map(|(x, y)| (&**x, *y))
-                               .collect::<HashMap<_, _>>();
-            match lexerdef.set_rule_ids(&owned_map) {
-                (x, y) => {
-                    (x.map(|a| a.iter()
-                                .map(|b| b.to_string())
-                                .collect::<HashSet<_>>()),
-                     y.map(|a| a.iter()
-                                .map(|b| b.to_string())
-                                .collect::<HashSet<_>>()))
+    pub fn new() -> Self {
+        LexerBuilder{
+            phantom: PhantomData
+        }
+    }
+
+    /// Given the filename `x.l` as input, it will statically compile the file `src/x.l` into a
+    /// Rust module which can then be imported using `lrlex_mod!(x_l)`. This is a convenience
+    /// function around [`process_file`](fn.process_file.html) which makes it easier to compile
+    /// `.l` files stored in a project's `src/` directory. Note that leaf names must be unique
+    /// within a single project, even if they are in different directories: in other words, `a.l`
+    /// and `x/a.l` will both be mapped to the same module `a_l` (and it is undefined what the
+    /// resulting Rust module will contain).
+    ///
+    /// See [`process_file`](fn.process_file.html)'s documentation for information about the
+    /// `rule_ids_map` argument and the returned tuple.
+    ///
+    /// # Panics
+    ///
+    /// If the input filename does not end in `.l`.
+    pub fn process_file_in_src(&self,
+                               srcp: &str,
+                               rule_ids_map: Option<HashMap<String, StorageT>>)
+                            -> Result<(Option<HashSet<String>>, Option<HashSet<String>>),
+                                       Box<Error>>
+    {
+        let mut inp = current_dir()?;
+        inp.push("src");
+        inp.push(srcp);
+        if Path::new(srcp).extension().unwrap().to_str().unwrap() != LEX_FILE_EXT {
+            panic!("File name passed to process_file_in_src must have extension '{}'.", LEX_FILE_EXT);
+        }
+        let mut leaf = inp.file_stem().unwrap().to_str().unwrap().to_owned();
+        leaf.push_str(&LEX_SUFFIX);
+        let mut outp = PathBuf::new();
+        outp.push(var("OUT_DIR").unwrap());
+        outp.push(leaf);
+        outp.set_extension(RUST_FILE_EXT);
+        self.process_file(inp, outp, rule_ids_map)
+    }
+
+    /// Statically compile the `.l` file `inp` into Rust, placing the output into `outp`. The
+    /// latter defines a module with a function `lexerdef()`, which returns a
+    /// [`LexerDef`](struct.LexerDef.html) that can then be used as normal.
+    ///
+    /// If `None` is passed to `rule_ids_map` is ignored: lexing rules have arbitrary, but
+    /// distinct, IDs. If `Some(x)` is passed to `rule_ids_map` then the semantics of this
+    /// parameter, and the returned tuple are the same as
+    /// [`set_rule_ids`](struct.LexerDef.html#method.set_rule_ids) (in other words, `rule_ids_map`
+    /// can be used to synchronise a lexer and parser, and to check that all rules are used by both
+    /// parts).
+    pub fn process_file<P, Q>(&self,
+                              inp: P,
+                              outp: Q,
+                              rule_ids_map: Option<HashMap<String, StorageT>>)
+                           -> Result<(Option<HashSet<String>>, Option<HashSet<String>>),
+                                      Box<Error>>
+                               where P: AsRef<Path>,
+                                     Q: AsRef<Path>
+    {
+        let inc = read_to_string(&inp).unwrap();
+        let mut lexerdef = parse_lex::<StorageT>(&inc)?;
+        let (missing_from_lexer, missing_from_parser) = match rule_ids_map {
+            Some(ref rim) => {
+                // Convert from HashMap<String, _> to HashMap<&str, _>
+                let owned_map = rim.iter()
+                                   .map(|(x, y)| (&**x, *y))
+                                   .collect::<HashMap<_, _>>();
+                match lexerdef.set_rule_ids(&owned_map) {
+                    (x, y) => {
+                        (x.map(|a| a.iter()
+                                    .map(|b| b.to_string())
+                                    .collect::<HashSet<_>>()),
+                         y.map(|a| a.iter()
+                                    .map(|b| b.to_string())
+                                    .collect::<HashSet<_>>()))
+                    }
                 }
+            },
+            None => (None, None)
+        };
+
+        let mut outs = String::new();
+        let mod_name = inp.as_ref().file_stem().unwrap().to_str().unwrap();
+        // Header
+        outs.push_str(&format!("mod {}_l {{", mod_name));
+        lexerdef.rust_pp(&mut outs);
+
+        // Token IDs
+        if let Some(rim) = rule_ids_map {
+            for (n, id) in &rim {
+                outs.push_str(&format!("#[allow(dead_code)]\nconst T_{}: {} = {:?};\n",
+                                       n.to_ascii_uppercase(),
+                                       StorageT::type_name(),
+                                       *id));
             }
-        },
-        None => (None, None)
-    };
-
-    let mut outs = String::new();
-    let mod_name = inp.as_ref().file_stem().unwrap().to_str().unwrap();
-    // Header
-    outs.push_str(&format!("mod {}_l {{", mod_name));
-    lexerdef.rust_pp(&mut outs);
-
-    // Token IDs
-    if let Some(rim) = rule_ids_map {
-        for (n, id) in &rim {
-            outs.push_str(&format!("#[allow(dead_code)]\nconst T_{}: {} = {:?};\n",
-                                   n.to_ascii_uppercase(),
-                                   StorageT::type_name(),
-                                   *id));
         }
-    }
 
-    // Footer
-    outs.push_str("}");
+        // Footer
+        outs.push_str("}");
 
-    // If the file we're about to write out already exists with the same contents, then we don't
-    // overwrite it (since that will force a recompile of the file, and relinking of the binary
-    // etc).
-    if let Ok(curs) = read_to_string(&outp) {
-        if curs == outs {
-            return Ok((missing_from_lexer, missing_from_parser));
+        // If the file we're about to write out already exists with the same contents, then we
+        // don't overwrite it (since that will force a recompile of the file, and relinking of the
+        // binary etc).
+        if let Ok(curs) = read_to_string(&outp) {
+            if curs == outs {
+                return Ok((missing_from_lexer, missing_from_parser));
+            }
         }
+        let mut f = File::create(outp)?;
+        f.write_all(outs.as_bytes())?;
+        Ok((missing_from_lexer, missing_from_parser))
     }
-    let mut f = File::create(outp)?;
-    f.write_all(outs.as_bytes())?;
-    Ok((missing_from_lexer, missing_from_parser))
 }
 
 impl<StorageT: Copy + Debug + Eq + TypeName> LexerDef<StorageT> {

--- a/lrlex/src/lib/builder.rs
+++ b/lrlex/src/lib/builder.rs
@@ -49,6 +49,8 @@ const LEX_SUFFIX: &str = "_l";
 const LEX_FILE_EXT: &str = "l";
 const RUST_FILE_EXT: &str = "rs";
 
+/// A `LexerBuilder` allows one to specify the criteria for building a statically generated
+/// lexer.
 pub struct LexerBuilder<StorageT=u32> {
     phantom: PhantomData<StorageT>
 }
@@ -56,22 +58,38 @@ pub struct LexerBuilder<StorageT=u32> {
 impl<StorageT> LexerBuilder<StorageT>
 where StorageT: Copy + Debug + Eq + TryFrom<usize> + TypeName
 {
+    /// Create a new `LexerBuilder`.
+    ///
+    /// `StorageT` must be an unsigned integer type (e.g. `u8`, `u16`) which is big enough to index
+    /// all the tokens, nonterminals, and productions in the lexer and less than or equal in size
+    /// to `usize` (e.g. on a 64-bit machine `u128` would be too big). If you are lexing large
+    /// files, the additional storage requirements of larger integer types can be noticeable, and
+    /// in such cases it can be worth specifying a smaller type. `StorageT` defaults to `u32` if
+    /// unspecified.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// LexerBuilder::<u8>::new()
+    ///     .process_file_in_src("grm.l", None)
+    ///     .unwrap();
+    /// ```
     pub fn new() -> Self {
         LexerBuilder{
             phantom: PhantomData
         }
     }
 
-    /// Given the filename `x.l` as input, it will statically compile the file `src/x.l` into a
-    /// Rust module which can then be imported using `lrlex_mod!(x_l)`. This is a convenience
-    /// function around [`process_file`](fn.process_file.html) which makes it easier to compile
-    /// `.l` files stored in a project's `src/` directory. Note that leaf names must be unique
-    /// within a single project, even if they are in different directories: in other words, `a.l`
-    /// and `x/a.l` will both be mapped to the same module `a_l` (and it is undefined what the
-    /// resulting Rust module will contain).
+    /// Given the filename `x.l` as input, statically compile the file `src/x.l` into a Rust module
+    /// which can then be imported using `lrlex_mod!(x_l)`. This is a convenience function around
+    /// [`process_file`](struct.LexerBuilder.html#method.process_file) which makes it easier to
+    /// compile `.l` files stored in a project's `src/` directory. Note that leaf names must be
+    /// unique within a single project, even if they are in different directories: in other words,
+    /// `a.l` and `x/a.l` will both be mapped to the same module `a_l` (and it is undefined which
+    /// of the input files will "win" the compilation race).
     ///
-    /// See [`process_file`](fn.process_file.html)'s documentation for information about the
-    /// `rule_ids_map` argument and the returned tuple.
+    /// See [`process_file`](struct.LexerBuilder.html#method.process_file)'s documentation for
+    /// information about the `rule_ids_map` argument and the returned tuple.
     ///
     /// # Panics
     ///

--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -57,15 +57,7 @@ pub struct LexBuildError {
     col: usize
 }
 
-impl Error for LexBuildError {
-    fn description(&self) -> &str {
-        panic!("XXX");
-    }
-
-    fn cause(&self) -> Option<&Error> {
-        None
-    }
-}
+impl Error for LexBuildError {}
 
 /// The various different possible Lex parser errors.
 #[derive(Debug)]

--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -43,7 +43,7 @@ mod builder;
 mod lexer;
 mod parser;
 
-pub use builder::{process_file, process_file_in_src};
+pub use builder::LexerBuilder;
 pub use lexer::{Lexeme, LexerDef, Lexer, Rule};
 use parser::parse_lex;
 

--- a/lrpar/Cargo.toml
+++ b/lrpar/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/lib/mod.rs"
 [dependencies]
 cactus = "1.0"
 cfgrammar = { path="../cfgrammar", features=["serde"] }
+filetime = "0.2"
 getopts = "0.2"
 indexmap = "1.0"
 lrlex = { path="../lrlex" }

--- a/lrpar/examples/calcparse/build.rs
+++ b/lrpar/examples/calcparse/build.rs
@@ -33,6 +33,8 @@
 extern crate lrlex;
 extern crate lrpar;
 
+use lrpar::ParserBuilder;
+
 fn main() {
     // First we create the parser, which returns a HashMap of all the tokens used, then we pass
     // that HashMap to the lexer.
@@ -40,6 +42,8 @@ fn main() {
     // Note that we specify the integer type (u8) we'll use for token IDs (this type *must* be big
     // enough to fit all IDs in) as well as the input file (which must end in ".y" for lrpar, and
     // ".l" for lrlex).
-    let lex_rule_ids_map = lrpar::process_file_in_src::<u8>("calc.y").unwrap();
+    let lex_rule_ids_map = ParserBuilder::<u8>::new()
+                                               .process_file_in_src("calc.y")
+                                               .unwrap();
     lrlex::process_file_in_src::<u8>("calc.l", Some(lex_rule_ids_map)).unwrap();
 }

--- a/lrpar/examples/calcparse/build.rs
+++ b/lrpar/examples/calcparse/build.rs
@@ -33,6 +33,7 @@
 extern crate lrlex;
 extern crate lrpar;
 
+use lrlex::LexerBuilder;
 use lrpar::ParserBuilder;
 
 fn main() {
@@ -45,5 +46,7 @@ fn main() {
     let lex_rule_ids_map = ParserBuilder::<u8>::new()
                                                .process_file_in_src("calc.y")
                                                .unwrap();
-    lrlex::process_file_in_src::<u8>("calc.l", Some(lex_rule_ids_map)).unwrap();
+    LexerBuilder::new()
+                 .process_file_in_src("calc.l", Some(lex_rule_ids_map))
+                 .unwrap();
 }

--- a/lrpar/examples/calcparse/build.rs
+++ b/lrpar/examples/calcparse/build.rs
@@ -37,9 +37,9 @@ use lrlex::LexerBuilder;
 use lrpar::ParserBuilder;
 
 fn main() {
-    // First we create the parser, which returns a HashMap of all the tokens used, then we pass
-    // that HashMap to the lexer.
-
+    // We need to build the parser before the lexer, so that we can tie identifiers up between the
+    // two.
+    //
     // Note that we specify the integer type (u8) we'll use for token IDs (this type *must* be big
     // enough to fit all IDs in) as well as the input file (which must end in ".y" for lrpar, and
     // ".l" for lrlex).
@@ -47,6 +47,7 @@ fn main() {
                                                .process_file_in_src("calc.y")
                                                .unwrap();
     LexerBuilder::new()
-                 .process_file_in_src("calc.l", Some(lex_rule_ids_map))
+                 .rule_ids_map(lex_rule_ids_map)
+                 .process_file_in_src("calc.l")
                  .unwrap();
 }

--- a/lrpar/examples/calcparse/build.rs
+++ b/lrpar/examples/calcparse/build.rs
@@ -36,18 +36,17 @@ extern crate lrpar;
 use lrlex::LexerBuilder;
 use lrpar::ParserBuilder;
 
-fn main() {
-    // We need to build the parser before the lexer, so that we can tie identifiers up between the
-    // two.
+fn main() -> Result<(), Box<std::error::Error>> {
+    // First we create the parser, which returns a HashMap of all the tokens used, then we pass
+    // that HashMap to the lexer.
     //
     // Note that we specify the integer type (u8) we'll use for token IDs (this type *must* be big
     // enough to fit all IDs in) as well as the input file (which must end in ".y" for lrpar, and
     // ".l" for lrlex).
     let lex_rule_ids_map = ParserBuilder::<u8>::new()
-                                               .process_file_in_src("calc.y")
-                                               .unwrap();
+                                               .process_file_in_src("calc.y")?;
     LexerBuilder::new()
                  .rule_ids_map(lex_rule_ids_map)
-                 .process_file_in_src("calc.l")
-                 .unwrap();
+                 .process_file_in_src("calc.l")?;
+    Ok(())
 }

--- a/lrpar/examples/calcparse/src/calc.y
+++ b/lrpar/examples/calcparse/src/calc.y
@@ -7,4 +7,4 @@ Term: Factor 'MUL' Term
     | Factor ;
 
 Factor: 'LBRACK' Expr 'RBRACK'
-      | 'INT' ;
+      | 'INT';

--- a/lrpar/src/lib/builder.rs
+++ b/lrpar/src/lib/builder.rs
@@ -122,22 +122,12 @@ pub fn process_file<StorageT, P, Q>(inp: P,
 {
     let inc = read_to_string(&inp).unwrap();
 
-    let grm = match YaccGrammar::<StorageT>::new_with_storaget(YaccKind::Eco, &inc) {
-        Ok(x) => x,
-        Err(s) => {
-            panic!("{:?}", s);
-        }
-    };
+    let grm = YaccGrammar::<StorageT>::new_with_storaget(YaccKind::Eco, &inc)?;
     let rule_ids = grm.terms_map().iter()
                                   .map(|(&n, &i)| (n.to_owned(), i.as_storaget()))
                                   .collect::<HashMap<_, _>>();
 
-    let (sgraph, stable) = match from_yacc(&grm, Minimiser::Pager) {
-        Ok(x) => x,
-        Err(s) => {
-            panic!("{:?}", s);
-        }
-    };
+    let (sgraph, stable) = from_yacc(&grm, Minimiser::Pager)?;
 
     let mut outs = String::new();
     // Header

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -34,6 +34,7 @@
 
 extern crate cactus;
 extern crate cfgrammar;
+extern crate filetime;
 #[macro_use] extern crate indexmap;
 extern crate lrlex;
 extern crate lrtable;

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -51,7 +51,7 @@ pub mod parser;
 pub use parser::{Node, parse_rcvry, ParseError, ParseRepair, RecoveryKind};
 mod mf;
 
-pub use builder::{process_file, process_file_in_src, reconstitute};
+pub use builder::{ParserBuilder, reconstitute};
 
 /// A convenience macro for including statically compiled `.y` files. A file `src/x.y` which is
 /// statically compiled by lrpar can then be used in a crate with `lrpar_mod!(x)`.

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -30,7 +30,8 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-use std::fmt::Debug;
+use std::fmt::{self, Debug, Display};
+use std::error::Error;
 use std::hash::Hash;
 use std::time::{Duration, Instant};
 
@@ -442,6 +443,14 @@ pub struct ParseError<StorageT> {
     lexeme: Lexeme<StorageT>,
     repairs: Vec<Vec<ParseRepair<StorageT>>>
 }
+
+impl<StorageT: Debug> Display for ParseError<StorageT> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Parse error at lexeme {:?}", self.lexeme)
+    }
+}
+
+impl<StorageT: Debug> Error for ParseError<StorageT> {}
 
 impl<StorageT: PrimInt + Unsigned> ParseError<StorageT> {
     /// Return the state table index where this error was detected.

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -31,8 +31,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 use std::collections::hash_map::{Entry, HashMap, OccupiedEntry};
+use std::error::Error;
 use std::hash::{Hash, BuildHasherDefault};
-use std::fmt;
+use std::fmt::{self, Debug};
 use std::marker::PhantomData;
 
 use cfgrammar::{Grammar, PIdx, NTIdx, Symbol, TIdx};
@@ -56,6 +57,8 @@ pub struct StateTableError<StorageT> {
     pub kind: StateTableErrorKind,
     pub prod_idx: PIdx<StorageT>
 }
+
+impl<StorageT: Debug> Error for StateTableError<StorageT> {}
 
 impl<StorageT> fmt::Display for StateTableError<StorageT> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
The API for statically generating grammars was, previously, pretty bad: in particular, it was a bit fiddly to use, not very flexible, and not very extendible. This PR moves it to a struct-based system that solves these problems as best as I know how to. It also provides more error checking, and a safe way to avoid recompiling grammars when possible. The commits are a bit of a hodge-podge, but hopefully each one makes clear what it's doing.