### PR TITLE
Use bincode to serialize grammars at compile time.

### DIFF
--- a/lrpar/Cargo.toml
+++ b/lrpar/Cargo.toml
@@ -12,6 +12,7 @@ name = "lrpar"
 path = "src/lib/mod.rs"
 
 [dependencies]
+bincode = "1.0"
 cactus = "1.0"
 cfgrammar = { path="../cfgrammar", features=["serde"] }
 filetime = "0.2"

--- a/lrpar/src/lib/builder.rs
+++ b/lrpar/src/lib/builder.rs
@@ -41,20 +41,23 @@ use std::io::Write;
 use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
 
+use bincode::{deserialize, serialize_into};
 use cfgrammar::Grammar;
 use cfgrammar::yacc::{YaccGrammar, YaccKind};
 use filetime::FileTime;
 use lrtable::{Minimiser, from_yacc, StateGraph, StateTable};
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
-use rmps::{Deserializer, Serializer};
 use serde::{Deserialize, Serialize};
 use typename::TypeName;
 
 use RecoveryKind;
 
 const YACC_SUFFIX: &str = "_y";
-const YACC_FILE_EXT: &str = "y";
+
+const GRM_FILE_EXT: &str = "grm";
 const RUST_FILE_EXT: &str = "rs";
+const SGRAPH_FILE_EXT: &str = "sgraph";
+const STABLE_FILE_EXT: &str = "stable";
 
 /// A `ParserBuilder` allows one to specify the criteria for building a statically generated
 /// parser.
@@ -98,38 +101,31 @@ where StorageT: 'static + Debug + Hash + PrimInt + Serialize + TypeName + Unsign
         self
     }
 
-    /// Given the filename `x.y` as input, statically compile the file `src/x.y` into a Rust module
-    /// which can then be imported using `lrpar_mod!(x_y)`. This is a convenience function around
-    /// [`process_file`](struct.ParserBuilder.html#method.process_file) which makes it easier to
-    /// compile `.y` files stored in a project's `src/` directory. Note that leaf names must be
-    /// unique within a single project, even if they are in different directories: in other words,
-    /// `a.y` and `x/a.y` will both be mapped to the same module `a_y` (and it is undefined which
-    /// of the input files will "win" the compilation race).
+    /// Given the filename `x/y.z` as input, statically compile the grammar `src/x/y.z` into a Rust
+    /// module which can then be imported using `lrpar_mod!(x_y)`. This is a convenience function
+    /// around [`process_file`](struct.ParserBuilder.html#method.process_file) which makes it
+    /// easier to compile `.y` files stored in a project's `src/` directory. Note that leaf names
+    /// must be unique within a single project, even if they are in different directories: in other
+    /// words, `y.z` and `x/y.z` will both be mapped to the same module `y_z` (and it is undefined
+    /// which of the input files will "win" the compilation race).
     ///
     /// # Panics
     ///
-    /// If the input filename does not end in `.y` or if `StorageT` is not big enough to index the
-    /// grammar's tokens, nonterminals, or productions.
+    /// If `StorageT` is not big enough to index the grammar's tokens, nonterminals, or
+    /// productions.
     pub fn process_file_in_src(&self, srcp: &str)
                             -> Result<(HashMap<String, StorageT>), Box<Error>>
     {
         let mut inp = current_dir()?;
         inp.push("src");
         inp.push(srcp);
-        if Path::new(srcp).extension().unwrap().to_str().unwrap() != YACC_FILE_EXT {
-            panic!("File name passed to process_file_in_src must have extension '{}'.", YACC_FILE_EXT);
-        }
-        let mut leaf = inp.file_stem().unwrap().to_str().unwrap().to_owned();
-        leaf.push_str(&YACC_SUFFIX);
-        let mut outp = PathBuf::new();
-        outp.push(var("OUT_DIR").unwrap());
-        outp.push(leaf);
-        outp.set_extension(RUST_FILE_EXT);
-        self.process_file(inp, outp)
+        let mut outd = PathBuf::new();
+        outd.push(var("OUT_DIR").unwrap());
+        self.process_file(inp, outd)
     }
 
-    /// Statically compile the `.y` file `inp` into Rust, placing the output into `outp`. The
-    /// latter defines a module with the following function:
+    /// Statically compile the Yacc file `inp` into Rust, placing the output file(s) into
+    /// the directory `outd`. The latter defines a module with the following function:
     ///
     /// ```rust,ignore
     ///      parser(lexemes: &Vec<Lexeme<StorageT>>)
