### PR TITLE
Add a panic mode recoverer

### DIFF
--- a/cfgrammar/Cargo.toml
+++ b/cfgrammar/Cargo.toml
@@ -14,3 +14,4 @@ indexmap = "1.0"
 num-traits = "0.2"
 regex = "1.0"
 serde = { version="1.0", features=["derive"], optional=true }
+vob = "1.3"

--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -63,11 +63,11 @@
 #[macro_use] extern crate lazy_static;
 extern crate indexmap;
 extern crate num_traits;
-#[cfg(feature="serde")]
-#[macro_use]
-extern crate serde;
+#[cfg(feature="serde")] #[macro_use] extern crate serde;
+extern crate vob;
 
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
+use vob::Vob;
 
 mod idxnewtype;
 pub mod yacc;
@@ -109,4 +109,21 @@ pub trait Grammar<StorageT: 'static + PrimInt + Unsigned> where usize: AsPrimiti
         // definition the integers we're creating fit within StorageT.
         Box::new((0..usize::from(self.terms_len())).map(|x| TIdx(x.as_())))
     }
+
+    fn firsts(&self) -> Box<dyn Firsts<StorageT>>;
+}
+
+pub trait Firsts<StorageT: 'static + PrimInt + Unsigned> where usize: AsPrimitive<StorageT> {
+    /// Returns true if the terminal `tidx` is in the first set for nonterminal `nidx`.
+    fn is_set(&self, nidx: NTIdx<StorageT>, tidx: TIdx<StorageT>) -> bool;
+
+    /// Return all the firsts for production `ntidx`.
+    fn prod_firsts(&self, ntidx: NTIdx<StorageT>) -> &Vob;
+
+    /// Returns true if the nonterminal `ntidx` has epsilon in its first set.
+    fn is_epsilon_set(&self, ntidx: NTIdx<StorageT>) -> bool;
+
+    /// Ensures that the firsts bit for terminal `tidx` nonterminal `nidx` is set. Returns true if
+    /// it was already set, or false otherwise.
+    fn set(&mut self, ntidx: NTIdx<StorageT>, tidx: TIdx<StorageT>) -> bool;
 }

--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -102,6 +102,16 @@ pub trait Grammar<StorageT: 'static + PrimInt + Unsigned> where usize: AsPrimiti
         Box::new((0..usize::from(self.nonterms_len())).map(|x| NTIdx(x.as_())))
     }
 
+    /// Return an iterator which produces (in order from `0..self.prods_len()`) all this
+    /// grammar's valid `PIdx`s.
+    fn iter_pidxs(&self) -> Box<dyn Iterator<Item=PIdx<StorageT>>>
+    {
+        // We can use as_ safely, because we know that we're only generating integers from
+        // 0..self.nonterms_len() and, since nonterms_len() returns an NTIdx<StorageT>, then by
+        // definition the integers we're creating fit within StorageT.
+        Box::new((0..usize::from(self.prods_len())).map(|x| PIdx(x.as_())))
+    }
+
     fn iter_tidxs(&self) -> Box<dyn Iterator<Item=TIdx<StorageT>>>
     {
         // We can use as_ safely, because we know that we're only generating integers from

--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -114,11 +114,11 @@ pub trait Grammar<StorageT: 'static + PrimInt + Unsigned> where usize: AsPrimiti
 }
 
 pub trait Firsts<StorageT: 'static + PrimInt + Unsigned> where usize: AsPrimitive<StorageT> {
+    /// Return all the firsts for nonterminal `ntidx`.
+    fn firsts(&self, ntidx: NTIdx<StorageT>) -> &Vob;
+
     /// Returns true if the terminal `tidx` is in the first set for nonterminal `nidx`.
     fn is_set(&self, nidx: NTIdx<StorageT>, tidx: TIdx<StorageT>) -> bool;
-
-    /// Return all the firsts for production `ntidx`.
-    fn prod_firsts(&self, ntidx: NTIdx<StorageT>) -> &Vob;
 
     /// Returns true if the nonterminal `ntidx` has epsilon in its first set.
     fn is_epsilon_set(&self, ntidx: NTIdx<StorageT>) -> bool;

--- a/cfgrammar/src/lib/yacc/firsts.rs
+++ b/cfgrammar/src/lib/yacc/firsts.rs
@@ -35,8 +35,8 @@ use std::marker::PhantomData;
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 use vob::Vob;
 
