### PR TITLE
The recoverer needs to be part of the rebuild cache.

### DIFF
--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -385,6 +385,7 @@ pub trait Recoverer<StorageT: Hash + PrimInt + Unsigned>
            -> (usize, Vec<Vec<ParseRepair<StorageT>>>);
 }
 
+#[derive(Debug)]
 pub enum RecoveryKind {
     CPCTPlus,
     MF,


### PR DESCRIPTION
The rebuild cache is a very useful performance feature, because it stops us spending time generating grammar information and having rustc compile it (the latter is much slower than the former). However, previously we were a bit sloppy, not included the recovered as part of the rebuild cache.

This commit fixes that oversight, and also documents a little more clearly what expectations the rebuild cache needs to satisfy.