@@ -143,19 +139,27 @@ where StorageT: 'static + Debug + Hash + PrimInt + Serialize + TypeName + Unsign
     /// productions.
     pub fn process_file<P, Q>(&self,
                               inp: P,
-                              outp: Q)
+                              outd: Q)
                            -> Result<(HashMap<String, StorageT>), Box<Error>>
                         where P: AsRef<Path>,
                               Q: AsRef<Path>
     {
         let inc = read_to_string(&inp).unwrap();
-
         let grm = YaccGrammar::<StorageT>::new_with_storaget(YaccKind::Eco, &inc)?;
         let rule_ids = grm.terms_map().iter()
                                       .map(|(&n, &i)| (n.to_owned(), i.as_storaget()))
                                       .collect::<HashMap<_, _>>();
         let imc = self.gen_ids_map_cache(&grm);
 
+        // out_base is the base filename for the output (e.g. /path/to/target/out/grm_y) to which
+        // we will write filenames with various extensions below.
+        let mut outp_base = outd.as_ref().to_path_buf();
+        let mut leaf = inp.as_ref().file_stem().unwrap().to_str().unwrap().to_owned();
+        leaf.push_str(YACC_SUFFIX);
+        outp_base.push(leaf);
+
+        let mut outp_rs = outp_base.clone();
+        outp_rs.set_extension(RUST_FILE_EXT);
         // We don't need to go through the full rigmarole of generating an output file if all of
         // the following are true: the output file exists; it is newer than the input file; and the
         // rule IDs map cache hasn't changed. The last of these might be surprising, but it's
@@ -163,10 +167,10 @@ where StorageT: 'static + Debug + Hash + PrimInt + Serialize + TypeName + Unsign
         // change for reasons beyond lrpar's control. If it does change, that means that the lexer
         // and lrpar would get out of sync, so we have to play it safe and regenerate in such cases.
         if let Ok(ref inmd) = fs::metadata(&inp) {
-            if let Ok(ref outmd) = fs::metadata(&outp) {
-                if FileTime::from_last_modification_time(outmd) >
+            if let Ok(ref out_rs_md) = fs::metadata(&outp_rs) {
+                if FileTime::from_last_modification_time(out_rs_md) >
                    FileTime::from_last_modification_time(inmd) {
-                    if let Ok(outc) = read_to_string(&outp) {
+                    if let Ok(outc) = read_to_string(&outp_rs) {
                         if outc.contains(&imc) {
                             return Ok(rule_ids);
                         }
@@ -175,9 +179,24 @@ where StorageT: 'static + Debug + Hash + PrimInt + Serialize + TypeName + Unsign
             }
         }
 
-        let (sgraph, stable) = from_yacc(&grm, Minimiser::Pager)?;
-        let mut outs = String::new();
+        // At this point, we know we're going to generate fresh output; however, if something goes
+        // wrong in the process between now and us writing /out/blah.rs, rustc thinks that
+        // everything's gone swimmingly (even if build.rs errored!), and tries to carry on
+        // compilation, leading to weird errors. We therefore delete /out/blah.rs at this point,
+        // which means, at worse, the user gets a "file not found" error from rustc (which is less
+        // confusing than the alternatives).
+        fs::remove_file(&outp_rs).ok();
 
+        let (sgraph, stable) = from_yacc(&grm, Minimiser::Pager)?;
+        // Because we're lazy, we don't write our own serializer. We use serde and bincode to
+        // create files $out_base.grm, $out_base.sgraph, and $out_base.out_stable which contain
+        // binary versions of the relevant structs, and then include those binary files into the
+        // Rust binary using "include_bytes" (see below).
+        let out_grm = self.bin_output(&outp_base, GRM_FILE_EXT, &grm)?;
+        let out_sgraph = self.bin_output(&outp_base, SGRAPH_FILE_EXT, &sgraph)?;
+        let out_stable = self.bin_output(&outp_base, STABLE_FILE_EXT, &stable)?;
+
+        let mut outs = String::new();
         // Header
         let mod_name = inp.as_ref().file_stem().unwrap().to_str().unwrap();
         outs.push_str(&format!("mod {}_y {{", mod_name));
@@ -189,21 +208,17 @@ pub fn parse(lexemes: &[Lexeme<{storaget}>])
 {{", storaget=StorageT::type_name()));
 
         // grm, sgraph, stable
-        let mut grm_buf = Vec::new();
-        grm.serialize(&mut Serializer::new(&mut grm_buf)).unwrap();
-        let mut sgraph_buf = Vec::new();
-        sgraph.serialize(&mut Serializer::new(&mut sgraph_buf)).unwrap();
-        let mut stable_buf = Vec::new();
-        stable.serialize(&mut Serializer::new(&mut stable_buf)).unwrap();
         let recoverer = match self.recoverer {
             RecoveryKind::CPCTPlus => "CPCTPlus",
             RecoveryKind::MF => "MF",
             RecoveryKind::None => "None"
         };
         outs.push_str(&format!("
-    let (grm, sgraph, stable) = reconstitute(&vec!{:?}, &vec!{:?}, &vec!{:?});
+    let (grm, sgraph, stable) = reconstitute(include_bytes!(\"{}\"),
+                                             include_bytes!(\"{}\"),
+                                             include_bytes!(\"{}\"));
     parse_rcvry(RecoveryKind::{}, &grm, |_| 1, &sgraph, &stable, lexemes)
-", grm_buf, sgraph_buf, stable_buf, recoverer));
+", out_grm.to_str().unwrap(), out_sgraph.to_str().unwrap(), out_stable.to_str().unwrap(), recoverer));
 
         outs.push_str("}\n");
 
@@ -212,7 +227,7 @@ pub fn parse(lexemes: &[Lexeme<{storaget}>])
         // Output the cache so that we can check whether the IDs map is stable.
         outs.push_str(&imc);
 
-        let mut f = File::create(outp)?;
+        let mut f = File::create(outp_rs)?;
         f.write_all(outs.as_bytes())?;
         Ok(rule_ids)
     }
@@ -233,20 +248,28 @@ pub fn parse(lexemes: &[Lexeme<{storaget}>])
         cache.push_str("*/\n");
         cache
     }
+
+    /// Output the structure `d` to the file `outp_base.ext`.
+    fn bin_output<P: AsRef<Path>, T: Serialize>
+                 (&self, outp_base: P, ext: &str, d: &T)
+               -> Result<PathBuf, Box<Error>> {
+        let mut outp = outp_base.as_ref().to_path_buf();
+        outp.set_extension(ext);
+        let f = File::create(&outp)?;
+        serialize_into(f, d)?;
+        Ok(outp)
+    }
 }
 
 /// This function is called by generated files; it exists so that generated files don't require a
 /// dependency on serde and rmps.
 #[doc(hidden)]
 pub fn reconstitute<'a, StorageT: Deserialize<'a> + Hash + PrimInt + Unsigned>
-                   (grm_buf: &[u8], sgraph_buf: &[u8], stable_buf: &[u8])
+                   (grm_buf: &'a [u8], sgraph_buf: &'a [u8], stable_buf: &'a [u8])
                 -> (YaccGrammar<StorageT>, StateGraph<StorageT>, StateTable<StorageT>)
 {
-    let mut grm_de = Deserializer::new(&grm_buf[..]);
-    let grm = Deserialize::deserialize(&mut grm_de).unwrap();
-    let mut sgraph_de = Deserializer::new(&sgraph_buf[..]);
-    let sgraph = Deserialize::deserialize(&mut sgraph_de).unwrap();
-    let mut stable_de = Deserializer::new(&stable_buf[..]);
-    let stable = Deserialize::deserialize(&mut stable_de).unwrap();
+    let grm = deserialize(grm_buf).unwrap();
+    let sgraph = deserialize(sgraph_buf).unwrap();
+    let stable = deserialize(stable_buf).unwrap();
     (grm, sgraph, stable)
 }

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -32,6 +32,7 @@
 
 #![feature(test)]
 
+extern crate bincode;
 extern crate cactus;
 extern crate cfgrammar;
 extern crate filetime;


### PR DESCRIPTION
Using rmps was comically slow for large grammars. For example, the java7 grammar built with --release took several hours to compile before causing LLVM to crash(presumably because we created intermediate Rust files that were ~4MiB big).

This commit moves things to using the bincode crate. As well as writing out a file "grm_y.rs" we also use bincode to output binary files "grm_y.grm", "grm_y.sgraph", and "grm_y.stable". These files are an order of magnitude smaller than their equivalents from before this commit and allow the java7 grammar to be compiled with --release in well under a minute.