-use cfgrammar::{Grammar, NTIdx, Symbol, TIdx};
-use cfgrammar::yacc::YaccGrammar;
+use {Firsts, Grammar, NTIdx, Symbol, TIdx};
+use yacc::YaccGrammar;
 
 /// `Firsts` stores all the first sets for a given grammar. For example, given this code and
 /// grammar:
@@ -56,13 +56,13 @@ use cfgrammar::yacc::YaccGrammar;
 ///   assert!(firsts.is_epsilon_set(grm.nonterm_idx("A").unwrap()));
 /// ```
 #[derive(Debug)]
-pub struct Firsts<StorageT> {
+pub struct YaccFirsts<StorageT> {
     prod_firsts: Vec<Vob>,
     prod_epsilons: Vob,
     phantom: PhantomData<StorageT>
 }
 
-impl<StorageT: 'static + PrimInt + Unsigned> Firsts<StorageT>
+impl<StorageT: 'static + PrimInt + Unsigned> YaccFirsts<StorageT>
 where usize: AsPrimitive<StorageT>
 {
     /// Generates and returns the firsts set for the given grammar.
@@ -71,7 +71,7 @@ where usize: AsPrimitive<StorageT>
         for _ in grm.iter_ntidxs() {
             prod_firsts.push(Vob::from_elem(usize::from(grm.terms_len()), false));
         }
-        let mut firsts = Firsts {
+        let mut firsts = YaccFirsts {
             prod_firsts,
             prod_epsilons: Vob::from_elem(usize::from(grm.nonterms_len()), false),
             phantom      : PhantomData
@@ -143,25 +143,25 @@ where usize: AsPrimitive<StorageT>
             }
         }
     }
+}
 
