### PR TITLE
Nonterm constants

### DIFF
--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -280,6 +280,11 @@ impl<StorageT: Copy> Lexeme<StorageT> {
         self.start
     }
 
+    /// Byte offset of the start of the lexeme
+    pub fn end(&self) -> usize {
+        self.start() + self.len()
+    }
+
     /// Length in bytes of the lexeme
     pub fn len(&self) -> usize {
         debug_assert!(usize::try_from(u32::max_value()).is_ok());

--- a/lrpar/examples/calcparse/Cargo.toml
+++ b/lrpar/examples/calcparse/Cargo.toml
@@ -12,5 +12,6 @@ lrlex = { path="../../../lrlex" }
 lrpar = { path="../.." }
 
 [dependencies]
+cfgrammar = { path="../../../cfgrammar" }
 lrlex = { path="../../../lrlex" }
 lrpar = { path="../.." }

--- a/lrpar/examples/calcparse/src/calc.l
+++ b/lrpar/examples/calcparse/src/calc.l
@@ -3,5 +3,5 @@
 \+ "PLUS"
 \* "MUL"
 \( "LBRACK"
-\( "RBRACK"
+\) "RBRACK"
 [\t ]+ ;

--- a/lrpar/examples/calcparse/src/main.rs
+++ b/lrpar/examples/calcparse/src/main.rs
@@ -1,7 +1,11 @@
 use std::io::{self, BufRead, Write};
 
+extern crate cfgrammar;
 #[macro_use] extern crate lrlex;
 #[macro_use] extern crate lrpar;
+
+use cfgrammar::NTIdx;
+use lrpar::Node;
 
 // Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
 lrlex_mod!(calc_l);
@@ -27,7 +31,7 @@ fn main() {
                     Ok(lexemes) => {
                         // Now parse the stream of lexemes into a tree
                         match calc_y::parse(&lexemes) {
-                            Ok(pt) => println!("{:?}", pt),
+                            Ok(pt) => println!("{}", Eval::new(l).eval(&pt)),
                             Err((_, errs)) => {
                                 // One or more errors were detected during parsing.
                                 for e in errs {
@@ -42,6 +46,50 @@ fn main() {
                 }
             },
             _ => break
+        }
+    }
+}
+
+struct Eval<'a> {
+    s: &'a str
+}
+
+impl<'a> Eval<'a> {
+    fn new(s: &'a str) -> Self {
+        Eval{s}
+    }
+
+    fn eval(&self, n: &Node<u8>) -> i64 {
+        match *n {
+            Node::Nonterm{nonterm_idx: NTIdx(ntidx), ref nodes} if ntidx==NT_EXPR => {
+                if nodes.len() == 1 {
+                    self.eval(&nodes[0])
+                } else {
+                    debug_assert_eq!(nodes.len(), 3);
+                    self.eval(&nodes[0]) + self.eval(&nodes[2])
+                }
+            },
+            Node::Nonterm{nonterm_idx: NTIdx(ntidx), ref nodes} if ntidx==NT_TERM => {
+                if nodes.len() == 1 {
+                    self.eval(&nodes[0])
+                } else {
+                    debug_assert_eq!(nodes.len(), 3);
+                    self.eval(&nodes[0]) * self.eval(&nodes[2])
+                }
+            },
+            Node::Nonterm{nonterm_idx: NTIdx(ntidx), ref nodes} if ntidx==NT_FACTOR => {
+                if nodes.len() == 1 {
+                    if let Node::Term{lexeme} = nodes[0] {
+                        self.s[lexeme.start()..lexeme.end()].parse().unwrap()
+                    } else {
+                        unreachable!();
+                    }
+                } else {
+                    debug_assert_eq!(nodes.len(), 3);
+                    self.eval(&nodes[1])
+                }
+            },
+            _ => unreachable!()
         }
     }
 }

--- a/lrpar/src/lib/builder.rs
+++ b/lrpar/src/lib/builder.rs
@@ -221,9 +221,18 @@ pub fn parse(lexemes: &[Lexeme<{storaget}>])
 ", out_grm.to_str().unwrap(), out_sgraph.to_str().unwrap(), out_stable.to_str().unwrap(), recoverer));
 
         outs.push_str("}\n");
-
-        // Footer
         outs.push_str("}\n\n");
+
+        // The nonterminal constants
+        for ntidx in grm.iter_ntidxs() {
+            if !grm.nonterm_to_prods(ntidx).contains(&grm.start_prod()) {
+                outs.push_str(&format!("#[allow(dead_code)]\nconst NT_{}: {} = {:?};\n",
+                                       grm.nonterm_name(ntidx).to_ascii_uppercase(),
+                                       StorageT::type_name(),
+                                       usize::from(ntidx)));
+            }
+        }
+
         // Output the cache so that we can check whether the IDs map is stable.
         outs.push_str(&imc);
 


### PR DESCRIPTION
Add nonterm constants to the compile-time grammar file. This then allows us to do useful stuff with the parse tree. As an example, add a calculator evaluator to `calcparse`. At the moment, this doesn't feel very ergonomic. I might see if I can do something (god help me... a macro?) to make it less syntactically awkward in the future, but this is already better than nothing.