-    /// Returns true if the terminal `tidx` is in the first set for nonterminal `nidx` is set.
-    pub fn is_set(&self, nidx: NTIdx<StorageT>, tidx: TIdx<StorageT>) -> bool {
+impl<StorageT: 'static + PrimInt + Unsigned>
+Firsts<StorageT> for YaccFirsts<StorageT>
+where usize: AsPrimitive<StorageT>
+{
+    fn is_set(&self, nidx: NTIdx<StorageT>, tidx: TIdx<StorageT>) -> bool {
         self.prod_firsts[usize::from(nidx)][usize::from(tidx)]
     }
 
-    /// Get all the firsts for production `ntidx`.
-    pub fn prod_firsts(&self, ntidx: NTIdx<StorageT>) -> &Vob {
+    fn prod_firsts(&self, ntidx: NTIdx<StorageT>) -> &Vob {
         &self.prod_firsts[usize::from(ntidx)]
     }
 
-    /// Returns true if the nonterminal `ntidx` has epsilon in its first set.
-    pub fn is_epsilon_set(&self, ntidx: NTIdx<StorageT>) -> bool {
+    fn is_epsilon_set(&self, ntidx: NTIdx<StorageT>) -> bool {
         self.prod_epsilons[usize::from(ntidx)]
     }
 
-    /// Ensures that the firsts bit for terminal `tidx` nonterminal `nidx` is set. Returns true if
-    /// it was already set, or false otherwise.
-    pub fn set(&mut self, ntidx: NTIdx<StorageT>, tidx: TIdx<StorageT>) -> bool {
+    fn set(&mut self, ntidx: NTIdx<StorageT>, tidx: TIdx<StorageT>) -> bool {
         let prod = &mut self.prod_firsts[usize::from(ntidx)];
         if prod[usize::from(tidx)] {
             true
@@ -173,17 +173,14 @@ where usize: AsPrimitive<StorageT>
     }
 }
 
-
 #[cfg(test)]
 mod test {
-    use cfgrammar::Grammar;
-    use cfgrammar::yacc::{YaccGrammar, YaccKind};
+    use {Firsts, Grammar};
+    use yacc::{YaccGrammar, YaccKind};
     use num_traits::{AsPrimitive, PrimInt, Unsigned};
 
-    use super::Firsts;
-
     fn has<StorageT: 'static + PrimInt + Unsigned>
-          (grm: &YaccGrammar<StorageT>, firsts: &Firsts<StorageT>, rn: &str, should_be: Vec<&str>)
+          (grm: &YaccGrammar<StorageT>, firsts: &Box<Firsts<StorageT>>, rn: &str, should_be: Vec<&str>)
      where usize: AsPrimitive<StorageT>
     {
         let nt_i = grm.nonterm_idx(rn).unwrap();
@@ -221,7 +218,7 @@ mod test {
           E: D | C;
           F: E;
           ").unwrap();
-        let firsts = Firsts::new(&grm);
+        let firsts = grm.firsts();
         has(&grm, &firsts, "^", vec!["c"]);
         has(&grm, &firsts, "D", vec!["d"]);
         has(&grm, &firsts, "E", vec!["d", "c"]);
@@ -238,7 +235,7 @@ mod test {
           D: 'd';
           E: D C;
           ").unwrap();
-        let firsts = Firsts::new(&grm);
+        let firsts = grm.firsts();
         has(&grm, &firsts, "E", vec!["d"]);
     }
 
@@ -253,7 +250,7 @@ mod test {
           C: 'c' | ;
           D: C;
           ").unwrap();
-        let firsts = Firsts::new(&grm);
+        let firsts = grm.firsts();
         has(&grm, &firsts, "A", vec!["b", "a"]);
         has(&grm, &firsts, "C", vec!["c", ""]);
         has(&grm, &firsts, "D", vec!["c", ""]);
@@ -269,7 +266,7 @@ mod test {
           B: 'b' | ;
           C: B 'c' B;
           ").unwrap();
-        let firsts = Firsts::new(&grm);
+        let firsts = grm.firsts();
         has(&grm, &firsts, "A", vec!["b", "c"]);
         has(&grm, &firsts, "B", vec!["b", ""]);
         has(&grm, &firsts, "C", vec!["b", "c"]);
@@ -284,7 +281,7 @@ mod test {
           A: B 'b';
           B: 'b' | ;
           ").unwrap();
-        let firsts = Firsts::new(&grm);
+        let firsts = grm.firsts();
         has(&grm, &firsts, "A", vec!["b"]);
     }
 
@@ -305,7 +302,7 @@ mod test {
     #[test]
     fn test_first_from_eco() {
         let grm = eco_grammar();
-        let firsts = Firsts::new(&grm);
+        let firsts = grm.firsts();
         has(&grm, &firsts, "S", vec!["a", "b"]);
         has(&grm, &firsts, "A", vec!["a"]);
         has(&grm, &firsts, "B", vec!["a"]);
@@ -328,7 +325,7 @@ mod test {
           F: 'f' | ;
           G: C D;
           ").unwrap();
-        let firsts = Firsts::new(&grm);
+        let firsts = grm.firsts();
         has(&grm, &firsts, "E", vec!["a"]);
         has(&grm, &firsts, "T", vec!["a"]);
         has(&grm, &firsts, "P", vec!["a"]);

--- a/cfgrammar/src/lib/yacc/firsts.rs
+++ b/cfgrammar/src/lib/yacc/firsts.rs
@@ -58,7 +58,7 @@ use yacc::YaccGrammar;
 #[derive(Debug)]
 pub struct YaccFirsts<StorageT> {
     firsts: Vec<Vob>,
-    prod_epsilons: Vob,
+    epsilons: Vob,
     phantom: PhantomData<StorageT>
 }
 
@@ -73,7 +73,7 @@ where usize: AsPrimitive<StorageT>
         }
         let mut firsts = YaccFirsts {
             firsts,
-            prod_epsilons: Vob::from_elem(usize::from(grm.nonterms_len()), false),
+            epsilons: Vob::from_elem(usize::from(grm.nonterms_len()), false),
             phantom      : PhantomData
         };
 
@@ -91,7 +91,7 @@ where usize: AsPrimitive<StorageT>
                         // if it's an empty production, ensure this nonterminal's epsilon bit is
                         // set.
                         if !firsts.is_epsilon_set(rul_i) {
-                            firsts.prod_epsilons.set(usize::from(rul_i), true);
+                            firsts.epsilons.set(usize::from(rul_i), true);
                             changed = true;
                         }
                         continue;
@@ -121,8 +121,8 @@ where usize: AsPrimitive<StorageT>
                                 // to FIRSTs.
                                 if firsts.is_epsilon_set(nonterm_i) && sym_i == prod.len() - 1 {
                                     // Only add epsilon if the symbol is the last in the production
-                                    if !firsts.prod_epsilons[usize::from(rul_i)] {
-                                        firsts.prod_epsilons.set(usize::from(rul_i), true);
+                                    if !firsts.epsilons[usize::from(rul_i)] {
+                                        firsts.epsilons.set(usize::from(rul_i), true);
                                         changed = true;
                                     }
                                 }
@@ -158,7 +158,7 @@ where usize: AsPrimitive<StorageT>
     }
 
     fn is_epsilon_set(&self, ntidx: NTIdx<StorageT>) -> bool {
-        self.prod_epsilons[usize::from(ntidx)]
+        self.epsilons[usize::from(ntidx)]
     }
 
     fn set(&mut self, ntidx: NTIdx<StorageT>, tidx: TIdx<StorageT>) -> bool {

--- a/cfgrammar/src/lib/yacc/firsts.rs
+++ b/cfgrammar/src/lib/yacc/firsts.rs
@@ -57,7 +57,7 @@ use yacc::YaccGrammar;
 /// ```
 #[derive(Debug)]
 pub struct YaccFirsts<StorageT> {
-    prod_firsts: Vec<Vob>,
+    firsts: Vec<Vob>,
     prod_epsilons: Vob,
     phantom: PhantomData<StorageT>
 }
@@ -67,12 +67,12 @@ where usize: AsPrimitive<StorageT>
 {
     /// Generates and returns the firsts set for the given grammar.
     pub fn new(grm: &YaccGrammar<StorageT>) -> Self {
-        let mut prod_firsts = Vec::with_capacity(usize::from(grm.nonterms_len()));
+        let mut firsts = Vec::with_capacity(usize::from(grm.nonterms_len()));
         for _ in grm.iter_ntidxs() {
-            prod_firsts.push(Vob::from_elem(usize::from(grm.terms_len()), false));
+            firsts.push(Vob::from_elem(usize::from(grm.terms_len()), false));
         }
         let mut firsts = YaccFirsts {
-            prod_firsts,
+            firsts,
             prod_epsilons: Vob::from_elem(usize::from(grm.nonterms_len()), false),
             phantom      : PhantomData
         };
@@ -149,12 +149,12 @@ impl<StorageT: 'static + PrimInt + Unsigned>
 Firsts<StorageT> for YaccFirsts<StorageT>
 where usize: AsPrimitive<StorageT>
 {
-    fn is_set(&self, nidx: NTIdx<StorageT>, tidx: TIdx<StorageT>) -> bool {
-        self.prod_firsts[usize::from(nidx)][usize::from(tidx)]
+    fn firsts(&self, ntidx: NTIdx<StorageT>) -> &Vob {
+        &self.firsts[usize::from(ntidx)]
     }
 
-    fn prod_firsts(&self, ntidx: NTIdx<StorageT>) -> &Vob {
-        &self.prod_firsts[usize::from(ntidx)]
+    fn is_set(&self, nidx: NTIdx<StorageT>, tidx: TIdx<StorageT>) -> bool {
+        self.firsts[usize::from(nidx)][usize::from(tidx)]
     }
 
     fn is_epsilon_set(&self, ntidx: NTIdx<StorageT>) -> bool {
@@ -162,12 +162,12 @@ where usize: AsPrimitive<StorageT>
     }
 
     fn set(&mut self, ntidx: NTIdx<StorageT>, tidx: TIdx<StorageT>) -> bool {
-        let prod = &mut self.prod_firsts[usize::from(ntidx)];
-        if prod[usize::from(tidx)] {
+        let nt = &mut self.firsts[usize::from(ntidx)];
+        if nt[usize::from(tidx)] {
             true
         }
         else {
-            prod.set(usize::from(tidx), true);
+            nt.set(usize::from(tidx), true);
             false
         }
     }

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -37,8 +37,9 @@ use std::fmt;
 
 use num_traits::{self, AsPrimitive, PrimInt, Unsigned};
 
-use {Grammar, NTIdx, PIdx, SIdx, Symbol, TIdx};
+use {Firsts, Grammar, NTIdx, PIdx, SIdx, Symbol, TIdx};
 use super::YaccKind;
+use yacc::firsts::YaccFirsts;
 use yacc::parser::YaccParser;
 
 const START_NONTERM         : &str = "^";
@@ -468,6 +469,11 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
         SentenceGenerator::new(self, term_cost)
     }
 
+    /// Return a `YaccFirsts` struct, allowing static dispatch (rather than the `firsts()` method,
+    /// which returns `Box<Firsts>`).
+    pub fn yacc_firsts(&self) -> YaccFirsts<StorageT> {
+        YaccFirsts::new(self)
+    }
 }
 
 impl<StorageT: 'static + PrimInt + Unsigned> Grammar<StorageT>
@@ -490,6 +496,10 @@ where usize: AsPrimitive<StorageT>
 
     fn terms_len(&self) -> TIdx<StorageT> {
         self.terms_len
+    }
+
+    fn firsts(&self) -> Box<dyn Firsts<StorageT>> {
+        Box::new(YaccFirsts::new(self))
     }
 }
 

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -394,6 +394,11 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
         m
     }
 
+    /// Return this grammar's start nonterminal.
+    pub fn start_nonterm(&self) -> NTIdx<StorageT> {
+        self.prod_to_nonterm(self.start_prod)
+    }
+
     /// Return the production index of the start rule's sole production (for Yacc grammars the
     /// start rule is defined to have precisely one production).
     pub fn start_prod(&self) -> PIdx<StorageT> {

--- a/cfgrammar/src/lib/yacc/mod.rs
+++ b/cfgrammar/src/lib/yacc/mod.rs
@@ -31,6 +31,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 pub mod ast;
+pub mod firsts;
 pub mod grammar;
 pub mod parser;
 

--- a/lrpar/src/lib/builder.rs
+++ b/lrpar/src/lib/builder.rs
@@ -211,6 +211,7 @@ pub fn parse(lexemes: &[Lexeme<{storaget}>])
         let recoverer = match self.recoverer {
             RecoveryKind::CPCTPlus => "CPCTPlus",
             RecoveryKind::MF => "MF",
+            RecoveryKind::Panic => "Panic",
             RecoveryKind::None => "None"
         };
         outs.push_str(&format!("

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -49,6 +49,7 @@ extern crate vob;
 mod astar;
 mod builder;
 mod cpctplus;
+mod panic;
 pub mod parser;
 pub use parser::{Node, parse_rcvry, ParseError, ParseRepair, RecoveryKind};
 mod mf;

--- a/lrpar/src/lib/panic.rs
+++ b/lrpar/src/lib/panic.rs
@@ -1,0 +1,91 @@
+// Copyright (c) 2018 King's College London
+// created by the Software Development Team <http://soft-dev.org/>
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
+// copy of this software, associated documentation and/or data (collectively the "Software"), free
+// of charge and under any and all copyright rights in the Software, and any and all patent rights
+// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
+// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
+// below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
+// if one is included with the Software (each a "Larger Work" to which the Software is contributed
+// by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create derivative works
+// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
+// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
+// foregoing rights on either these or other terms.
+//
+// This license is subject to the following condition: The above copyright notice and either this
+// complete permission notice or at a minimum a reference to the UPL must be included in all copies
+// or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+use std::fmt::Debug;
+use std::hash::Hash;
+use std::time::Instant;
+
+use lrtable::StIdx;
+use num_traits::{AsPrimitive, PrimInt, Unsigned};
+
+use parser::{Node, Parser, ParseRepair, Recoverer};
+
+struct Panic;
+
+pub(crate) fn recoverer<'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned>
+                       (_: &'a Parser<StorageT>)
+                     -> Box<Recoverer<StorageT> + 'a>
+                  where usize: AsPrimitive<StorageT>
+{
+    Box::new(Panic)
+}
+
+impl<StorageT: 'static + Debug + Hash + PrimInt + Unsigned> Recoverer<StorageT> for Panic
+where usize: AsPrimitive<StorageT>
+{
+    fn recover(&self,
+               finish_by: Instant,
+               parser: &Parser<StorageT>,
+               in_la_idx: usize,
+               in_pstack: &mut Vec<StIdx>,
+               _: &mut Vec<Node<StorageT>>)
+           -> (usize, Vec<Vec<ParseRepair<StorageT>>>)
+    {
+        // This recoverer is based on that in Compiler Design in C by Allen I. Holub p.348.
+        //
+        // It doesn't really fit into our recoverer mould very well: it can't always flesh out a
+        // valid parse tree, and it often recovers in a way that the user can't emulate (i.e. there
+        // is no way the user can adjust their input to get the parser into the same state as the
+        // recovery algorithm manages).
+        let iter_pstack = in_pstack.clone();
+        for la_idx in in_la_idx..parser.lexemes.len() {
+            if Instant::now() >= finish_by {
+                break;
+            }
+            for (st_i, st) in iter_pstack.iter().enumerate().rev().skip(1) {
+                if parser.stable.action(*st, parser.next_tidx(la_idx)).is_some() {
+                    let mut rprs = Vec::with_capacity(la_idx - in_la_idx);
+                    // It's often possible that we found a state that will accept the lexeme at
+                    // in_la_idx, at which point there are no repairs the user can make which will
+                    // emulate this panic mode (i.e. the list of actions they are advised to take
+                    // will be empty). There isn't much we can do about this.
+                    for _ in in_la_idx..la_idx {
+                        rprs.push(ParseRepair::Delete);
+                    }
+                    in_pstack.drain(st_i + 1..);
+                    return (la_idx, vec![rprs]);
+                }
+            }
+        }
+        return (in_la_idx, vec![]);
+    }
+}

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -44,6 +44,7 @@ use num_traits::{AsPrimitive, PrimInt, Unsigned};
 
 use mf;
 use cpctplus;
+use panic;
 
 const RECOVERY_TIME_BUDGET: u64 = 500; // milliseconds
 
@@ -181,6 +182,7 @@ where usize: AsPrimitive<StorageT>
                         recoverer = Some(match self.rcvry_kind {
                                              RecoveryKind::CPCTPlus => cpctplus::recoverer(self),
                                              RecoveryKind::MF => mf::recoverer(self),
+                                             RecoveryKind::Panic => panic::recoverer(self),
                                              RecoveryKind::None => {
                                                 let la_lexeme = self.next_lexeme(la_idx);
                                                 errors.push(ParseError{state_idx: st,
@@ -386,6 +388,7 @@ pub trait Recoverer<StorageT: Hash + PrimInt + Unsigned>
 pub enum RecoveryKind {
     CPCTPlus,
     MF,
+    Panic,
     None
 }
 

--- a/lrpar/src/main.rs
+++ b/lrpar/src/main.rs
@@ -59,7 +59,7 @@ fn usage(prog: &str, msg: &str) -> ! {
         writeln!(&mut stderr(), "{}", msg).ok();
     }
     writeln!(&mut stderr(),
-             "Usage: {} [-r <cpctplus|cpctplusdyndist|mf|none>] [-y <eco|original>] <lexer.l> <parser.y> <input file>",
+             "Usage: {} [-r <cpctplus|mf|panic|none>] [-y <eco|original>] <lexer.l> <parser.y> <input file>",
              leaf).ok();
     process::exit(1);
 }
@@ -84,7 +84,7 @@ fn main() {
                                 .optflag("h", "help", "")
                                 .optopt("r", "recoverer",
                                         "Recoverer to be used (default: mf)",
-                                        "cpctplus|mf|none")
+                                        "cpctplus|mf|panic|none")
                                 .optopt("y", "yaccvariant",
                                         "Yacc variant to be parsed (default: Original)",
                                         "Original|Eco")
@@ -103,6 +103,7 @@ fn main() {
             match &*s.to_lowercase() {
                 "cpctplus" => RecoveryKind::CPCTPlus,
                 "mf" => RecoveryKind::MF,
+                "panic" => RecoveryKind::Panic,
                 "none" => RecoveryKind::None,
                 _ => usage(prog, &format!("Unknown recoverer '{}'.", s))
             }

--- a/lrtable/src/lib/itemset.rs
+++ b/lrtable/src/lib/itemset.rs
@@ -39,7 +39,8 @@ use fnv::FnvHasher;
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 use vob::Vob;
 
-use firsts::Firsts;
+use cfgrammar::Firsts;
+use cfgrammar::yacc::firsts::YaccFirsts;
 
 /// The type of "context" (also known as "lookaheads")
 pub type Ctx = Vob;
@@ -74,7 +75,7 @@ where usize: AsPrimitive<StorageT>
     }
 
     /// Create a new itemset which is a closed version of `self`.
-    pub fn close(&self, grm: &YaccGrammar<StorageT>, firsts: &Firsts<StorageT>) -> Self {
+    pub fn close(&self, grm: &YaccGrammar<StorageT>, firsts: &YaccFirsts<StorageT>) -> Self {
         // This function can be seen as a merger of getClosure and getContext from Chen's
         // dissertation.
 
@@ -183,7 +184,6 @@ where usize: AsPrimitive<StorageT>
 mod test {
     use vob::Vob;
     use super::Itemset;
-    use firsts::Firsts;
     use cfgrammar::{Grammar, SIdx, Symbol};
     use cfgrammar::yacc::{YaccGrammar, YaccKind};
     use stategraph::state_exists;
@@ -198,7 +198,7 @@ mod test {
           L: '*' R | 'id';
           R: L;
           ").unwrap();
-        let firsts = Firsts::new(&grm);
+        let firsts = grm.yacc_firsts();
 
         let mut is = Itemset::new(&grm);
         let mut la = Vob::from_elem(usize::from(grm.terms_len()), false);
@@ -232,7 +232,7 @@ mod test {
     #[test]
     fn test_closure1_ecogrm() {
         let grm = eco_grammar();
-        let firsts = Firsts::new(&grm);
+        let firsts = grm.yacc_firsts();
 
         let mut is = Itemset::new(&grm);
         let mut la = Vob::from_elem(usize::from(grm.terms_len()), false);
@@ -274,7 +274,7 @@ mod test {
     #[test]
     fn test_closure1_grm3() {
         let grm = grammar3();
-        let firsts = Firsts::new(&grm);
+        let firsts = grm.yacc_firsts();
 
         let mut is = Itemset::new(&grm);
         let mut la = Vob::from_elem(usize::from(grm.terms_len()), false);
@@ -308,7 +308,7 @@ mod test {
     #[test]
     fn test_goto1() {
         let grm = grammar3();
-        let firsts = Firsts::new(&grm);
+        let firsts = grm.yacc_firsts();
 
         let mut is = Itemset::new(&grm);
         let mut la = Vob::from_elem(usize::from(grm.terms_len()), false);

--- a/lrtable/src/lib/itemset.rs
+++ b/lrtable/src/lib/itemset.rs
@@ -142,7 +142,7 @@ where usize: AsPrimitive<StorageT>
                             break;
                         },
                         Symbol::Nonterm(nonterm_j) => {
-                            new_ctx.or(firsts.prod_firsts(nonterm_j));
+                            new_ctx.or(firsts.firsts(nonterm_j));
                             if !firsts.is_epsilon_set(nonterm_j) {
                                 nullable = false;
                                 break;

--- a/lrtable/src/lib/mod.rs
+++ b/lrtable/src/lib/mod.rs
@@ -45,7 +45,6 @@ use std::mem::size_of;
 
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 
-mod firsts;
 mod itemset;
 mod pager;
 mod stategraph;

--- a/lrtable/src/lib/pager.rs
+++ b/lrtable/src/lib/pager.rs
@@ -40,7 +40,6 @@ use num_traits::{AsPrimitive, PrimInt, Unsigned};
 use vob::Vob;
 
 use StIdx;
-use firsts::Firsts;
 use itemset::Itemset;
 use stategraph::StateGraph;
 
@@ -151,7 +150,7 @@ where usize: AsPrimitive<StorageT>
 {
     // This function can be seen as a modified version of items() from Chen's dissertation.
 
-    let firsts = Firsts::new(grm);
+    let firsts = grm.yacc_firsts();
     // closed_states and core_states are both equally sized vectors of states. Core states are
     // smaller, and used for the weakly compatible checks, but we ultimately need to return
     // closed states. Closed states which are None are those which require processing; thus


### PR DESCRIPTION
This PR ultimately adds a simple panic mode recoverer in https://github.com/softdevteam/grmtools/commit/4b9cf76e8f1a3b099388ce80261cd481ff4ec885. This isn't really intended for anyone to use, but it'll be useful in an upcoming comparison of this vs. CPCT+ and MF.

However, the original intention was to implement a slightly different style of recoverer. Hence the first few commits are tidy-ups for the recoverer-that-never-was. Each commit should be pretty easy to understand; only https://github.com/softdevteam/grmtools/commit/2155408c6251c8380c212f5b8ab7f3d9c3b6be03 is moderately complex. https://github.com/softdevteam/grmtools/commit/312845579c2e61c53c193a7a3e0287e62efb848b and https://github.com/softdevteam/grmtools/commit/aefe649d9a5816504956d65aff9c5769fc4f3796 are mechanical `srep` renamings. 