### PR TITLE
Homogenise naming

### DIFF
--- a/cfgrammar/src/lib/idxnewtype.rs
+++ b/cfgrammar/src/lib/idxnewtype.rs
@@ -66,12 +66,6 @@ macro_rules! IdxNewtype {
     }
 }
 
-// Will anyone create a grammar with more than 65535 non-terminals, productions, symbols within a
-// production, or terminals? Yes, now that I've said it out loud, they probably will. But all
-// practical grammars I know of are comfortably within these limits, so use narrow storage types
-// for now, knowing that we can transparently move the storage type from u16 to u32 in the future
-// without changing the user visible API.
-
 IdxNewtype!(
     /// A type specifically for rule indices.
     ///

--- a/cfgrammar/src/lib/idxnewtype.rs
+++ b/cfgrammar/src/lib/idxnewtype.rs
@@ -73,7 +73,7 @@ macro_rules! IdxNewtype {
 // without changing the user visible API.
 
 IdxNewtype!(
-    /// A type specifically for nonterminal indices.
+    /// A type specifically for rule indices.
     ///
     /// It is guaranteed that `RIdx` can be converted, without loss of precision, to `usize` with
     /// the idiom `RIdx::from(x_usize)`. `usize` values can be converted to `RIdx`, causing a

--- a/cfgrammar/src/lib/idxnewtype.rs
+++ b/cfgrammar/src/lib/idxnewtype.rs
@@ -75,10 +75,10 @@ macro_rules! IdxNewtype {
 IdxNewtype!(
     /// A type specifically for nonterminal indices.
     ///
-    /// It is guaranteed that `NTIdx` can be converted, without loss of precision, to `usize` with
-    /// the idiom `NTIdx::from(x_usize)`. `usize` values can be converted to `NTIdx`, causing a
+    /// It is guaranteed that `RIdx` can be converted, without loss of precision, to `usize` with
+    /// the idiom `RIdx::from(x_usize)`. `usize` values can be converted to `RIdx`, causing a
     /// panic if this would lead to a loss of precision with `usize::from(y_ntidx)`.
-    NTIdx);
+    RIdx);
 IdxNewtype!(
     /// A type specifically for production indices (e.g. a rule `E::=A|B` would
     /// have two productions for the single rule `E`).
@@ -91,7 +91,7 @@ IdxNewtype!(
     /// A type specifically for symbol indices (within a production).
     ///
     /// It is guaranteed that `SIdx` can be converted, without loss of precision, to `usize` with
-    /// the idiom `SIdx::from(x_usize)`. `usize` values can be converted to `NTIdx`, causing a
+    /// the idiom `SIdx::from(x_usize)`. `usize` values can be converted to `RIdx`, causing a
     /// panic if this would lead to a loss of precision with `usize::from(y_sidx)`.
     SIdx);
 IdxNewtype!(

--- a/cfgrammar/src/lib/idxnewtype.rs
+++ b/cfgrammar/src/lib/idxnewtype.rs
@@ -71,7 +71,7 @@ IdxNewtype!(
     ///
     /// It is guaranteed that `RIdx` can be converted, without loss of precision, to `usize` with
     /// the idiom `RIdx::from(x_usize)`. `usize` values can be converted to `RIdx`, causing a
-    /// panic if this would lead to a loss of precision with `usize::from(y_ntidx)`.
+    /// panic if this would lead to a loss of precision with `usize::from(y_ridx)`.
     RIdx);
 IdxNewtype!(
     /// A type specifically for production indices (e.g. a rule `E::=A|B` would

--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -93,7 +93,7 @@ pub use idxnewtype::{RIdx, PIdx, SIdx, TIdx};
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Symbol<StorageT> {
-    Nonterm(RIdx<StorageT>),
+    Rule(RIdx<StorageT>),
     Term(TIdx<StorageT>)
 }
 

--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -104,7 +104,7 @@ pub trait Grammar<StorageT: 'static + PrimInt + Unsigned> where usize: AsPrimiti
     fn rules_len(&self) -> RIdx<StorageT>;
     /// What is the index of the start rule?
     fn start_rule_idx(&self) -> RIdx<StorageT>;
-    /// How many terminals does this grammar have?
+    /// How many tokens does this grammar have?
     fn terms_len(&self) -> TIdx<StorageT>;
 
     /// Return an iterator which produces (in order from `0..self.rules_len()`) all this
@@ -142,13 +142,13 @@ pub trait Firsts<StorageT: 'static + PrimInt + Unsigned> where usize: AsPrimitiv
     /// Return all the firsts for rule `ntidx`.
     fn firsts(&self, ntidx: RIdx<StorageT>) -> &Vob;
 
-    /// Returns true if the terminal `tidx` is in the first set for rule `nidx`.
+    /// Returns true if the token `tidx` is in the first set for rule `nidx`.
     fn is_set(&self, nidx: RIdx<StorageT>, tidx: TIdx<StorageT>) -> bool;
 
     /// Returns true if the rule `ntidx` has epsilon in its first set.
     fn is_epsilon_set(&self, ntidx: RIdx<StorageT>) -> bool;
 
-    /// Ensures that the firsts bit for terminal `tidx` rule `nidx` is set. Returns true if
+    /// Ensures that the firsts bit for token `tidx` rule `nidx` is set. Returns true if
     /// it was already set, or false otherwise.
     fn set(&mut self, ntidx: RIdx<StorageT>, tidx: TIdx<StorageT>) -> bool;
 }

--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -88,12 +88,12 @@ mod idxnewtype;
 pub mod yacc;
 
 /// A type specifically for nonterminal indices.
-pub use idxnewtype::{NTIdx, PIdx, SIdx, TIdx};
+pub use idxnewtype::{RIdx, PIdx, SIdx, TIdx};
 
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Symbol<StorageT> {
-    Nonterm(NTIdx<StorageT>),
+    Nonterm(RIdx<StorageT>),
     Term(TIdx<StorageT>)
 }
 
@@ -101,20 +101,20 @@ pub trait Grammar<StorageT: 'static + PrimInt + Unsigned> where usize: AsPrimiti
     /// How many productions does this grammar have?
     fn prods_len(&self) -> PIdx<StorageT>;
     /// How many nonterminals does this grammar have?
-    fn nonterms_len(&self) -> NTIdx<StorageT>;
+    fn nonterms_len(&self) -> RIdx<StorageT>;
     /// What is the index of the start rule?
-    fn start_rule_idx(&self) -> NTIdx<StorageT>;
+    fn start_rule_idx(&self) -> RIdx<StorageT>;
     /// How many terminals does this grammar have?
     fn terms_len(&self) -> TIdx<StorageT>;
 
     /// Return an iterator which produces (in order from `0..self.nonterms_len()`) all this
-    /// grammar's valid `NTIdx`s.
-    fn iter_ntidxs(&self) -> Box<dyn Iterator<Item=NTIdx<StorageT>>>
+    /// grammar's valid `RIdx`s.
+    fn iter_ntidxs(&self) -> Box<dyn Iterator<Item=RIdx<StorageT>>>
     {
         // We can use as_ safely, because we know that we're only generating integers from
-        // 0..self.nonterms_len() and, since nonterms_len() returns an NTIdx<StorageT>, then by
+        // 0..self.nonterms_len() and, since nonterms_len() returns an RIdx<StorageT>, then by
         // definition the integers we're creating fit within StorageT.
-        Box::new((0..usize::from(self.nonterms_len())).map(|x| NTIdx(x.as_())))
+        Box::new((0..usize::from(self.nonterms_len())).map(|x| RIdx(x.as_())))
     }
 
     /// Return an iterator which produces (in order from `0..self.prods_len()`) all this
@@ -122,7 +122,7 @@ pub trait Grammar<StorageT: 'static + PrimInt + Unsigned> where usize: AsPrimiti
     fn iter_pidxs(&self) -> Box<dyn Iterator<Item=PIdx<StorageT>>>
     {
         // We can use as_ safely, because we know that we're only generating integers from
-        // 0..self.nonterms_len() and, since nonterms_len() returns an NTIdx<StorageT>, then by
+        // 0..self.nonterms_len() and, since nonterms_len() returns an RIdx<StorageT>, then by
         // definition the integers we're creating fit within StorageT.
         Box::new((0..usize::from(self.prods_len())).map(|x| PIdx(x.as_())))
     }
@@ -140,15 +140,15 @@ pub trait Grammar<StorageT: 'static + PrimInt + Unsigned> where usize: AsPrimiti
 
 pub trait Firsts<StorageT: 'static + PrimInt + Unsigned> where usize: AsPrimitive<StorageT> {
     /// Return all the firsts for nonterminal `ntidx`.
-    fn firsts(&self, ntidx: NTIdx<StorageT>) -> &Vob;
+    fn firsts(&self, ntidx: RIdx<StorageT>) -> &Vob;
 
     /// Returns true if the terminal `tidx` is in the first set for nonterminal `nidx`.
-    fn is_set(&self, nidx: NTIdx<StorageT>, tidx: TIdx<StorageT>) -> bool;
+    fn is_set(&self, nidx: RIdx<StorageT>, tidx: TIdx<StorageT>) -> bool;
 
     /// Returns true if the nonterminal `ntidx` has epsilon in its first set.
-    fn is_epsilon_set(&self, ntidx: NTIdx<StorageT>) -> bool;
+    fn is_epsilon_set(&self, ntidx: RIdx<StorageT>) -> bool;
 
     /// Ensures that the firsts bit for terminal `tidx` nonterminal `nidx` is set. Returns true if
     /// it was already set, or false otherwise.
-    fn set(&mut self, ntidx: NTIdx<StorageT>, tidx: TIdx<StorageT>) -> bool;
+    fn set(&mut self, ntidx: RIdx<StorageT>, tidx: TIdx<StorageT>) -> bool;
 }

--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -109,7 +109,7 @@ pub trait Grammar<StorageT: 'static + PrimInt + Unsigned> where usize: AsPrimiti
 
     /// Return an iterator which produces (in order from `0..self.rules_len()`) all this
     /// grammar's valid `RIdx`s.
-    fn iter_ntidxs(&self) -> Box<dyn Iterator<Item=RIdx<StorageT>>>
+    fn iter_rules(&self) -> Box<dyn Iterator<Item=RIdx<StorageT>>>
     {
         // We can use as_ safely, because we know that we're only generating integers from
         // 0..self.rules_len() and, since rules_len() returns an RIdx<StorageT>, then by

--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -101,20 +101,20 @@ pub trait Grammar<StorageT: 'static + PrimInt + Unsigned> where usize: AsPrimiti
     /// How many productions does this grammar have?
     fn prods_len(&self) -> PIdx<StorageT>;
     /// How many nonterminals does this grammar have?
-    fn nonterms_len(&self) -> RIdx<StorageT>;
+    fn rules_len(&self) -> RIdx<StorageT>;
     /// What is the index of the start rule?
     fn start_rule_idx(&self) -> RIdx<StorageT>;
     /// How many terminals does this grammar have?
     fn terms_len(&self) -> TIdx<StorageT>;
 
-    /// Return an iterator which produces (in order from `0..self.nonterms_len()`) all this
+    /// Return an iterator which produces (in order from `0..self.rules_len()`) all this
     /// grammar's valid `RIdx`s.
     fn iter_ntidxs(&self) -> Box<dyn Iterator<Item=RIdx<StorageT>>>
     {
         // We can use as_ safely, because we know that we're only generating integers from
-        // 0..self.nonterms_len() and, since nonterms_len() returns an RIdx<StorageT>, then by
+        // 0..self.rules_len() and, since rules_len() returns an RIdx<StorageT>, then by
         // definition the integers we're creating fit within StorageT.
-        Box::new((0..usize::from(self.nonterms_len())).map(|x| RIdx(x.as_())))
+        Box::new((0..usize::from(self.rules_len())).map(|x| RIdx(x.as_())))
     }
 
     /// Return an iterator which produces (in order from `0..self.prods_len()`) all this
@@ -122,7 +122,7 @@ pub trait Grammar<StorageT: 'static + PrimInt + Unsigned> where usize: AsPrimiti
     fn iter_pidxs(&self) -> Box<dyn Iterator<Item=PIdx<StorageT>>>
     {
         // We can use as_ safely, because we know that we're only generating integers from
-        // 0..self.nonterms_len() and, since nonterms_len() returns an RIdx<StorageT>, then by
+        // 0..self.rules_len() and, since rules_len() returns an RIdx<StorageT>, then by
         // definition the integers we're creating fit within StorageT.
         Box::new((0..usize::from(self.prods_len())).map(|x| PIdx(x.as_())))
     }
@@ -130,7 +130,7 @@ pub trait Grammar<StorageT: 'static + PrimInt + Unsigned> where usize: AsPrimiti
     fn iter_tidxs(&self) -> Box<dyn Iterator<Item=TIdx<StorageT>>>
     {
         // We can use as_ safely, because we know that we're only generating integers from
-        // 0..self.nonterms_len() and, since nonterms_len() returns an TIdx<StorageT>, then by
+        // 0..self.rules_len() and, since rules_len() returns an TIdx<StorageT>, then by
         // definition the integers we're creating fit within StorageT.
         Box::new((0..usize::from(self.terms_len())).map(|x| TIdx(x.as_())))
     }

--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -139,16 +139,16 @@ pub trait Grammar<StorageT: 'static + PrimInt + Unsigned> where usize: AsPrimiti
 }
 
 pub trait Firsts<StorageT: 'static + PrimInt + Unsigned> where usize: AsPrimitive<StorageT> {
-    /// Return all the firsts for rule `ntidx`.
-    fn firsts(&self, ntidx: RIdx<StorageT>) -> &Vob;
+    /// Return all the firsts for rule `ridx`.
+    fn firsts(&self, ridx: RIdx<StorageT>) -> &Vob;
 
-    /// Returns true if the token `tidx` is in the first set for rule `nidx`.
-    fn is_set(&self, nidx: RIdx<StorageT>, tidx: TIdx<StorageT>) -> bool;
+    /// Returns true if the token `tidx` is in the first set for rule `ridx`.
+    fn is_set(&self, ridx: RIdx<StorageT>, tidx: TIdx<StorageT>) -> bool;
 
-    /// Returns true if the rule `ntidx` has epsilon in its first set.
-    fn is_epsilon_set(&self, ntidx: RIdx<StorageT>) -> bool;
+    /// Returns true if the rule `ridx` has epsilon in its first set.
+    fn is_epsilon_set(&self, ridx: RIdx<StorageT>) -> bool;
 
-    /// Ensures that the firsts bit for token `tidx` rule `nidx` is set. Returns true if
+    /// Ensures that the firsts bit for token `tidx` rule `ridx` is set. Returns true if
     /// it was already set, or false otherwise.
-    fn set(&mut self, ntidx: RIdx<StorageT>, tidx: TIdx<StorageT>) -> bool;
+    fn set(&mut self, ridx: RIdx<StorageT>, tidx: TIdx<StorageT>) -> bool;
 }

--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -87,7 +87,7 @@ use vob::Vob;
 mod idxnewtype;
 pub mod yacc;
 
-/// A type specifically for nonterminal indices.
+/// A type specifically for rule indices.
 pub use idxnewtype::{RIdx, PIdx, SIdx, TIdx};
 
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
@@ -100,7 +100,7 @@ pub enum Symbol<StorageT> {
 pub trait Grammar<StorageT: 'static + PrimInt + Unsigned> where usize: AsPrimitive<StorageT> {
     /// How many productions does this grammar have?
     fn prods_len(&self) -> PIdx<StorageT>;
-    /// How many nonterminals does this grammar have?
+    /// How many rules does this grammar have?
     fn rules_len(&self) -> RIdx<StorageT>;
     /// What is the index of the start rule?
     fn start_rule_idx(&self) -> RIdx<StorageT>;
@@ -139,16 +139,16 @@ pub trait Grammar<StorageT: 'static + PrimInt + Unsigned> where usize: AsPrimiti
 }
 
 pub trait Firsts<StorageT: 'static + PrimInt + Unsigned> where usize: AsPrimitive<StorageT> {
-    /// Return all the firsts for nonterminal `ntidx`.
+    /// Return all the firsts for rule `ntidx`.
     fn firsts(&self, ntidx: RIdx<StorageT>) -> &Vob;
 
-    /// Returns true if the terminal `tidx` is in the first set for nonterminal `nidx`.
+    /// Returns true if the terminal `tidx` is in the first set for rule `nidx`.
     fn is_set(&self, nidx: RIdx<StorageT>, tidx: TIdx<StorageT>) -> bool;
 
-    /// Returns true if the nonterminal `ntidx` has epsilon in its first set.
+    /// Returns true if the rule `ntidx` has epsilon in its first set.
     fn is_epsilon_set(&self, ntidx: RIdx<StorageT>) -> bool;
 
-    /// Ensures that the firsts bit for terminal `tidx` nonterminal `nidx` is set. Returns true if
+    /// Ensures that the firsts bit for terminal `tidx` rule `nidx` is set. Returns true if
     /// it was already set, or false otherwise.
     fn set(&mut self, ntidx: RIdx<StorageT>, tidx: TIdx<StorageT>) -> bool;
 }

--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -94,7 +94,7 @@ pub use idxnewtype::{RIdx, PIdx, SIdx, TIdx};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Symbol<StorageT> {
     Rule(RIdx<StorageT>),
-    Term(TIdx<StorageT>)
+    Token(TIdx<StorageT>)
 }
 
 pub trait Grammar<StorageT: 'static + PrimInt + Unsigned> where usize: AsPrimitive<StorageT> {

--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -105,7 +105,7 @@ pub trait Grammar<StorageT: 'static + PrimInt + Unsigned> where usize: AsPrimiti
     /// What is the index of the start rule?
     fn start_rule_idx(&self) -> RIdx<StorageT>;
     /// How many tokens does this grammar have?
-    fn terms_len(&self) -> TIdx<StorageT>;
+    fn tokens_len(&self) -> TIdx<StorageT>;
 
     /// Return an iterator which produces (in order from `0..self.rules_len()`) all this
     /// grammar's valid `RIdx`s.
@@ -132,7 +132,7 @@ pub trait Grammar<StorageT: 'static + PrimInt + Unsigned> where usize: AsPrimiti
         // We can use as_ safely, because we know that we're only generating integers from
         // 0..self.rules_len() and, since rules_len() returns an TIdx<StorageT>, then by
         // definition the integers we're creating fit within StorageT.
-        Box::new((0..usize::from(self.terms_len())).map(|x| TIdx(x.as_())))
+        Box::new((0..usize::from(self.tokens_len())).map(|x| TIdx(x.as_())))
     }
 
     fn firsts(&self) -> Box<dyn Firsts<StorageT>>;

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -65,7 +65,7 @@ pub struct Production {
 
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub enum Symbol {
-    Nonterm(String),
+    Rule(String),
     Term(String)
 }
 
@@ -113,7 +113,7 @@ impl fmt::Display for GrammarValidationError {
 impl fmt::Display for Symbol {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Symbol::Nonterm(ref s) => write!(f, "{}", s),
+            Symbol::Rule(ref s) => write!(f, "{}", s),
             Symbol::Term(ref s)    => write!(f, "{}", s)
         }
     }
@@ -163,7 +163,7 @@ impl GrammarAST {
             Some(ref s) => {
                 if !self.rules.contains_key(s) {
                     return Err(GrammarValidationError{kind: GrammarValidationErrorKind::InvalidStartRule,
-                                               sym: Some(Symbol::Nonterm(s.clone()))});
+                                               sym: Some(Symbol::Rule(s.clone()))});
                 }
             }
         }
@@ -182,7 +182,7 @@ impl GrammarAST {
                 }
                 for sym in &prod.symbols {
                     match *sym {
-                        Symbol::Nonterm(ref name) => {
+                        Symbol::Rule(ref name) => {
                             if !self.rules.contains_key(name) {
                                 return Err(GrammarValidationError{kind: GrammarValidationErrorKind::UnknownRuleRef,
                                     sym: Some(sym.clone())});
@@ -208,7 +208,7 @@ mod test {
     use yacc::{AssocKind, Precedence};
 
     fn rule(n: &str) -> Symbol {
-        Symbol::Nonterm(n.to_string())
+        Symbol::Rule(n.to_string())
     }
 
     fn terminal(n: &str) -> Symbol {

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -66,7 +66,7 @@ pub struct Production {
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub enum Symbol {
     Rule(String),
-    Term(String)
+    Token(String)
 }
 
 /// The various different possible grammar validation errors.
@@ -114,7 +114,7 @@ impl fmt::Display for Symbol {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Symbol::Rule(ref s) => write!(f, "{}", s),
-            Symbol::Term(ref s)    => write!(f, "{}", s)
+            Symbol::Token(ref s)    => write!(f, "{}", s)
         }
     }
 }
@@ -173,11 +173,11 @@ impl GrammarAST {
                 if let Some(ref n) = prod.precedence {
                     if !self.tokens.contains(n) {
                         return Err(GrammarValidationError{kind: GrammarValidationErrorKind::UnknownToken,
-                            sym: Some(Symbol::Term(n.clone()))});
+                            sym: Some(Symbol::Token(n.clone()))});
                     }
                     if !self.precs.contains_key(n) {
                         return Err(GrammarValidationError{kind: GrammarValidationErrorKind::NoPrecForToken,
-                            sym: Some(Symbol::Term(n.clone()))});
+                            sym: Some(Symbol::Token(n.clone()))});
                     }
                 }
                 for sym in &prod.symbols {
@@ -188,7 +188,7 @@ impl GrammarAST {
                                     sym: Some(sym.clone())});
                             }
                         }
-                        Symbol::Term(ref name) => {
+                        Symbol::Token(ref name) => {
                             if !self.tokens.contains(name) {
                                 return Err(GrammarValidationError{kind: GrammarValidationErrorKind::UnknownToken,
                                     sym: Some(sym.clone())});
@@ -212,7 +212,7 @@ mod test {
     }
 
     fn token(n: &str) -> Symbol {
-        Symbol::Term(n.to_string())
+        Symbol::Token(n.to_string())
     }
 
     #[test]

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -54,7 +54,7 @@ pub struct GrammarAST {
 #[derive(Debug)]
 pub struct Rule {
     pub name: String,
-    pub prod_idxs: Vec<usize> // index into GrammarAST.prod
+    pub pidxs: Vec<usize> // index into GrammarAST.prod
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -167,9 +167,9 @@ impl GrammarAST {
                 }
             }
         }
-        for prod_idxs in self.rules.values() {
-            for &prod_idx in prod_idxs {
-                let prod = &self.prods[prod_idx];
+        for pidxs in self.rules.values() {
+            for &pidx in pidxs {
+                let prod = &self.prods[pidx];
                 if let Some(ref n) = prod.precedence {
                     if !self.tokens.contains(n) {
                         return Err(GrammarValidationError{kind: GrammarValidationErrorKind::UnknownToken,

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -150,7 +150,7 @@ impl GrammarAST {
     /// After the AST has been populated, perform any final operations, and validate the grammar
     /// checking that:
     ///   1) The start rule references a rule in the grammar
-    ///   2) Every nonterminal reference references a rule in the grammar
+    ///   2) Every rule reference references a rule in the grammar
     ///   3) Every terminal reference references a declared token
     ///   4) If a production has a precedence terminal, then it references a declared token
     /// If the validation succeeds, None is returned.
@@ -207,7 +207,7 @@ mod test {
     use super::{GrammarAST, GrammarValidationError, GrammarValidationErrorKind, Symbol};
     use yacc::{AssocKind, Precedence};
 
-    fn nonterminal(n: &str) -> Symbol {
+    fn rule(n: &str) -> Symbol {
         Symbol::Nonterm(n.to_string())
     }
 
@@ -244,19 +244,19 @@ mod test {
     }
 
     #[test]
-    fn test_valid_nonterminal_ref(){
+    fn test_valid_rule_ref(){
         let mut grm = GrammarAST::new();
         grm.start = Some("A".to_string());
-        grm.add_prod("A".to_string(), vec!(nonterminal("B")), None);
+        grm.add_prod("A".to_string(), vec!(rule("B")), None);
         grm.add_prod("B".to_string(), vec!(), None);
         assert!(grm.complete_and_validate().is_ok());
     }
 
     #[test]
-    fn test_invalid_nonterminal_ref(){
+    fn test_invalid_rule_ref(){
         let mut grm = GrammarAST::new();
         grm.start = Some("A".to_string());
-        grm.add_prod("A".to_string(), vec!(nonterminal("B")), None);
+        grm.add_prod("A".to_string(), vec!(rule("B")), None);
         match grm.complete_and_validate() {
             Err(GrammarValidationError{kind: GrammarValidationErrorKind::UnknownRuleRef, ..}) => (),
             _ => panic!("Validation error")
@@ -276,11 +276,11 @@ mod test {
     #[should_panic]
     fn test_valid_token_ref(){
         // for now we won't support the YACC feature that allows
-        // to redefine nonterminals as tokens by adding them to '%token'
+        // to redefine rules as tokens by adding them to '%token'
         let mut grm = GrammarAST::new();
         grm.tokens.insert("b".to_string());
         grm.start = Some("A".to_string());
-        grm.add_prod("A".to_string(), vec!(nonterminal("b")), None);
+        grm.add_prod("A".to_string(), vec!(rule("b")), None);
         assert!(grm.complete_and_validate().is_ok());
     }
 
@@ -296,10 +296,10 @@ mod test {
     }
 
     #[test]
-    fn test_invalid_nonterminal_forgotten_token(){
+    fn test_invalid_rule_forgotten_token(){
         let mut grm = GrammarAST::new();
         grm.start = Some("A".to_string());
-        grm.add_prod("A".to_string(), vec!(nonterminal("b"), terminal("b")), None);
+        grm.add_prod("A".to_string(), vec!(rule("b"), terminal("b")), None);
         match grm.complete_and_validate() {
             Err(GrammarValidationError{kind: GrammarValidationErrorKind::UnknownRuleRef, ..}) => (),
             _ => panic!("Validation error")

--- a/cfgrammar/src/lib/yacc/firsts.rs
+++ b/cfgrammar/src/lib/yacc/firsts.rs
@@ -108,7 +108,7 @@ where usize: AsPrimitive<StorageT>
                             Symbol::Rule(nonterm_i) => {
                                 // if we're dealing with another Nonterm, union its FIRSTs
                                 // together with the current rules FIRSTs. Note this is
-                                // (intentionally) a no-op if the two terminals are one and the
+                                // (intentionally) a no-op if the two tokens are one and the
                                 // same.
                                 for tidx in grm.iter_tidxs() {
                                     if firsts.is_set(nonterm_i, tidx) && !firsts.set(rul_i, tidx) {

--- a/cfgrammar/src/lib/yacc/firsts.rs
+++ b/cfgrammar/src/lib/yacc/firsts.rs
@@ -50,10 +50,10 @@ use yacc::YaccGrammar;
 /// then the following assertions (and only the following assertions) about the firsts set are
 /// correct:
 /// ```ignore
-///   assert!(firsts.is_set(grm.nonterm_idx("S").unwrap(), grm.term_idx("a").unwrap()));
-///   assert!(firsts.is_set(grm.nonterm_idx("S").unwrap(), grm.term_idx("b").unwrap()));
-///   assert!(firsts.is_set(grm.nonterm_idx("A").unwrap(), grm.term_idx("a").unwrap()));
-///   assert!(firsts.is_epsilon_set(grm.nonterm_idx("A").unwrap()));
+///   assert!(firsts.is_set(grm.rule_idx("S").unwrap(), grm.term_idx("a").unwrap()));
+///   assert!(firsts.is_set(grm.rule_idx("S").unwrap(), grm.term_idx("b").unwrap()));
+///   assert!(firsts.is_set(grm.rule_idx("A").unwrap(), grm.term_idx("a").unwrap()));
+///   assert!(firsts.is_epsilon_set(grm.rule_idx("A").unwrap()));
 /// ```
 #[derive(Debug)]
 pub struct YaccFirsts<StorageT> {
@@ -183,7 +183,7 @@ mod test {
           (grm: &YaccGrammar<StorageT>, firsts: &Box<Firsts<StorageT>>, rn: &str, should_be: Vec<&str>)
      where usize: AsPrimitive<StorageT>
     {
-        let nt_i = grm.nonterm_idx(rn).unwrap();
+        let nt_i = grm.rule_idx(rn).unwrap();
         for tidx in grm.iter_tidxs() {
             let n = match grm.term_name(tidx) {
                 Some(n) => n,

--- a/cfgrammar/src/lib/yacc/firsts.rs
+++ b/cfgrammar/src/lib/yacc/firsts.rs
@@ -105,7 +105,7 @@ where usize: AsPrimitive<StorageT>
                                 }
                                 break;
                             },
-                            Symbol::Nonterm(nonterm_i) => {
+                            Symbol::Rule(nonterm_i) => {
                                 // if we're dealing with another Nonterm, union its FIRSTs
                                 // together with the current rules FIRSTs. Note this is
                                 // (intentionally) a no-op if the two terminals are one and the

--- a/cfgrammar/src/lib/yacc/firsts.rs
+++ b/cfgrammar/src/lib/yacc/firsts.rs
@@ -68,7 +68,7 @@ where usize: AsPrimitive<StorageT>
     /// Generates and returns the firsts set for the given grammar.
     pub fn new(grm: &YaccGrammar<StorageT>) -> Self {
         let mut firsts = Vec::with_capacity(usize::from(grm.rules_len()));
-        for _ in grm.iter_ntidxs() {
+        for _ in grm.iter_rules() {
             firsts.push(Vob::from_elem(usize::from(grm.terms_len()), false));
         }
         let mut firsts = YaccFirsts {
@@ -82,7 +82,7 @@ where usize: AsPrimitive<StorageT>
         // have new elements in since we last looked. If they do, we'll have to do another round.
         loop {
             let mut changed = false;
-            for rul_i in grm.iter_ntidxs() {
+            for rul_i in grm.iter_rules() {
                 // For each rule E
                 for prod_i in grm.nonterm_to_prods(rul_i).iter() {
                     // ...and each production A

--- a/cfgrammar/src/lib/yacc/firsts.rs
+++ b/cfgrammar/src/lib/yacc/firsts.rs
@@ -78,7 +78,7 @@ where usize: AsPrimitive<StorageT>
         };
 
         // Loop looking for changes to the firsts set, until we reach a fixed point. In essence, we
-        // look at each rule E, and see if any of the nonterminals at the start of its productions
+        // look at each rule E, and see if any of the rules at the start of its productions
         // have new elements in since we last looked. If they do, we'll have to do another round.
         loop {
             let mut changed = false;
@@ -88,7 +88,7 @@ where usize: AsPrimitive<StorageT>
                     // ...and each production A
                     let prod = grm.prod(*prod_i);
                     if prod.is_empty() {
-                        // if it's an empty production, ensure this nonterminal's epsilon bit is
+                        // if it's an empty production, ensure this rule's epsilon bit is
                         // set.
                         if !firsts.is_epsilon_set(rul_i) {
                             firsts.epsilons.set(usize::from(rul_i), true);
@@ -107,7 +107,7 @@ where usize: AsPrimitive<StorageT>
                             },
                             Symbol::Nonterm(nonterm_i) => {
                                 // if we're dealing with another Nonterm, union its FIRSTs
-                                // together with the current nonterminals FIRSTs. Note this is
+                                // together with the current rules FIRSTs. Note this is
                                 // (intentionally) a no-op if the two terminals are one and the
                                 // same.
                                 for tidx in grm.iter_tidxs() {
@@ -116,7 +116,7 @@ where usize: AsPrimitive<StorageT>
                                     }
                                 }
 
-                                // If the epsilon bit in the nonterminal being referenced is set,
+                                // If the epsilon bit in the rule being referenced is set,
                                 // and if its the last symbol in the production, then add epsilon
                                 // to FIRSTs.
                                 if firsts.is_epsilon_set(nonterm_i) && sym_i == prod.len() - 1 {
@@ -226,7 +226,7 @@ mod test {
     }
 
     #[test]
-    fn test_first_no_subsequent_nonterminals() {
+    fn test_first_no_subsequent_rules() {
         let grm = YaccGrammar::new(YaccKind::Original, &"
           %start C
           %token c d

--- a/cfgrammar/src/lib/yacc/firsts.rs
+++ b/cfgrammar/src/lib/yacc/firsts.rs
@@ -98,7 +98,7 @@ where usize: AsPrimitive<StorageT>
                     }
                     for (sym_i, sym) in prod.iter().enumerate() {
                         match *sym {
-                            Symbol::Term(term_i) => {
+                            Symbol::Token(term_i) => {
                                 // if symbol is a Term, add to FIRSTS
                                 if !firsts.set(rul_i, term_i) {
                                     changed = true;

--- a/cfgrammar/src/lib/yacc/firsts.rs
+++ b/cfgrammar/src/lib/yacc/firsts.rs
@@ -84,7 +84,7 @@ where usize: AsPrimitive<StorageT>
             let mut changed = false;
             for rul_i in grm.iter_rules() {
                 // For each rule E
-                for prod_i in grm.nonterm_to_prods(rul_i).iter() {
+                for prod_i in grm.rule_to_prods(rul_i).iter() {
                     // ...and each production A
                     let prod = grm.prod(*prod_i);
                     if prod.is_empty() {

--- a/cfgrammar/src/lib/yacc/firsts.rs
+++ b/cfgrammar/src/lib/yacc/firsts.rs
@@ -185,7 +185,7 @@ mod test {
     {
         let nt_i = grm.rule_idx(rn).unwrap();
         for tidx in grm.iter_tidxs() {
-            let n = match grm.term_name(tidx) {
+            let n = match grm.token_name(tidx) {
                 Some(n) => n,
                 None => &"<no name>"
             };

--- a/cfgrammar/src/lib/yacc/firsts.rs
+++ b/cfgrammar/src/lib/yacc/firsts.rs
@@ -35,7 +35,7 @@ use std::marker::PhantomData;
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 use vob::Vob;
 
-use {Firsts, Grammar, NTIdx, Symbol, TIdx};
+use {Firsts, Grammar, RIdx, Symbol, TIdx};
 use yacc::YaccGrammar;
 
 /// `Firsts` stores all the first sets for a given grammar. For example, given this code and
@@ -149,19 +149,19 @@ impl<StorageT: 'static + PrimInt + Unsigned>
 Firsts<StorageT> for YaccFirsts<StorageT>
 where usize: AsPrimitive<StorageT>
 {
-    fn firsts(&self, ntidx: NTIdx<StorageT>) -> &Vob {
+    fn firsts(&self, ntidx: RIdx<StorageT>) -> &Vob {
         &self.firsts[usize::from(ntidx)]
     }
 
-    fn is_set(&self, nidx: NTIdx<StorageT>, tidx: TIdx<StorageT>) -> bool {
+    fn is_set(&self, nidx: RIdx<StorageT>, tidx: TIdx<StorageT>) -> bool {
         self.firsts[usize::from(nidx)][usize::from(tidx)]
     }
 
-    fn is_epsilon_set(&self, ntidx: NTIdx<StorageT>) -> bool {
+    fn is_epsilon_set(&self, ntidx: RIdx<StorageT>) -> bool {
         self.epsilons[usize::from(ntidx)]
     }
 
-    fn set(&mut self, ntidx: NTIdx<StorageT>, tidx: TIdx<StorageT>) -> bool {
+    fn set(&mut self, ntidx: RIdx<StorageT>, tidx: TIdx<StorageT>) -> bool {
         let nt = &mut self.firsts[usize::from(ntidx)];
         if nt[usize::from(tidx)] {
             true

--- a/cfgrammar/src/lib/yacc/firsts.rs
+++ b/cfgrammar/src/lib/yacc/firsts.rs
@@ -69,7 +69,7 @@ where usize: AsPrimitive<StorageT>
     pub fn new(grm: &YaccGrammar<StorageT>) -> Self {
         let mut firsts = Vec::with_capacity(usize::from(grm.rules_len()));
         for _ in grm.iter_rules() {
-            firsts.push(Vob::from_elem(usize::from(grm.terms_len()), false));
+            firsts.push(Vob::from_elem(usize::from(grm.tokens_len()), false));
         }
         let mut firsts = YaccFirsts {
             firsts,

--- a/cfgrammar/src/lib/yacc/firsts.rs
+++ b/cfgrammar/src/lib/yacc/firsts.rs
@@ -50,9 +50,9 @@ use yacc::YaccGrammar;
 /// then the following assertions (and only the following assertions) about the firsts set are
 /// correct:
 /// ```ignore
-///   assert!(firsts.is_set(grm.rule_idx("S").unwrap(), grm.term_idx("a").unwrap()));
-///   assert!(firsts.is_set(grm.rule_idx("S").unwrap(), grm.term_idx("b").unwrap()));
-///   assert!(firsts.is_set(grm.rule_idx("A").unwrap(), grm.term_idx("a").unwrap()));
+///   assert!(firsts.is_set(grm.rule_idx("S").unwrap(), grm.token_idx("a").unwrap()));
+///   assert!(firsts.is_set(grm.rule_idx("S").unwrap(), grm.token_idx("b").unwrap()));
+///   assert!(firsts.is_set(grm.rule_idx("A").unwrap(), grm.token_idx("a").unwrap()));
 ///   assert!(firsts.is_epsilon_set(grm.rule_idx("A").unwrap()));
 /// ```
 #[derive(Debug)]

--- a/cfgrammar/src/lib/yacc/firsts.rs
+++ b/cfgrammar/src/lib/yacc/firsts.rs
@@ -67,13 +67,13 @@ where usize: AsPrimitive<StorageT>
 {
     /// Generates and returns the firsts set for the given grammar.
     pub fn new(grm: &YaccGrammar<StorageT>) -> Self {
-        let mut firsts = Vec::with_capacity(usize::from(grm.nonterms_len()));
+        let mut firsts = Vec::with_capacity(usize::from(grm.rules_len()));
         for _ in grm.iter_ntidxs() {
             firsts.push(Vob::from_elem(usize::from(grm.terms_len()), false));
         }
         let mut firsts = YaccFirsts {
             firsts,
-            epsilons: Vob::from_elem(usize::from(grm.nonterms_len()), false),
+            epsilons: Vob::from_elem(usize::from(grm.rules_len()), false),
             phantom      : PhantomData
         };
 

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -264,7 +264,7 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
                 // Add a production for each implicit token
                 for t in ast.implicit_tokens.as_ref().unwrap().iter() {
                     implicit_prods.push(PIdx(prods.len().as_()));
-                    prods.push(Some(vec![Symbol::Term(term_map[t]), Symbol::Rule(rule_idx)]));
+                    prods.push(Some(vec![Symbol::Token(term_map[t]), Symbol::Rule(rule_idx)]));
                     prod_precs.push(Some(None));
                     prods_rules.push(Some(rule_idx));
                 }
@@ -285,8 +285,8 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
                         ast::Symbol::Rule(ref n) => {
                             prod.push(Symbol::Rule(nonterm_map[n]));
                         },
-                        ast::Symbol::Term(ref n) => {
-                            prod.push(Symbol::Term(term_map[n]));
+                        ast::Symbol::Token(ref n) => {
+                            prod.push(Symbol::Token(term_map[n]));
                             if implicit_rule.is_some() {
                                 prod.push(Symbol::Rule(nonterm_map[&implicit_rule.clone().unwrap()]));
                             }
@@ -298,7 +298,7 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
                     prec = Some(ast.precs[n]);
                 } else {
                     for astsym in astprod.symbols.iter().rev() {
-                        if let ast::Symbol::Term(ref n) = *astsym {
+                        if let ast::Symbol::Token(ref n) = *astsym {
                             if let Some(p) = ast.precs.get(n) {
                                 prec = Some(*p);
                             }
@@ -582,7 +582,7 @@ where usize: AsPrimitive<StorageT>
                 for sym in self.grm.prod(pidx).iter() {
                     sc += match *sym {
                         Symbol::Rule(i) => self.min_sentence_cost(i),
-                        Symbol::Term(i)    => u16::from(self.token_costs[usize::from(i)])
+                        Symbol::Token(i)    => u16::from(self.token_costs[usize::from(i)])
                     };
                 }
                 if low_sc.is_none() || sc < low_sc.unwrap() {
@@ -604,7 +604,7 @@ where usize: AsPrimitive<StorageT>
                         st.push((p_idx, i + 1));
                         st.push((cheapest_prod(*j), 0));
                     },
-                    Symbol::Term(j) => {
+                    Symbol::Token(j) => {
                         s.push(*j);
                     }
                 }
@@ -623,7 +623,7 @@ where usize: AsPrimitive<StorageT>
                 for sym in self.grm.prod(pidx).iter() {
                     sc += match *sym {
                         Symbol::Rule(i) => self.min_sentence_cost(i),
-                        Symbol::Term(i)    => u16::from(self.token_costs[usize::from(i)])
+                        Symbol::Token(i)    => u16::from(self.token_costs[usize::from(i)])
                     };
                 }
                 if low_sc.is_none() || sc <= low_sc.unwrap() {
@@ -659,7 +659,7 @@ where usize: AsPrimitive<StorageT>
             for sym in prod {
                 match *sym {
                     Symbol::Rule(nt_idx) => ms.push(self.min_sentences(nt_idx)),
-                    Symbol::Term(t_idx) => ms.push(vec![vec![t_idx]])
+                    Symbol::Token(t_idx) => ms.push(vec![vec![t_idx]])
                 }
             }
 
@@ -763,7 +763,7 @@ fn rule_min_costs<StorageT: 'static + PrimInt + Unsigned>
                 let mut cmplt = true;
                 for sym in grm.prod(*p_idx) {
                     let sc = match *sym {
-                                 Symbol::Term(token_idx) =>
+                                 Symbol::Token(token_idx) =>
                                      u16::from(token_costs[usize::from(token_idx)]),
                                  Symbol::Rule(nt_idx) => {
                                      if !done[usize::from(nt_idx)] {
@@ -836,7 +836,7 @@ fn rule_max_costs<StorageT: 'static + PrimInt + Unsigned>
                 let mut cmplt = true;
                 for sym in grm.prod(*p_idx) {
                     let sc = match *sym {
-                                 Symbol::Term(token_idx) =>
+                                 Symbol::Token(token_idx) =>
                                      u16::from(token_costs[usize::from(token_idx)]),
                                  Symbol::Rule(nt_idx) => {
                                      if costs[usize::from(nt_idx)] == u16::max_value() {
@@ -931,7 +931,7 @@ mod test {
         let start_prod = grm.prod(grm.rules_prods[usize::from(grm.rule_idx("^").unwrap())][0]);
         assert_eq!(*start_prod, [Symbol::Rule(grm.rule_idx("R").unwrap())]);
         let r_prod = grm.prod(grm.rules_prods[usize::from(grm.rule_idx("R").unwrap())][0]);
-        assert_eq!(*r_prod, [Symbol::Term(grm.token_idx("T").unwrap())]);
+        assert_eq!(*r_prod, [Symbol::Token(grm.token_idx("T").unwrap())]);
         assert_eq!(grm.prods_rules, vec![RIdx(1), RIdx(0)]);
 
         assert_eq!(grm.tokens_map(),
@@ -963,7 +963,7 @@ mod test {
         assert_eq!(r_prod[0], Symbol::Rule(grm.rule_idx("S").unwrap()));
         let s_prod = grm.prod(grm.rules_prods[usize::from(grm.rule_idx("S").unwrap())][0]);
         assert_eq!(s_prod.len(), 1);
-        assert_eq!(s_prod[0], Symbol::Term(grm.token_idx("T").unwrap()));
+        assert_eq!(s_prod[0], Symbol::Token(grm.token_idx("T").unwrap()));
     }
 
     #[test]
@@ -988,11 +988,11 @@ mod test {
         let r_prod = grm.prod(grm.rules_prods[usize::from(grm.rule_idx("R").unwrap())][0]);
         assert_eq!(r_prod.len(), 3);
         assert_eq!(r_prod[0], Symbol::Rule(grm.rule_idx("S").unwrap()));
-        assert_eq!(r_prod[1], Symbol::Term(grm.token_idx("T1").unwrap()));
+        assert_eq!(r_prod[1], Symbol::Token(grm.token_idx("T1").unwrap()));
         assert_eq!(r_prod[2], Symbol::Rule(grm.rule_idx("S").unwrap()));
         let s_prod = grm.prod(grm.rules_prods[usize::from(grm.rule_idx("S").unwrap())][0]);
         assert_eq!(s_prod.len(), 1);
-        assert_eq!(s_prod[0], Symbol::Term(grm.token_idx("T2").unwrap()));
+        assert_eq!(s_prod[0], Symbol::Token(grm.token_idx("T2").unwrap()));
     }
 
     #[test]
@@ -1101,7 +1101,7 @@ mod test {
 
         let s_prod1 = &grm.prods[usize::from(grm.rules_prods[usize::from(s_rule_idx)][0])];
         assert_eq!(s_prod1.len(), 2);
-        assert_eq!(s_prod1[0], Symbol::Term(grm.token_idx("a").unwrap()));
+        assert_eq!(s_prod1[0], Symbol::Token(grm.token_idx("a").unwrap()));
         assert_eq!(s_prod1[1], Symbol::Rule(grm.rule_idx(IMPLICIT_RULE).unwrap()));
 
         let s_prod2 = &grm.prods[usize::from(grm.rules_prods[usize::from(s_rule_idx)][1])];
@@ -1113,7 +1113,7 @@ mod test {
 
         let t_prod1 = &grm.prods[usize::from(grm.rules_prods[usize::from(t_rule_idx)][0])];
         assert_eq!(t_prod1.len(), 2);
-        assert_eq!(t_prod1[0], Symbol::Term(grm.token_idx("c").unwrap()));
+        assert_eq!(t_prod1[0], Symbol::Token(grm.token_idx("c").unwrap()));
         assert_eq!(t_prod1[1], Symbol::Rule(grm.rule_idx(IMPLICIT_RULE).unwrap()));
 
         let t_prod2 = &grm.prods[usize::from(grm.rules_prods[usize::from(t_rule_idx)][1])];
@@ -1128,9 +1128,9 @@ mod test {
         assert_eq!(i_prod2.len(), 2);
         // We don't know what order the implicit rule will contain our tokens in,
         // hence the awkward dance below.
-        let cnd1 = vec![Symbol::Term(grm.token_idx("ws1").unwrap()),
+        let cnd1 = vec![Symbol::Token(grm.token_idx("ws1").unwrap()),
                         Symbol::Rule(grm.implicit_rule().unwrap())];
-        let cnd2 = vec![Symbol::Term(grm.token_idx("ws2").unwrap()),
+        let cnd2 = vec![Symbol::Token(grm.token_idx("ws2").unwrap()),
                         Symbol::Rule(grm.implicit_rule().unwrap())];
         assert!((*i_prod1 == cnd1 && *i_prod2 == cnd2) || (*i_prod1 == cnd2 && *i_prod2 == cnd1));
         let i_prod3 = &grm.prods[usize::from(grm.rules_prods[usize::from(i_rule_idx)][2])];

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -67,10 +67,10 @@ pub enum AssocKind {
 }
 
 /// Representation of a `YaccGrammar`. See the [top-level documentation](../../index.html) for the
-/// guarantees this struct makes about nonterminals, terminals, productions, and symbols.
+/// guarantees this struct makes about rules, terminals, productions, and symbols.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct YaccGrammar<StorageT=u32> {
-    /// How many nonterminals does this grammar have?
+    /// How many rules does this grammar have?
     rules_len: RIdx<StorageT>,
     /// A mapping from `RIdx` -> `String`.
     nonterm_names: Vec<String>,
@@ -97,7 +97,7 @@ pub struct YaccGrammar<StorageT=u32> {
     prods_rules: Vec<RIdx<StorageT>>,
     /// The precedence of each production.
     prod_precs: Vec<Option<Precedence>>,
-    /// The index of the nonterminal added for implicit tokens, if they were specified; otherwise
+    /// The index of the rule added for implicit tokens, if they were specified; otherwise
     /// `None`.
     implicit_nonterm: Option<RIdx<StorageT>>
 }
@@ -153,7 +153,7 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
 
         // Generate a guaranteed unique start nonterm name. We simply keep making the string longer
         // until we've hit something unique (at the very worst, this will require looping for as
-        // many times as there are nonterminals). We use the same technique later for unique end
+        // many times as there are rules). We use the same technique later for unique end
         // term and whitespace names.
         let mut start_nonterm = START_NONTERM.to_string();
         while ast.rules.get(&start_nonterm).is_some() {
@@ -226,7 +226,7 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
             let rule_idx = nonterm_map[astrulename];
             if astrulename == &start_nonterm {
                 // Add the special start rule which has a single production which references a
-                // single nonterminal.
+                // single rule.
                 rules_prods[usize::from(nonterm_map[astrulename])]
                     .push(PIdx(prods.len().as_()));
                 let start_prod = match implicit_start_nonterm {
@@ -337,12 +337,12 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
         self.eof_term_idx
     }
 
-    /// Return the productions for nonterminal `i`. Panics if `i` doesn't exist.
+    /// Return the productions for rule `i`. Panics if `i` doesn't exist.
     pub fn nonterm_to_prods(&self, i: RIdx<StorageT>) -> &[PIdx<StorageT>] {
         &self.rules_prods[usize::from(i)]
     }
 
-    /// Return the name of nonterminal `i`. Panics if `i` doesn't exist.
+    /// Return the name of rule `i`. Panics if `i` doesn't exist.
     pub fn nonterm_name(&self, i: RIdx<StorageT>) -> &str {
         &self.nonterm_names[usize::from(i)]
     }
@@ -394,7 +394,7 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
         m
     }
 
-    /// Return this grammar's start nonterminal.
+    /// Return this grammar's start rule.
     pub fn start_nonterm(&self) -> RIdx<StorageT> {
         self.prod_to_nonterm(self.start_prod)
     }
@@ -410,7 +410,7 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
         self.implicit_nonterm
     }
 
-    /// Return the index of the nonterminal named `n` or `None` if it doesn't exist.
+    /// Return the index of the rule named `n` or `None` if it doesn't exist.
     pub fn nonterm_idx(&self, n: &str) -> Option<RIdx<StorageT>> {
         self.nonterm_names.iter()
                           .position(|x| x == n)
@@ -1131,7 +1131,7 @@ mod test {
         let i_prod2 = &grm.prods[usize::from(grm.rules_prods[usize::from(i_rule_idx)][1])];
         assert_eq!(i_prod1.len(), 2);
         assert_eq!(i_prod2.len(), 2);
-        // We don't know what order the implicit nonterminal will contain our tokens in,
+        // We don't know what order the implicit rule will contain our tokens in,
         // hence the awkward dance below.
         let cnd1 = vec![Symbol::Term(grm.term_idx("ws1").unwrap()),
                         Symbol::Nonterm(grm.implicit_nonterm().unwrap())];

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -343,7 +343,7 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
     }
 
     /// Return the name of rule `i`. Panics if `i` doesn't exist.
-    pub fn nonterm_name(&self, i: RIdx<StorageT>) -> &str {
+    pub fn rule_name(&self, i: RIdx<StorageT>) -> &str {
         &self.rule_names[usize::from(i)]
     }
 

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -42,9 +42,9 @@ use super::YaccKind;
 use yacc::firsts::YaccFirsts;
 use yacc::parser::YaccParser;
 
-const START_NONTERM         : &str = "^";
+const START_RULE         : &str = "^";
 const IMPLICIT_NONTERM      : &str = "~";
-const IMPLICIT_START_NONTERM: &str = "^~";
+const IMPLICIT_START_RULE: &str = "^~";
 
 use yacc::ast;
 use yacc::ast::GrammarValidationError;
@@ -155,9 +155,9 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
         // until we've hit something unique (at the very worst, this will require looping for as
         // many times as there are rules). We use the same technique later for unique end
         // term and whitespace names.
-        let mut start_nonterm = START_NONTERM.to_string();
+        let mut start_nonterm = START_RULE.to_string();
         while ast.rules.get(&start_nonterm).is_some() {
-            start_nonterm += START_NONTERM;
+            start_nonterm += START_RULE;
         }
         rule_names.push(start_nonterm.clone());
 
@@ -176,9 +176,9 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
                     }
                     rule_names.push(n1.clone());
                     implicit_rule = Some(n1);
-                    let mut n2 = IMPLICIT_START_NONTERM.to_string();
+                    let mut n2 = IMPLICIT_START_RULE.to_string();
                     while ast.rules.get(&n2).is_some() {
-                        n2 += IMPLICIT_START_NONTERM;
+                        n2 += IMPLICIT_START_RULE;
                     }
                     rule_names.push(n2.clone());
                     implicit_start_nonterm = Some(n2);
@@ -912,7 +912,7 @@ impl fmt::Display for YaccGrammarError {
 #[cfg(test)]
 mod test {
     use std::collections::HashMap;
-    use super::{IMPLICIT_NONTERM, IMPLICIT_START_NONTERM, rule_max_costs, rule_min_costs};
+    use super::{IMPLICIT_NONTERM, IMPLICIT_START_RULE, rule_max_costs, rule_min_costs};
     use {Grammar, RIdx, PIdx, Symbol, TIdx};
     use yacc::{AssocKind, Precedence, YaccGrammar, YaccKind};
 
@@ -1088,7 +1088,7 @@ mod test {
 
         assert_eq!(grm.prod_precs.len(), 9);
 
-        let itfs_rule_idx = grm.rule_idx(IMPLICIT_START_NONTERM).unwrap();
+        let itfs_rule_idx = grm.rule_idx(IMPLICIT_START_RULE).unwrap();
         assert_eq!(grm.rules_prods[usize::from(itfs_rule_idx)].len(), 1);
 
         let itfs_prod1 = &grm.prods[usize::from(grm.rules_prods[usize::from(itfs_rule_idx)][0])];

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -338,7 +338,7 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
     }
 
     /// Return the productions for rule `i`. Panics if `i` doesn't exist.
-    pub fn nonterm_to_prods(&self, i: RIdx<StorageT>) -> &[PIdx<StorageT>] {
+    pub fn rule_to_prods(&self, i: RIdx<StorageT>) -> &[PIdx<StorageT>] {
         &self.rules_prods[usize::from(i)]
     }
 
@@ -445,7 +445,7 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
                 seen[usize::from(ntidx)] = true;
                 todo[usize::from(ntidx)] = false;
                 empty = false;
-                for p_idx in self.nonterm_to_prods(ntidx).iter() {
+                for p_idx in self.rule_to_prods(ntidx).iter() {
                     for sym in self.prod(*p_idx) {
                         if let Symbol::Nonterm(pt_ntidx) = *sym {
                             if pt_ntidx == to {
@@ -582,7 +582,7 @@ where usize: AsPrimitive<StorageT>
         let cheapest_prod = |nt_idx: RIdx<StorageT>| -> PIdx<StorageT> {
             let mut low_sc = None;
             let mut low_idx = None;
-            for &pidx in self.grm.nonterm_to_prods(nt_idx).iter() {
+            for &pidx in self.grm.rule_to_prods(nt_idx).iter() {
                 let mut sc = 0;
                 for sym in self.grm.prod(pidx).iter() {
                     sc += match *sym {
@@ -623,7 +623,7 @@ where usize: AsPrimitive<StorageT>
         let cheapest_prods = |nt_idx: RIdx<StorageT>| -> Vec<PIdx<StorageT>> {
             let mut low_sc = None;
             let mut low_idxs = vec![];
-            for &pidx in self.grm.nonterm_to_prods(nt_idx).iter() {
+            for &pidx in self.grm.rule_to_prods(nt_idx).iter() {
                 let mut sc = 0;
                 for sym in self.grm.prod(pidx).iter() {
                     sc += match *sym {
@@ -763,7 +763,7 @@ fn nonterm_min_costs<StorageT: 'static + PrimInt + Unsigned>
             let mut ls_noncmplt = None; // lowest non-completed cost
             // The call to as_() is guaranteed safe because done.len() == grm.rules_len(), and
             // we guarantee that grm.rules_len() can fit in StorageT.
-            for p_idx in grm.nonterm_to_prods(RIdx(i.as_())).iter() {
+            for p_idx in grm.rule_to_prods(RIdx(i.as_())).iter() {
                 let mut c: u16 = 0; // production cost
                 let mut cmplt = true;
                 for sym in grm.prod(*p_idx) {
@@ -836,7 +836,7 @@ fn nonterm_max_costs<StorageT: 'static + PrimInt + Unsigned>
             let mut hs_noncmplt = None; // highest non-completed cost
             // The call to as_() is guaranteed safe because done.len() == grm.rules_len(), and
             // we guarantee that grm.rules_len() can fit in StorageT.
-            'a: for p_idx in grm.nonterm_to_prods(RIdx(i.as_())).iter() {
+            'a: for p_idx in grm.rule_to_prods(RIdx(i.as_())).iter() {
                 let mut c: u16 = 0; // production cost
                 let mut cmplt = true;
                 for sym in grm.prod(*p_idx) {

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -372,7 +372,7 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
 
     /// Return the name of token `i` (where `None` indicates "the rule has no name"). Panics if
     /// `i` doesn't exist.
-    pub fn term_name(&self, i: TIdx<StorageT>) -> Option<&str> {
+    pub fn token_name(&self, i: TIdx<StorageT>) -> Option<&str> {
         self.token_names[usize::from(i)].as_ref().and_then(|x| Some(x.as_str()))
     }
 
@@ -951,7 +951,7 @@ mod test {
         grm.rule_idx("R").unwrap();
         grm.rule_idx("S").unwrap();
         grm.term_idx("T").unwrap();
-        assert!(grm.term_name(grm.eof_token_idx()).is_none());
+        assert!(grm.token_name(grm.eof_token_idx()).is_none());
 
         assert_eq!(grm.rules_prods, vec![vec![PIdx(2)],
                                          vec![PIdx(0)],

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -80,7 +80,7 @@ pub struct YaccGrammar<StorageT=u32> {
     /// A mapping from `TIdx` -> `Option<Precedence>`
     token_precs: Vec<Option<Precedence>>,
     /// How many tokens does this grammar have?
-    terms_len: TIdx<StorageT>,
+    tokens_len: TIdx<StorageT>,
     /// The offset of the EOF token.
     eof_term_idx: TIdx<StorageT>,
     /// How many productions does this grammar have?
@@ -318,7 +318,7 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
         Ok(YaccGrammar{
             rules_len:     RIdx(rule_names.len().as_()),
             rule_names,
-            terms_len:        TIdx(token_names.len().as_()),
+            tokens_len:        TIdx(token_names.len().as_()),
             eof_term_idx,
             token_names,
             token_precs,
@@ -385,7 +385,7 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
     /// Returns a map from names to `TIdx`s of all tokens that a lexer will need to generate valid
     /// inputs from this grammar.
     pub fn terms_map(&self) -> HashMap<&str, TIdx<StorageT>> {
-        let mut m = HashMap::with_capacity(usize::from(self.terms_len) - 1);
+        let mut m = HashMap::with_capacity(usize::from(self.tokens_len) - 1);
         for tidx in self.iter_tidxs() {
             if let Some(n) = self.token_names[usize::from(tidx)].as_ref() {
                 m.insert(&**n, tidx);
@@ -494,8 +494,8 @@ where usize: AsPrimitive<StorageT>
         self.prod_to_rule(self.start_prod)
     }
 
-    fn terms_len(&self) -> TIdx<StorageT> {
-        self.terms_len
+    fn tokens_len(&self) -> TIdx<StorageT> {
+        self.tokens_len
     }
 
     fn firsts(&self) -> Box<dyn Firsts<StorageT>> {
@@ -536,7 +536,7 @@ where usize: AsPrimitive<StorageT>
     fn new<F>(grm: &'a YaccGrammar<StorageT>, term_cost: F) -> Self
         where F: Fn(TIdx<StorageT>) -> u8
     {
-        let mut term_costs = Vec::with_capacity(usize::from(grm.terms_len()));
+        let mut term_costs = Vec::with_capacity(usize::from(grm.tokens_len()));
         for tidx in grm.iter_tidxs() {
             term_costs.push(term_cost(tidx));
         }

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -384,7 +384,7 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
 
     /// Returns a map from names to `TIdx`s of all tokens that a lexer will need to generate valid
     /// inputs from this grammar.
-    pub fn terms_map(&self) -> HashMap<&str, TIdx<StorageT>> {
+    pub fn tokens_map(&self) -> HashMap<&str, TIdx<StorageT>> {
         let mut m = HashMap::with_capacity(usize::from(self.tokens_len) - 1);
         for tidx in self.iter_tidxs() {
             if let Some(n) = self.token_names[usize::from(tidx)].as_ref() {
@@ -934,7 +934,7 @@ mod test {
         assert_eq!(*r_prod, [Symbol::Term(grm.term_idx("T").unwrap())]);
         assert_eq!(grm.prods_rules, vec![RIdx(1), RIdx(0)]);
 
-        assert_eq!(grm.terms_map(),
+        assert_eq!(grm.tokens_map(),
                    [("T", TIdx(0))].iter()
                                                 .cloned()
                                                 .collect::<HashMap<&str, TIdx<_>>>());

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -438,7 +438,7 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
         todo[usize::from(from)] = true;
         loop {
             let mut empty = true;
-            for ntidx in self.iter_ntidxs() {
+            for ntidx in self.iter_rules() {
                 if !todo[usize::from(ntidx)] {
                     continue;
                 }
@@ -817,7 +817,7 @@ fn nonterm_max_costs<StorageT: 'static + PrimInt + Unsigned>
     costs.resize(usize::from(grm.rules_len()), 0);
 
     // First mark all recursive non-terminals.
-    for ntidx in grm.iter_ntidxs() {
+    for ntidx in grm.iter_rules() {
         // Calling has_path so frequently is not exactly efficient...
         if grm.has_path(ntidx, ntidx) {
             costs[usize::from(ntidx)] = u16::max_value();
@@ -943,7 +943,7 @@ mod test {
                    [("T", TIdx(0))].iter()
                                                 .cloned()
                                                 .collect::<HashMap<&str, TIdx<_>>>());
-        assert_eq!(grm.iter_ntidxs().collect::<Vec<_>>(),
+        assert_eq!(grm.iter_rules().collect::<Vec<_>>(),
                    vec![RIdx(0), RIdx(1)]);
     }
 

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -378,7 +378,7 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
 
     /// Return the precedence of token `i` (where `None` indicates "no precedence specified").
     /// Panics if `i` doesn't exist.
-    pub fn term_precedence(&self, i: TIdx<StorageT>) -> Option<Precedence> {
+    pub fn token_precedence(&self, i: TIdx<StorageT>) -> Option<Precedence> {
         self.token_precs[usize::from(i)]
     }
 

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -359,7 +359,7 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
     }
 
     /// Return the nonterm index of the production `i`. Panics if `i` doesn't exist.
-    pub fn prod_to_nonterm(&self, i: PIdx<StorageT>) -> RIdx<StorageT>
+    pub fn prod_to_rule(&self, i: PIdx<StorageT>) -> RIdx<StorageT>
     {
         self.prods_rules[usize::from(i)]
     }
@@ -396,7 +396,7 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
 
     /// Return this grammar's start rule.
     pub fn start_nonterm(&self) -> RIdx<StorageT> {
-        self.prod_to_nonterm(self.start_prod)
+        self.prod_to_rule(self.start_prod)
     }
 
     /// Return the production index of the start rule's sole production (for Yacc grammars the
@@ -496,7 +496,7 @@ where usize: AsPrimitive<StorageT>
     /// Return the index of the start rule.
     fn start_rule_idx(&self) -> RIdx<StorageT>
     {
-        self.prod_to_nonterm(self.start_prod)
+        self.prod_to_rule(self.start_prod)
     }
 
     fn terms_len(&self) -> TIdx<StorageT> {

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -82,7 +82,7 @@ pub struct YaccGrammar<StorageT=u32> {
     /// How many tokens does this grammar have?
     tokens_len: TIdx<StorageT>,
     /// The offset of the EOF token.
-    eof_term_idx: TIdx<StorageT>,
+    eof_token_idx: TIdx<StorageT>,
     /// How many productions does this grammar have?
     prods_len: PIdx<StorageT>,
     /// Which production is the sole production of the start rule?
@@ -206,7 +206,7 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
             token_names.push(Some(k.clone()));
             token_precs.push(ast.precs.get(k).cloned());
         }
-        let eof_term_idx = TIdx(token_names.len().as_());
+        let eof_token_idx = TIdx(token_names.len().as_());
         token_names.push(None);
         token_precs.push(None);
         let mut term_map = HashMap::<String, TIdx<StorageT>>::new();
@@ -319,7 +319,7 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
             rules_len:     RIdx(rule_names.len().as_()),
             rule_names,
             tokens_len:        TIdx(token_names.len().as_()),
-            eof_term_idx,
+            eof_token_idx,
             token_names,
             token_precs,
             prods_len:        PIdx(prods.len().as_()),
@@ -333,8 +333,8 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
     }
 
     /// Return the index of the end token.
-    pub fn eof_term_idx(&self) -> TIdx<StorageT> {
-        self.eof_term_idx
+    pub fn eof_token_idx(&self) -> TIdx<StorageT> {
+        self.eof_token_idx
     }
 
     /// Return the productions for rule `i`. Panics if `i` doesn't exist.
@@ -951,7 +951,7 @@ mod test {
         grm.rule_idx("R").unwrap();
         grm.rule_idx("S").unwrap();
         grm.term_idx("T").unwrap();
-        assert!(grm.term_name(grm.eof_term_idx()).is_none());
+        assert!(grm.term_name(grm.eof_token_idx()).is_none());
 
         assert_eq!(grm.rules_prods, vec![vec![PIdx(2)],
                                          vec![PIdx(0)],

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -415,7 +415,7 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
     }
 
     /// Return the index of the token named `n` or `None` if it doesn't exist.
-    pub fn term_idx(&self, n: &str) -> Option<TIdx<StorageT>> {
+    pub fn token_idx(&self, n: &str) -> Option<TIdx<StorageT>> {
         self.token_names.iter()
                        .position(|x| x.as_ref().map_or(false, |x| x == n))
                        // The call to as_() is safe because token_names is guaranteed to be small
@@ -763,8 +763,8 @@ fn rule_min_costs<StorageT: 'static + PrimInt + Unsigned>
                 let mut cmplt = true;
                 for sym in grm.prod(*p_idx) {
                     let sc = match *sym {
-                                 Symbol::Term(term_idx) =>
-                                     u16::from(term_costs[usize::from(term_idx)]),
+                                 Symbol::Term(token_idx) =>
+                                     u16::from(term_costs[usize::from(token_idx)]),
                                  Symbol::Rule(nt_idx) => {
                                      if !done[usize::from(nt_idx)] {
                                          cmplt = false;
@@ -836,8 +836,8 @@ fn rule_max_costs<StorageT: 'static + PrimInt + Unsigned>
                 let mut cmplt = true;
                 for sym in grm.prod(*p_idx) {
                     let sc = match *sym {
-                                 Symbol::Term(term_idx) =>
-                                     u16::from(term_costs[usize::from(term_idx)]),
+                                 Symbol::Term(token_idx) =>
+                                     u16::from(term_costs[usize::from(token_idx)]),
                                  Symbol::Rule(nt_idx) => {
                                      if costs[usize::from(nt_idx)] == u16::max_value() {
                                          // As soon as we find reference to an infinite rule, we
@@ -925,13 +925,13 @@ mod test {
         assert_eq!(grm.implicit_rule(), None);
         grm.rule_idx("^").unwrap();
         grm.rule_idx("R").unwrap();
-        grm.term_idx("T").unwrap();
+        grm.token_idx("T").unwrap();
 
         assert_eq!(grm.rules_prods, vec![vec![PIdx(1)], vec![PIdx(0)]]);
         let start_prod = grm.prod(grm.rules_prods[usize::from(grm.rule_idx("^").unwrap())][0]);
         assert_eq!(*start_prod, [Symbol::Rule(grm.rule_idx("R").unwrap())]);
         let r_prod = grm.prod(grm.rules_prods[usize::from(grm.rule_idx("R").unwrap())][0]);
-        assert_eq!(*r_prod, [Symbol::Term(grm.term_idx("T").unwrap())]);
+        assert_eq!(*r_prod, [Symbol::Term(grm.token_idx("T").unwrap())]);
         assert_eq!(grm.prods_rules, vec![RIdx(1), RIdx(0)]);
 
         assert_eq!(grm.tokens_map(),
@@ -950,7 +950,7 @@ mod test {
         grm.rule_idx("^").unwrap();
         grm.rule_idx("R").unwrap();
         grm.rule_idx("S").unwrap();
-        grm.term_idx("T").unwrap();
+        grm.token_idx("T").unwrap();
         assert!(grm.token_name(grm.eof_token_idx()).is_none());
 
         assert_eq!(grm.rules_prods, vec![vec![PIdx(2)],
@@ -963,7 +963,7 @@ mod test {
         assert_eq!(r_prod[0], Symbol::Rule(grm.rule_idx("S").unwrap()));
         let s_prod = grm.prod(grm.rules_prods[usize::from(grm.rule_idx("S").unwrap())][0]);
         assert_eq!(s_prod.len(), 1);
-        assert_eq!(s_prod[0], Symbol::Term(grm.term_idx("T").unwrap()));
+        assert_eq!(s_prod[0], Symbol::Term(grm.token_idx("T").unwrap()));
     }
 
     #[test]
@@ -974,8 +974,8 @@ mod test {
         grm.rule_idx("^").unwrap();
         grm.rule_idx("R").unwrap();
         grm.rule_idx("S").unwrap();
-        grm.term_idx("T1").unwrap();
-        grm.term_idx("T2").unwrap();
+        grm.token_idx("T1").unwrap();
+        grm.token_idx("T2").unwrap();
 
         assert_eq!(grm.rules_prods, vec![vec![PIdx(2)],
                                          vec![PIdx(0)],
@@ -988,11 +988,11 @@ mod test {
         let r_prod = grm.prod(grm.rules_prods[usize::from(grm.rule_idx("R").unwrap())][0]);
         assert_eq!(r_prod.len(), 3);
         assert_eq!(r_prod[0], Symbol::Rule(grm.rule_idx("S").unwrap()));
-        assert_eq!(r_prod[1], Symbol::Term(grm.term_idx("T1").unwrap()));
+        assert_eq!(r_prod[1], Symbol::Term(grm.token_idx("T1").unwrap()));
         assert_eq!(r_prod[2], Symbol::Rule(grm.rule_idx("S").unwrap()));
         let s_prod = grm.prod(grm.rules_prods[usize::from(grm.rule_idx("S").unwrap())][0]);
         assert_eq!(s_prod.len(), 1);
-        assert_eq!(s_prod[0], Symbol::Term(grm.term_idx("T2").unwrap()));
+        assert_eq!(s_prod[0], Symbol::Term(grm.token_idx("T2").unwrap()));
     }
 
     #[test]
@@ -1101,7 +1101,7 @@ mod test {
 
         let s_prod1 = &grm.prods[usize::from(grm.rules_prods[usize::from(s_rule_idx)][0])];
         assert_eq!(s_prod1.len(), 2);
-        assert_eq!(s_prod1[0], Symbol::Term(grm.term_idx("a").unwrap()));
+        assert_eq!(s_prod1[0], Symbol::Term(grm.token_idx("a").unwrap()));
         assert_eq!(s_prod1[1], Symbol::Rule(grm.rule_idx(IMPLICIT_RULE).unwrap()));
 
         let s_prod2 = &grm.prods[usize::from(grm.rules_prods[usize::from(s_rule_idx)][1])];
@@ -1113,7 +1113,7 @@ mod test {
 
         let t_prod1 = &grm.prods[usize::from(grm.rules_prods[usize::from(t_rule_idx)][0])];
         assert_eq!(t_prod1.len(), 2);
-        assert_eq!(t_prod1[0], Symbol::Term(grm.term_idx("c").unwrap()));
+        assert_eq!(t_prod1[0], Symbol::Term(grm.token_idx("c").unwrap()));
         assert_eq!(t_prod1[1], Symbol::Rule(grm.rule_idx(IMPLICIT_RULE).unwrap()));
 
         let t_prod2 = &grm.prods[usize::from(grm.rules_prods[usize::from(t_rule_idx)][1])];
@@ -1128,9 +1128,9 @@ mod test {
         assert_eq!(i_prod2.len(), 2);
         // We don't know what order the implicit rule will contain our tokens in,
         // hence the awkward dance below.
-        let cnd1 = vec![Symbol::Term(grm.term_idx("ws1").unwrap()),
+        let cnd1 = vec![Symbol::Term(grm.token_idx("ws1").unwrap()),
                         Symbol::Rule(grm.implicit_rule().unwrap())];
-        let cnd2 = vec![Symbol::Term(grm.term_idx("ws2").unwrap()),
+        let cnd2 = vec![Symbol::Term(grm.token_idx("ws2").unwrap()),
                         Symbol::Rule(grm.implicit_rule().unwrap())];
         assert!((*i_prod1 == cnd1 && *i_prod2 == cnd2) || (*i_prod1 == cnd2 && *i_prod2 == cnd1));
         let i_prod3 = &grm.prods[usize::from(grm.rules_prods[usize::from(i_rule_idx)][2])];
@@ -1196,7 +1196,7 @@ mod test {
         let find = |nt_name: &str, str_cnds: Vec<Vec<&str>>| {
             let cnds = str_cnds.iter()
                                .map(|x| x.iter()
-                                         .map(|y| grm.term_idx(y)
+                                         .map(|y| grm.token_idx(y)
                                                      .unwrap())
                                          .collect::<Vec<_>>())
                                .collect::<Vec<_>>();

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -43,7 +43,7 @@ use yacc::firsts::YaccFirsts;
 use yacc::parser::YaccParser;
 
 const START_RULE         : &str = "^";
-const IMPLICIT_NONTERM      : &str = "~";
+const IMPLICIT_RULE      : &str = "~";
 const IMPLICIT_START_RULE: &str = "^~";
 
 use yacc::ast;
@@ -170,9 +170,9 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
             },
             YaccKind::Eco => {
                 if ast.implicit_tokens.is_some() {
-                    let mut n1 = IMPLICIT_NONTERM.to_string();
+                    let mut n1 = IMPLICIT_RULE.to_string();
                     while ast.rules.get(&n1).is_some() {
-                        n1 += IMPLICIT_NONTERM;
+                        n1 += IMPLICIT_RULE;
                     }
                     rule_names.push(n1.clone());
                     implicit_rule = Some(n1);
@@ -912,7 +912,7 @@ impl fmt::Display for YaccGrammarError {
 #[cfg(test)]
 mod test {
     use std::collections::HashMap;
-    use super::{IMPLICIT_NONTERM, IMPLICIT_START_RULE, rule_max_costs, rule_min_costs};
+    use super::{IMPLICIT_RULE, IMPLICIT_START_RULE, rule_max_costs, rule_min_costs};
     use {Grammar, RIdx, PIdx, Symbol, TIdx};
     use yacc::{AssocKind, Precedence, YaccGrammar, YaccKind};
 
@@ -1093,7 +1093,7 @@ mod test {
 
         let itfs_prod1 = &grm.prods[usize::from(grm.rules_prods[usize::from(itfs_rule_idx)][0])];
         assert_eq!(itfs_prod1.len(), 2);
-        assert_eq!(itfs_prod1[0], Symbol::Rule(grm.rule_idx(IMPLICIT_NONTERM).unwrap()));
+        assert_eq!(itfs_prod1[0], Symbol::Rule(grm.rule_idx(IMPLICIT_RULE).unwrap()));
         assert_eq!(itfs_prod1[1], Symbol::Rule(grm.rule_idx(&"S").unwrap()));
 
         let s_rule_idx = grm.rule_idx(&"S").unwrap();
@@ -1102,7 +1102,7 @@ mod test {
         let s_prod1 = &grm.prods[usize::from(grm.rules_prods[usize::from(s_rule_idx)][0])];
         assert_eq!(s_prod1.len(), 2);
         assert_eq!(s_prod1[0], Symbol::Term(grm.term_idx("a").unwrap()));
-        assert_eq!(s_prod1[1], Symbol::Rule(grm.rule_idx(IMPLICIT_NONTERM).unwrap()));
+        assert_eq!(s_prod1[1], Symbol::Rule(grm.rule_idx(IMPLICIT_RULE).unwrap()));
 
         let s_prod2 = &grm.prods[usize::from(grm.rules_prods[usize::from(s_rule_idx)][1])];
         assert_eq!(s_prod2.len(), 1);
@@ -1114,13 +1114,13 @@ mod test {
         let t_prod1 = &grm.prods[usize::from(grm.rules_prods[usize::from(t_rule_idx)][0])];
         assert_eq!(t_prod1.len(), 2);
         assert_eq!(t_prod1[0], Symbol::Term(grm.term_idx("c").unwrap()));
-        assert_eq!(t_prod1[1], Symbol::Rule(grm.rule_idx(IMPLICIT_NONTERM).unwrap()));
+        assert_eq!(t_prod1[1], Symbol::Rule(grm.rule_idx(IMPLICIT_RULE).unwrap()));
 
         let t_prod2 = &grm.prods[usize::from(grm.rules_prods[usize::from(t_rule_idx)][1])];
         assert_eq!(t_prod2.len(), 0);
 
-        assert_eq!(Some(grm.rule_idx(IMPLICIT_NONTERM).unwrap()), grm.implicit_rule());
-        let i_rule_idx = grm.rule_idx(IMPLICIT_NONTERM).unwrap();
+        assert_eq!(Some(grm.rule_idx(IMPLICIT_RULE).unwrap()), grm.implicit_rule());
+        let i_rule_idx = grm.rule_idx(IMPLICIT_RULE).unwrap();
         assert_eq!(grm.rules_prods[usize::from(i_rule_idx)].len(), 3);
         let i_prod1 = &grm.prods[usize::from(grm.rules_prods[usize::from(i_rule_idx)][0])];
         let i_prod2 = &grm.prods[usize::from(grm.rules_prods[usize::from(i_rule_idx)][1])];

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -71,7 +71,7 @@ pub enum AssocKind {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct YaccGrammar<StorageT=u32> {
     /// How many nonterminals does this grammar have?
-    nonterms_len: RIdx<StorageT>,
+    rules_len: RIdx<StorageT>,
     /// A mapping from `RIdx` -> `String`.
     nonterm_names: Vec<String>,
     /// A mapping from `TIdx` -> `Option<String>`. Every user-specified terminal will have a name,
@@ -316,7 +316,7 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
         assert!(!term_names.is_empty());
         assert!(!nonterm_names.is_empty());
         Ok(YaccGrammar{
-            nonterms_len:     RIdx(nonterm_names.len().as_()),
+            rules_len:     RIdx(nonterm_names.len().as_()),
             nonterm_names,
             terms_len:        TIdx(term_names.len().as_()),
             eof_term_idx,
@@ -432,9 +432,9 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
     /// return `true` for a path from themselves to themselves.
     pub fn has_path(&self, from: RIdx<StorageT>, to: RIdx<StorageT>) -> bool {
         let mut seen = vec![];
-        seen.resize(usize::from(self.nonterms_len()), false);
+        seen.resize(usize::from(self.rules_len()), false);
         let mut todo = vec![];
-        todo.resize(usize::from(self.nonterms_len()), false);
+        todo.resize(usize::from(self.rules_len()), false);
         todo[usize::from(from)] = true;
         loop {
             let mut empty = true;
@@ -489,8 +489,8 @@ where usize: AsPrimitive<StorageT>
         self.prods_len
     }
 
-    fn nonterms_len(&self) -> RIdx<StorageT> {
-        self.nonterms_len
+    fn rules_len(&self) -> RIdx<StorageT> {
+        self.rules_len
     }
 
     /// Return the index of the start rule.
@@ -749,9 +749,9 @@ fn nonterm_min_costs<StorageT: 'static + PrimInt + Unsigned>
     // eventually we will reach a point where we can determine it definitively.
 
     let mut costs = vec![];
-    costs.resize(usize::from(grm.nonterms_len()), 0);
+    costs.resize(usize::from(grm.rules_len()), 0);
     let mut done = vec![];
-    done.resize(usize::from(grm.nonterms_len()), false);
+    done.resize(usize::from(grm.rules_len()), false);
     loop {
         let mut all_done = true;
         for i in 0..done.len() {
@@ -761,8 +761,8 @@ fn nonterm_min_costs<StorageT: 'static + PrimInt + Unsigned>
             all_done = false;
             let mut ls_cmplt = None; // lowest completed cost
             let mut ls_noncmplt = None; // lowest non-completed cost
-            // The call to as_() is guaranteed safe because done.len() == grm.nonterms_len(), and
-            // we guarantee that grm.nonterms_len() can fit in StorageT.
+            // The call to as_() is guaranteed safe because done.len() == grm.rules_len(), and
+            // we guarantee that grm.rules_len() can fit in StorageT.
             for p_idx in grm.nonterm_to_prods(RIdx(i.as_())).iter() {
                 let mut c: u16 = 0; // production cost
                 let mut cmplt = true;
@@ -812,9 +812,9 @@ fn nonterm_max_costs<StorageT: 'static + PrimInt + Unsigned>
                where usize: AsPrimitive<StorageT>
 {
     let mut done = vec![];
-    done.resize(usize::from(grm.nonterms_len()), false);
+    done.resize(usize::from(grm.rules_len()), false);
     let mut costs = vec![];
-    costs.resize(usize::from(grm.nonterms_len()), 0);
+    costs.resize(usize::from(grm.rules_len()), 0);
 
     // First mark all recursive non-terminals.
     for ntidx in grm.iter_ntidxs() {
@@ -834,8 +834,8 @@ fn nonterm_max_costs<StorageT: 'static + PrimInt + Unsigned>
             all_done = false;
             let mut hs_cmplt = None; // highest completed cost
             let mut hs_noncmplt = None; // highest non-completed cost
-            // The call to as_() is guaranteed safe because done.len() == grm.nonterms_len(), and
-            // we guarantee that grm.nonterms_len() can fit in StorageT.
+            // The call to as_() is guaranteed safe because done.len() == grm.rules_len(), and
+            // we guarantee that grm.rules_len() can fit in StorageT.
             'a: for p_idx in grm.nonterm_to_prods(RIdx(i.as_())).iter() {
                 let mut c: u16 = 0; // production cost
                 let mut cmplt = true;

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -394,11 +394,6 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
         m
     }
 
-    /// Return this grammar's start rule.
-    pub fn start_nonterm(&self) -> RIdx<StorageT> {
-        self.prod_to_rule(self.start_prod)
-    }
-
     /// Return the production index of the start rule's sole production (for Yacc grammars the
     /// start rule is defined to have precisely one production).
     pub fn start_prod(&self) -> PIdx<StorageT> {

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -78,7 +78,7 @@ pub struct YaccGrammar<StorageT=u32> {
     /// but tokens inserted by cfgrammar (e.g. the EOF token) won't.
     token_names: Vec<Option<String>>,
     /// A mapping from `TIdx` -> `Option<Precedence>`
-    term_precs: Vec<Option<Precedence>>,
+    token_precs: Vec<Option<Precedence>>,
     /// How many tokens does this grammar have?
     terms_len: TIdx<StorageT>,
     /// The offset of the EOF token.
@@ -201,14 +201,14 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
         }
 
         let mut token_names: Vec<Option<String>> = Vec::with_capacity(ast.tokens.len() + 1);
-        let mut term_precs: Vec<Option<Precedence>> = Vec::with_capacity(ast.tokens.len() + 1);
+        let mut token_precs: Vec<Option<Precedence>> = Vec::with_capacity(ast.tokens.len() + 1);
         for k in &ast.tokens {
             token_names.push(Some(k.clone()));
-            term_precs.push(ast.precs.get(k).cloned());
+            token_precs.push(ast.precs.get(k).cloned());
         }
         let eof_term_idx = TIdx(token_names.len().as_());
         token_names.push(None);
-        term_precs.push(None);
+        token_precs.push(None);
         let mut term_map = HashMap::<String, TIdx<StorageT>>::new();
         for (i, v) in token_names.iter().enumerate() {
             if let Some(n) = v.as_ref() {
@@ -321,7 +321,7 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
             terms_len:        TIdx(token_names.len().as_()),
             eof_term_idx,
             token_names,
-            term_precs,
+            token_precs,
             prods_len:        PIdx(prods.len().as_()),
             start_prod:       rules_prods[usize::from(nonterm_map[&start_nonterm])][0],
             rules_prods,
@@ -379,7 +379,7 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
     /// Return the precedence of token `i` (where `None` indicates "no precedence specified").
     /// Panics if `i` doesn't exist.
     pub fn term_precedence(&self, i: TIdx<StorageT>) -> Option<Precedence> {
-        self.term_precs[usize::from(i)]
+        self.token_precs[usize::from(i)]
     }
 
     /// Returns a map from names to `TIdx`s of all tokens that a lexer will need to generate valid

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -270,7 +270,7 @@ impl YaccParser {
                 let (j, sym) = try!(self.parse_token(i));
                 i = try!(self.parse_ws(j));
                 self.ast.tokens.insert(sym.clone());
-                syms.push(Symbol::Term(sym));
+                syms.push(Symbol::Token(sym));
             } else if let Some(j) = self.lookahead_is("%prec", i) {
                 i = try!(self.parse_ws(j));
                 let (k, sym) = try!(self.parse_token(i));
@@ -283,7 +283,7 @@ impl YaccParser {
             } else {
                 let (j, sym) = try!(self.parse_token(i));
                 if self.ast.tokens.contains(&sym) {
-                    syms.push(Symbol::Term(sym));
+                    syms.push(Symbol::Token(sym));
                 } else {
                     syms.push(Symbol::Rule(sym));
                 }
@@ -435,12 +435,12 @@ mod test {
     }
 
     fn token(n: &str) -> Symbol {
-        Symbol::Term(n.to_string())
+        Symbol::Token(n.to_string())
     }
 
     #[test]
     fn test_macro() {
-        assert_eq!(Symbol::Term("A".to_string()), token("A"));
+        assert_eq!(Symbol::Token("A".to_string()), token("A"));
     }
 
     #[test]

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -430,7 +430,7 @@ mod test {
         Ok(yp.ast())
     }
 
-    fn nonterminal(n: &str) -> Symbol {
+    fn rule(n: &str) -> Symbol {
         Symbol::Nonterm(n.to_string())
     }
 
@@ -445,9 +445,9 @@ mod test {
 
     #[test]
     fn test_symbol_eq() {
-        assert_eq!(nonterminal("A"), nonterminal("A"));
-        assert!(nonterminal("A") != nonterminal("B"));
-        assert!(nonterminal("A") != terminal("A"));
+        assert_eq!(rule("A"), rule("A"));
+        assert!(rule("A") != rule("B"));
+        assert!(rule("A") != terminal("A"));
     }
 
     #[test]
@@ -520,7 +520,7 @@ mod test {
         let src = "%%\nA : 'a' B;".to_string();
         let grm = parse(YaccKind::Original, &src).unwrap();
         assert_eq!(grm.prods[grm.get_rule("A").unwrap()[0]],
-                   Production{symbols: vec![terminal("a"), nonterminal("B")],
+                   Production{symbols: vec![terminal("a"), rule("B")],
                               precedence: None});
     }
 

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -285,7 +285,7 @@ impl YaccParser {
                 if self.ast.tokens.contains(&sym) {
                     syms.push(Symbol::Term(sym));
                 } else {
-                    syms.push(Symbol::Nonterm(sym));
+                    syms.push(Symbol::Rule(sym));
                 }
                 i = j;
             }
@@ -431,7 +431,7 @@ mod test {
     }
 
     fn rule(n: &str) -> Symbol {
-        Symbol::Nonterm(n.to_string())
+        Symbol::Rule(n.to_string())
     }
 
     fn terminal(n: &str) -> Symbol {

--- a/lrlex/src/lib/builder.rs
+++ b/lrlex/src/lib/builder.rs
@@ -157,7 +157,7 @@ where StorageT: Copy + Debug + Eq + TryFrom<usize> + TypeName
 
         if !self.allow_missing_terms_in_lexer {
             if let Some(ref mfl) = missing_from_lexer {
-                eprintln!("Error: the following terminals are used in the grammar but are not defined in the lexer:");
+                eprintln!("Error: the following tokens are used in the grammar but are not defined in the lexer:");
                 for n in mfl {
                     eprintln!("    {}", n);
                 }
@@ -167,7 +167,7 @@ where StorageT: Copy + Debug + Eq + TryFrom<usize> + TypeName
         }
         if !self.allow_missing_terms_in_parser {
             if let Some(ref mfp) = missing_from_parser {
-                eprintln!("Error: the following terminals are defined in the lexer but not used in the grammar:");
+                eprintln!("Error: the following tokens are defined in the lexer but not used in the grammar:");
                 for n in mfp {
                     eprintln!("    {}", n);
                 }
@@ -208,14 +208,14 @@ where StorageT: Copy + Debug + Eq + TryFrom<usize> + TypeName
         Ok((missing_from_lexer, missing_from_parser))
     }
 
-    /// If passed false, terminals used in the grammar but not defined in the lexer will cause a
+    /// If passed false, tokens used in the grammar but not defined in the lexer will cause a
     /// panic at lexer generation time. Defaults to false.
     pub fn allow_missing_terms_in_lexer(mut self, allow: bool) -> Self {
         self.allow_missing_terms_in_lexer = allow;
         self
     }
 
-    /// If passed false, terminals defined in the lexer but not used in the grammar will cause a
+    /// If passed false, tokens defined in the lexer but not used in the grammar will cause a
     /// panic at lexer generation time. Defaults to true (since lexers sometimes define tokens such
     /// as reserved words, which are intentionally not in the grammar).
     pub fn allow_missing_terms_in_parser(mut self, allow: bool) -> Self {

--- a/lrlex/src/lib/builder.rs
+++ b/lrlex/src/lib/builder.rs
@@ -62,7 +62,7 @@ where StorageT: Copy + Debug + Eq + TryFrom<usize> + TypeName
     /// Create a new `LexerBuilder`.
     ///
     /// `StorageT` must be an unsigned integer type (e.g. `u8`, `u16`) which is big enough to index
-    /// all the tokens, nonterminals, and productions in the lexer and less than or equal in size
+    /// all the tokens, rules, and productions in the lexer and less than or equal in size
     /// to `usize` (e.g. on a 64-bit machine `u128` would be too big). If you are lexing large
     /// files, the additional storage requirements of larger integer types can be noticeable, and
     /// in such cases it can be worth specifying a smaller type. `StorageT` defaults to `u32` if

--- a/lrlex/src/lib/builder.rs
+++ b/lrlex/src/lib/builder.rs
@@ -53,7 +53,7 @@ const RUST_FILE_EXT: &str = "rs";
 pub struct LexerBuilder<StorageT=u32> {
     rule_ids_map: Option<HashMap<String, StorageT>>,
     allow_missing_terms_in_lexer: bool,
-    allow_missing_terms_in_parser: bool
+    allow_missing_tokens_in_parser: bool
 }
 
 impl<StorageT> LexerBuilder<StorageT>
@@ -79,7 +79,7 @@ where StorageT: Copy + Debug + Eq + TryFrom<usize> + TypeName
         LexerBuilder{
             rule_ids_map: None,
             allow_missing_terms_in_lexer: false,
-            allow_missing_terms_in_parser: true
+            allow_missing_tokens_in_parser: true
         }
     }
 
@@ -165,7 +165,7 @@ where StorageT: Copy + Debug + Eq + TryFrom<usize> + TypeName
                 panic!();
             }
         }
-        if !self.allow_missing_terms_in_parser {
+        if !self.allow_missing_tokens_in_parser {
             if let Some(ref mfp) = missing_from_parser {
                 eprintln!("Error: the following tokens are defined in the lexer but not used in the grammar:");
                 for n in mfp {
@@ -218,8 +218,8 @@ where StorageT: Copy + Debug + Eq + TryFrom<usize> + TypeName
     /// If passed false, tokens defined in the lexer but not used in the grammar will cause a
     /// panic at lexer generation time. Defaults to true (since lexers sometimes define tokens such
     /// as reserved words, which are intentionally not in the grammar).
-    pub fn allow_missing_terms_in_parser(mut self, allow: bool) -> Self {
-        self.allow_missing_terms_in_parser = allow;
+    pub fn allow_missing_tokens_in_parser(mut self, allow: bool) -> Self {
+        self.allow_missing_tokens_in_parser = allow;
         self
     }
 }

--- a/lrpar/examples/calcparse/src/main.rs
+++ b/lrpar/examples/calcparse/src/main.rs
@@ -61,7 +61,7 @@ impl<'a> Eval<'a> {
 
     fn eval(&self, n: &Node<u8>) -> i64 {
         match *n {
-            Node::Nonterm{nonterm_idx: RIdx(ntidx), ref nodes} if ntidx==NT_EXPR => {
+            Node::Nonterm{rule_idx: RIdx(ntidx), ref nodes} if ntidx==NT_EXPR => {
                 if nodes.len() == 1 {
                     self.eval(&nodes[0])
                 } else {
@@ -69,7 +69,7 @@ impl<'a> Eval<'a> {
                     self.eval(&nodes[0]) + self.eval(&nodes[2])
                 }
             },
-            Node::Nonterm{nonterm_idx: RIdx(ntidx), ref nodes} if ntidx==NT_TERM => {
+            Node::Nonterm{rule_idx: RIdx(ntidx), ref nodes} if ntidx==NT_TERM => {
                 if nodes.len() == 1 {
                     self.eval(&nodes[0])
                 } else {
@@ -77,7 +77,7 @@ impl<'a> Eval<'a> {
                     self.eval(&nodes[0]) * self.eval(&nodes[2])
                 }
             },
-            Node::Nonterm{nonterm_idx: RIdx(ntidx), ref nodes} if ntidx==NT_FACTOR => {
+            Node::Nonterm{rule_idx: RIdx(ntidx), ref nodes} if ntidx==NT_FACTOR => {
                 if nodes.len() == 1 {
                     if let Node::Term{lexeme} = nodes[0] {
                         self.s[lexeme.start()..lexeme.end()].parse().unwrap()

--- a/lrpar/examples/calcparse/src/main.rs
+++ b/lrpar/examples/calcparse/src/main.rs
@@ -4,7 +4,7 @@ extern crate cfgrammar;
 #[macro_use] extern crate lrlex;
 #[macro_use] extern crate lrpar;
 
-use cfgrammar::NTIdx;
+use cfgrammar::RIdx;
 use lrpar::Node;
 
 // Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
@@ -61,7 +61,7 @@ impl<'a> Eval<'a> {
 
     fn eval(&self, n: &Node<u8>) -> i64 {
         match *n {
-            Node::Nonterm{nonterm_idx: NTIdx(ntidx), ref nodes} if ntidx==NT_EXPR => {
+            Node::Nonterm{nonterm_idx: RIdx(ntidx), ref nodes} if ntidx==NT_EXPR => {
                 if nodes.len() == 1 {
                     self.eval(&nodes[0])
                 } else {
@@ -69,7 +69,7 @@ impl<'a> Eval<'a> {
                     self.eval(&nodes[0]) + self.eval(&nodes[2])
                 }
             },
-            Node::Nonterm{nonterm_idx: NTIdx(ntidx), ref nodes} if ntidx==NT_TERM => {
+            Node::Nonterm{nonterm_idx: RIdx(ntidx), ref nodes} if ntidx==NT_TERM => {
                 if nodes.len() == 1 {
                     self.eval(&nodes[0])
                 } else {
@@ -77,7 +77,7 @@ impl<'a> Eval<'a> {
                     self.eval(&nodes[0]) * self.eval(&nodes[2])
                 }
             },
-            Node::Nonterm{nonterm_idx: NTIdx(ntidx), ref nodes} if ntidx==NT_FACTOR => {
+            Node::Nonterm{nonterm_idx: RIdx(ntidx), ref nodes} if ntidx==NT_FACTOR => {
                 if nodes.len() == 1 {
                     if let Node::Term{lexeme} = nodes[0] {
                         self.s[lexeme.start()..lexeme.end()].parse().unwrap()

--- a/lrpar/examples/calcparse/src/main.rs
+++ b/lrpar/examples/calcparse/src/main.rs
@@ -61,7 +61,7 @@ impl<'a> Eval<'a> {
 
     fn eval(&self, n: &Node<u8>) -> i64 {
         match *n {
-            Node::Nonterm{ridx: RIdx(ridx), ref nodes} if ridx==NT_EXPR => {
+            Node::Nonterm{ridx: RIdx(ridx), ref nodes} if ridx==R_EXPR => {
                 if nodes.len() == 1 {
                     self.eval(&nodes[0])
                 } else {
@@ -69,7 +69,7 @@ impl<'a> Eval<'a> {
                     self.eval(&nodes[0]) + self.eval(&nodes[2])
                 }
             },
-            Node::Nonterm{ridx: RIdx(ridx), ref nodes} if ridx==NT_TERM => {
+            Node::Nonterm{ridx: RIdx(ridx), ref nodes} if ridx==R_TERM => {
                 if nodes.len() == 1 {
                     self.eval(&nodes[0])
                 } else {
@@ -77,7 +77,7 @@ impl<'a> Eval<'a> {
                     self.eval(&nodes[0]) * self.eval(&nodes[2])
                 }
             },
-            Node::Nonterm{ridx: RIdx(ridx), ref nodes} if ridx==NT_FACTOR => {
+            Node::Nonterm{ridx: RIdx(ridx), ref nodes} if ridx==R_FACTOR => {
                 if nodes.len() == 1 {
                     if let Node::Term{lexeme} = nodes[0] {
                         self.s[lexeme.start()..lexeme.end()].parse().unwrap()

--- a/lrpar/examples/calcparse/src/main.rs
+++ b/lrpar/examples/calcparse/src/main.rs
@@ -61,7 +61,7 @@ impl<'a> Eval<'a> {
 
     fn eval(&self, n: &Node<u8>) -> i64 {
         match *n {
-            Node::Nonterm{rule_idx: RIdx(ntidx), ref nodes} if ntidx==NT_EXPR => {
+            Node::Nonterm{ridx: RIdx(ridx), ref nodes} if ridx==NT_EXPR => {
                 if nodes.len() == 1 {
                     self.eval(&nodes[0])
                 } else {
@@ -69,7 +69,7 @@ impl<'a> Eval<'a> {
                     self.eval(&nodes[0]) + self.eval(&nodes[2])
                 }
             },
-            Node::Nonterm{rule_idx: RIdx(ntidx), ref nodes} if ntidx==NT_TERM => {
+            Node::Nonterm{ridx: RIdx(ridx), ref nodes} if ridx==NT_TERM => {
                 if nodes.len() == 1 {
                     self.eval(&nodes[0])
                 } else {
@@ -77,7 +77,7 @@ impl<'a> Eval<'a> {
                     self.eval(&nodes[0]) * self.eval(&nodes[2])
                 }
             },
-            Node::Nonterm{rule_idx: RIdx(ntidx), ref nodes} if ntidx==NT_FACTOR => {
+            Node::Nonterm{ridx: RIdx(ridx), ref nodes} if ridx==NT_FACTOR => {
                 if nodes.len() == 1 {
                     if let Node::Term{lexeme} = nodes[0] {
                         self.s[lexeme.start()..lexeme.end()].parse().unwrap()

--- a/lrpar/src/lib/builder.rs
+++ b/lrpar/src/lib/builder.rs
@@ -231,7 +231,7 @@ pub fn parse(lexemes: &[Lexeme<{storaget}>])
         for ntidx in grm.iter_rules() {
             if !grm.rule_to_prods(ntidx).contains(&grm.start_prod()) {
                 outs.push_str(&format!("#[allow(dead_code)]\nconst NT_{}: {} = {:?};\n",
-                                       grm.nonterm_name(ntidx).to_ascii_uppercase(),
+                                       grm.rule_name(ntidx).to_ascii_uppercase(),
                                        StorageT::type_name(),
                                        usize::from(ntidx)));
             }

--- a/lrpar/src/lib/builder.rs
+++ b/lrpar/src/lib/builder.rs
@@ -229,7 +229,7 @@ pub fn parse(lexemes: &[Lexeme<{storaget}>])
 
         // The rule constants
         for ntidx in grm.iter_rules() {
-            if !grm.nonterm_to_prods(ntidx).contains(&grm.start_prod()) {
+            if !grm.rule_to_prods(ntidx).contains(&grm.start_prod()) {
                 outs.push_str(&format!("#[allow(dead_code)]\nconst NT_{}: {} = {:?};\n",
                                        grm.nonterm_name(ntidx).to_ascii_uppercase(),
                                        StorageT::type_name(),

--- a/lrpar/src/lib/builder.rs
+++ b/lrpar/src/lib/builder.rs
@@ -258,7 +258,7 @@ pub fn parse(lexemes: &[Lexeme<{storaget}>])
 
         // Record the rule IDs map
         for tidx in grm.iter_tidxs() {
-            let n = match grm.term_name(tidx) {
+            let n = match grm.token_name(tidx) {
                 Some(n) => format!("'{}'", n),
                 None => format!("<unknown>")
             };

--- a/lrpar/src/lib/builder.rs
+++ b/lrpar/src/lib/builder.rs
@@ -228,12 +228,12 @@ pub fn parse(lexemes: &[Lexeme<{storaget}>])
         outs.push_str("}\n\n");
 
         // The rule constants
-        for ntidx in grm.iter_rules() {
-            if !grm.rule_to_prods(ntidx).contains(&grm.start_prod()) {
+        for ridx in grm.iter_rules() {
+            if !grm.rule_to_prods(ridx).contains(&grm.start_prod()) {
                 outs.push_str(&format!("#[allow(dead_code)]\nconst NT_{}: {} = {:?};\n",
-                                       grm.rule_name(ntidx).to_ascii_uppercase(),
+                                       grm.rule_name(ridx).to_ascii_uppercase(),
                                        StorageT::type_name(),
-                                       usize::from(ntidx)));
+                                       usize::from(ridx)));
             }
         }
 

--- a/lrpar/src/lib/builder.rs
+++ b/lrpar/src/lib/builder.rs
@@ -75,9 +75,9 @@ where StorageT: 'static + Debug + Hash + PrimInt + Serialize + TypeName + Unsign
     /// Create a new `ParserBuilder`.
     ///
     /// `StorageT` must be an unsigned integer type (e.g. `u8`, `u16`) which is big enough to index
-    /// (separately) all the tokens, nonterminals, and productions in the grammar and less than or
+    /// (separately) all the tokens, rules, and productions in the grammar and less than or
     /// equal in size to `usize` (e.g. on a 64-bit machine `u128` would be too big). In other
-    /// words, if you have a grammar with 256 tokens, 256 nonterminals, and 256 productions, you
+    /// words, if you have a grammar with 256 tokens, 256 rules, and 256 productions, you
     /// can safely specify `u8` here; but if any of those counts becomes 256 you will need to
     /// specify `u16`. If you are parsing large files, the additional storage requirements of
     /// larger integer types can be noticeable, and in such cases it can be worth specifying a
@@ -113,7 +113,7 @@ where StorageT: 'static + Debug + Hash + PrimInt + Serialize + TypeName + Unsign
     ///
     /// # Panics
     ///
-    /// If `StorageT` is not big enough to index the grammar's tokens, nonterminals, or
+    /// If `StorageT` is not big enough to index the grammar's tokens, rules, or
     /// productions.
     pub fn process_file_in_src(&self, srcp: &str)
                             -> Result<(HashMap<String, StorageT>), Box<Error>>
@@ -137,7 +137,7 @@ where StorageT: 'static + Debug + Hash + PrimInt + Serialize + TypeName + Unsign
     ///
     /// # Panics
     ///
-    /// If `StorageT` is not big enough to index the grammar's tokens, nonterminals, or
+    /// If `StorageT` is not big enough to index the grammar's tokens, rules, or
     /// productions.
     pub fn process_file<P, Q>(&self,
                               inp: P,
@@ -227,7 +227,7 @@ pub fn parse(lexemes: &[Lexeme<{storaget}>])
         outs.push_str("}\n");
         outs.push_str("}\n\n");
 
-        // The nonterminal constants
+        // The rule constants
         for ntidx in grm.iter_rules() {
             if !grm.nonterm_to_prods(ntidx).contains(&grm.start_prod()) {
                 outs.push_str(&format!("#[allow(dead_code)]\nconst NT_{}: {} = {:?};\n",

--- a/lrpar/src/lib/builder.rs
+++ b/lrpar/src/lib/builder.rs
@@ -148,7 +148,7 @@ where StorageT: 'static + Debug + Hash + PrimInt + Serialize + TypeName + Unsign
     {
         let inc = read_to_string(&inp).unwrap();
         let grm = YaccGrammar::<StorageT>::new_with_storaget(YaccKind::Eco, &inc)?;
-        let rule_ids = grm.terms_map().iter()
+        let rule_ids = grm.tokens_map().iter()
                                       .map(|(&n, &i)| (n.to_owned(), i.as_storaget()))
                                       .collect::<HashMap<_, _>>();
         let cache = self.rebuild_cache(&grm);

--- a/lrpar/src/lib/builder.rs
+++ b/lrpar/src/lib/builder.rs
@@ -228,7 +228,7 @@ pub fn parse(lexemes: &[Lexeme<{storaget}>])
         outs.push_str("}\n\n");
 
         // The nonterminal constants
-        for ntidx in grm.iter_ntidxs() {
+        for ntidx in grm.iter_rules() {
             if !grm.nonterm_to_prods(ntidx).contains(&grm.start_prod()) {
                 outs.push_str(&format!("#[allow(dead_code)]\nconst NT_{}: {} = {:?};\n",
                                        grm.nonterm_name(ntidx).to_ascii_uppercase(),

--- a/lrpar/src/lib/builder.rs
+++ b/lrpar/src/lib/builder.rs
@@ -230,7 +230,7 @@ pub fn parse(lexemes: &[Lexeme<{storaget}>])
         // The rule constants
         for ridx in grm.iter_rules() {
             if !grm.rule_to_prods(ridx).contains(&grm.start_prod()) {
-                outs.push_str(&format!("#[allow(dead_code)]\nconst NT_{}: {} = {:?};\n",
+                outs.push_str(&format!("#[allow(dead_code)]\nconst R_{}: {} = {:?};\n",
                                        grm.rule_name(ridx).to_ascii_uppercase(),
                                        StorageT::type_name(),
                                        usize::from(ridx)));

--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -48,7 +48,7 @@ const PARSE_AT_LEAST: usize = 3; // N in Corchuelo et al.
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 enum Repair<StorageT> {
-    /// Insert a `Symbol::Term` with idx `term_idx`.
+    /// Insert a `Symbol::Term` with idx `token_idx`.
     InsertTerm(TIdx<StorageT>),
     /// Delete a symbol.
     Delete,
@@ -409,8 +409,8 @@ where usize: AsPrimitive<StorageT>
         from.iter()
             .map(|y| {
                  match *y {
-                     Repair::InsertTerm(term_idx) =>
-                         ParseRepair::Insert(term_idx),
+                     Repair::InsertTerm(token_idx) =>
+                         ParseRepair::Insert(token_idx),
                      Repair::Delete => ParseRepair::Delete,
                      Repair::Shift => ParseRepair::Shift,
                  }
@@ -455,8 +455,8 @@ mod test {
         for r in repairs.iter() {
             match *r {
                 ParseRepair::InsertSeq{..} => panic!("Internal error"),
-                ParseRepair::Insert(term_idx) =>
-                    out.push(format!("Insert \"{}\"", grm.token_name(term_idx).unwrap())),
+                ParseRepair::Insert(token_idx) =>
+                    out.push(format!("Insert \"{}\"", grm.token_name(token_idx).unwrap())),
                 ParseRepair::Delete =>
                     out.push(format!("Delete")),
                 ParseRepair::Shift =>
@@ -535,7 +535,7 @@ E : 'N'
         }
 
         assert_eq!(errs.len(), 1);
-        let err_tok_id = u32::from(grm.term_idx("N").unwrap()).to_u16().unwrap();
+        let err_tok_id = u32::from(grm.token_idx("N").unwrap()).to_u16().unwrap();
         assert_eq!(errs[0].lexeme(), &Lexeme::new(err_tok_id, 2, 1));
         check_all_repairs(&grm,
                           errs[0].repairs(),

--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -270,7 +270,7 @@ where usize: AsPrimitive<StorageT>
     {
         let la_idx = n.la_idx;
         for t_idx in self.parser.stable.state_actions(*n.pstack.val().unwrap()) {
-            if t_idx == self.parser.grm.eof_term_idx() {
+            if t_idx == self.parser.grm.eof_token_idx() {
                 continue;
             }
 

--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -269,13 +269,13 @@ where usize: AsPrimitive<StorageT>
              nbrs: &mut Vec<(u16, PathFNode<StorageT>)>)
     {
         let la_idx = n.la_idx;
-        for t_idx in self.parser.stable.state_actions(*n.pstack.val().unwrap()) {
-            if t_idx == self.parser.grm.eof_token_idx() {
+        for tidx in self.parser.stable.state_actions(*n.pstack.val().unwrap()) {
+            if tidx == self.parser.grm.eof_token_idx() {
                 continue;
             }
 
             let next_lexeme = self.parser.next_lexeme(n.la_idx);
-            let new_lexeme = Lexeme::new(StorageT::from(u32::from(t_idx)).unwrap(),
+            let new_lexeme = Lexeme::new(StorageT::from(u32::from(tidx)).unwrap(),
                                          next_lexeme.start(), 0);
             let (new_la_idx, n_pstack) =
                 self.parser.lr_cactus(Some(new_lexeme), la_idx, la_idx + 1,
@@ -284,8 +284,8 @@ where usize: AsPrimitive<StorageT>
                 let nn = PathFNode{
                     pstack: n_pstack,
                     la_idx: n.la_idx,
-                    repairs: n.repairs.child(RepairMerge::Repair(Repair::InsertTerm(t_idx))),
-                    cf: n.cf.checked_add(u16::from((self.parser.token_cost)(t_idx))).unwrap()};
+                    repairs: n.repairs.child(RepairMerge::Repair(Repair::InsertTerm(tidx))),
+                    cf: n.cf.checked_add(u16::from((self.parser.token_cost)(tidx))).unwrap()};
                 nbrs.push((nn.cf, nn));
             }
         }

--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -456,7 +456,7 @@ mod test {
             match *r {
                 ParseRepair::InsertSeq{..} => panic!("Internal error"),
                 ParseRepair::Insert(term_idx) =>
-                    out.push(format!("Insert \"{}\"", grm.term_name(term_idx).unwrap())),
+                    out.push(format!("Insert \"{}\"", grm.token_name(term_idx).unwrap())),
                 ParseRepair::Delete =>
                     out.push(format!("Delete")),
                 ParseRepair::Shift =>

--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -48,7 +48,7 @@ const PARSE_AT_LEAST: usize = 3; // N in Corchuelo et al.
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 enum Repair<StorageT> {
-    /// Insert a `Symbol::Term` with idx `token_idx`.
+    /// Insert a `Symbol::Token` with idx `token_idx`.
     InsertTerm(TIdx<StorageT>),
     /// Delete a symbol.
     Delete,

--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -285,7 +285,7 @@ where usize: AsPrimitive<StorageT>
                     pstack: n_pstack,
                     la_idx: n.la_idx,
                     repairs: n.repairs.child(RepairMerge::Repair(Repair::InsertTerm(t_idx))),
-                    cf: n.cf.checked_add(u16::from((self.parser.term_cost)(t_idx))).unwrap()};
+                    cf: n.cf.checked_add(u16::from((self.parser.token_cost)(t_idx))).unwrap()};
                 nbrs.push((nn.cf, nn));
             }
         }
@@ -300,7 +300,7 @@ where usize: AsPrimitive<StorageT>
         }
 
         let la_tidx = self.parser.next_tidx(n.la_idx);
-        let cost = (self.parser.term_cost)(la_tidx);
+        let cost = (self.parser.token_cost)(la_tidx);
         let nn = PathFNode{pstack: n.pstack.clone(),
                            la_idx: n.la_idx + 1,
                            repairs: n.repairs.child(RepairMerge::Repair(Repair::Delete)),

--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -669,7 +669,7 @@ where usize: AsPrimitive<StorageT>
                 // The first phase is KimYi's dist algorithm.
                 for (&sym, &sym_st_idx) in sgraph.edges(st_idx).iter() {
                     let d = match sym {
-                        Symbol::Nonterm(nt_idx) => sengen.min_sentence_cost(nt_idx),
+                        Symbol::Rule(nt_idx) => sengen.min_sentence_cost(nt_idx),
                         Symbol::Term(t_idx) => {
                             let off = usize::from(st_idx) * terms_len + usize::from(t_idx);
                             if table[off] != 0 {
@@ -864,7 +864,7 @@ A: '(' A ')'
         assert_eq!(d.dist(s0, grm.term_idx("b").unwrap()), 0);
         assert_eq!(d.dist(s0, grm.eof_term_idx()), 1);
 
-        let s1 = sgraph.edge(s0, Symbol::Nonterm(grm.rule_idx("A").unwrap())).unwrap();
+        let s1 = sgraph.edge(s0, Symbol::Rule(grm.rule_idx("A").unwrap())).unwrap();
         assert_eq!(d.dist(s1, grm.term_idx("(").unwrap()), u16::max_value());
         assert_eq!(d.dist(s1, grm.term_idx(")").unwrap()), u16::max_value());
         assert_eq!(d.dist(s1, grm.term_idx("a").unwrap()), u16::max_value());
@@ -892,7 +892,7 @@ A: '(' A ')'
         assert_eq!(d.dist(s5, grm.term_idx("b").unwrap()), 0);
         assert_eq!(d.dist(s5, grm.eof_term_idx()), 1);
 
-        let s6 = sgraph.edge(s5, Symbol::Nonterm(grm.rule_idx("A").unwrap())).unwrap();
+        let s6 = sgraph.edge(s5, Symbol::Rule(grm.rule_idx("A").unwrap())).unwrap();
         assert_eq!(d.dist(s6, grm.term_idx("(").unwrap()), u16::max_value());
         assert_eq!(d.dist(s6, grm.term_idx(")").unwrap()), 0);
         assert_eq!(d.dist(s6, grm.term_idx("a").unwrap()), u16::max_value());
@@ -928,12 +928,12 @@ U: 'B';
         assert_eq!(d.dist(s0, grm.term_idx("B").unwrap()), 1);
         assert_eq!(d.dist(s0, grm.term_idx("C").unwrap()), 2);
 
-        let s1 = sgraph.edge(s0, Symbol::Nonterm(grm.rule_idx("T").unwrap())).unwrap();
+        let s1 = sgraph.edge(s0, Symbol::Rule(grm.rule_idx("T").unwrap())).unwrap();
         assert_eq!(d.dist(s1, grm.term_idx("A").unwrap()), u16::max_value());
         assert_eq!(d.dist(s1, grm.term_idx("B").unwrap()), 0);
         assert_eq!(d.dist(s1, grm.term_idx("C").unwrap()), 1);
 
-        let s2 = sgraph.edge(s0, Symbol::Nonterm(grm.rule_idx("S").unwrap())).unwrap();
+        let s2 = sgraph.edge(s0, Symbol::Rule(grm.rule_idx("S").unwrap())).unwrap();
         assert_eq!(d.dist(s2, grm.term_idx("A").unwrap()), u16::max_value());
         assert_eq!(d.dist(s2, grm.term_idx("B").unwrap()), u16::max_value());
         assert_eq!(d.dist(s2, grm.term_idx("C").unwrap()), u16::max_value());
@@ -943,7 +943,7 @@ U: 'B';
         assert_eq!(d.dist(s3, grm.term_idx("B").unwrap()), 0);
         assert_eq!(d.dist(s3, grm.term_idx("C").unwrap()), 1);
 
-        let s4 = sgraph.edge(s1, Symbol::Nonterm(grm.rule_idx("U").unwrap())).unwrap();
+        let s4 = sgraph.edge(s1, Symbol::Rule(grm.rule_idx("U").unwrap())).unwrap();
         assert_eq!(d.dist(s4, grm.term_idx("A").unwrap()), u16::max_value());
         assert_eq!(d.dist(s4, grm.term_idx("B").unwrap()), u16::max_value());
         assert_eq!(d.dist(s4, grm.term_idx("C").unwrap()), 0);
@@ -994,7 +994,7 @@ Factor: '(' Expr ')'
         assert_eq!(d.dist(s1, grm.term_idx(")").unwrap()), 1);
         assert_eq!(d.dist(s1, grm.term_idx("INT").unwrap()), 0);
 
-        let s2 = sgraph.edge(s0, Symbol::Nonterm(grm.rule_idx("Factor").unwrap())).unwrap();
+        let s2 = sgraph.edge(s0, Symbol::Rule(grm.rule_idx("Factor").unwrap())).unwrap();
         assert_eq!(d.dist(s2, grm.term_idx("+").unwrap()), 0);
         assert_eq!(d.dist(s2, grm.term_idx("*").unwrap()), 0);
         assert_eq!(d.dist(s2, grm.term_idx("(").unwrap()), 1);
@@ -1046,12 +1046,12 @@ W: 'b' ;
         assert_eq!(d.dist(s0, grm.term_idx("b").unwrap()), 1);
         assert_eq!(d.dist(s0, grm.eof_term_idx()), 0);
 
-        let s1 = sgraph.edge(s0, Symbol::Nonterm(grm.rule_idx("T").unwrap())).unwrap();
+        let s1 = sgraph.edge(s0, Symbol::Rule(grm.rule_idx("T").unwrap())).unwrap();
         assert_eq!(d.dist(s1, grm.term_idx("a").unwrap()), 0);
         assert_eq!(d.dist(s1, grm.term_idx("b").unwrap()), 1);
         assert_eq!(d.dist(s1, grm.eof_term_idx()), 0);
 
-        let s2 = sgraph.edge(s0, Symbol::Nonterm(grm.rule_idx("S").unwrap())).unwrap();
+        let s2 = sgraph.edge(s0, Symbol::Rule(grm.rule_idx("S").unwrap())).unwrap();
         assert_eq!(d.dist(s2, grm.term_idx("a").unwrap()), u16::max_value());
         assert_eq!(d.dist(s2, grm.term_idx("b").unwrap()), u16::max_value());
         assert_eq!(d.dist(s2, grm.eof_term_idx()), 0);
@@ -1061,12 +1061,12 @@ W: 'b' ;
         assert_eq!(d.dist(s3, grm.term_idx("b").unwrap()), 0);
         assert_eq!(d.dist(s3, grm.eof_term_idx()), 1);
 
-        let s4 = sgraph.edge(s1, Symbol::Nonterm(grm.rule_idx("U").unwrap())).unwrap();
+        let s4 = sgraph.edge(s1, Symbol::Rule(grm.rule_idx("U").unwrap())).unwrap();
         assert_eq!(d.dist(s4, grm.term_idx("a").unwrap()), 0);
         assert_eq!(d.dist(s4, grm.term_idx("b").unwrap()), 1);
         assert_eq!(d.dist(s4, grm.eof_term_idx()), 0);
 
-        let s5 = sgraph.edge(s1, Symbol::Nonterm(grm.rule_idx("V").unwrap())).unwrap();
+        let s5 = sgraph.edge(s1, Symbol::Rule(grm.rule_idx("V").unwrap())).unwrap();
         assert_eq!(d.dist(s5, grm.term_idx("a").unwrap()), 1);
         assert_eq!(d.dist(s5, grm.term_idx("b").unwrap()), 0);
         assert_eq!(d.dist(s5, grm.eof_term_idx()), 1);
@@ -1076,7 +1076,7 @@ W: 'b' ;
         assert_eq!(d.dist(s6, grm.term_idx("b").unwrap()), 1);
         assert_eq!(d.dist(s6, grm.eof_term_idx()), 0);
 
-        let s7 = sgraph.edge(s5, Symbol::Nonterm(grm.rule_idx("W").unwrap())).unwrap();
+        let s7 = sgraph.edge(s5, Symbol::Rule(grm.rule_idx("W").unwrap())).unwrap();
         assert_eq!(d.dist(s7, grm.term_idx("a").unwrap()), 0);
         assert_eq!(d.dist(s7, grm.term_idx("b").unwrap()), 1);
         assert_eq!(d.dist(s7, grm.eof_term_idx()), 0);

--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -1214,8 +1214,8 @@ E : 'N'
 
     fn kimyi_lex_grm() -> (&'static str, &'static str) {
         // The example from the KimYi paper, with a bit of alpha-renaming to make it clearer. The
-        // paper uses "A" as a rule name and "a" as a terminal name, which are then easily
-        // confused. Here we use "E" as the rule name, and keep "a" as the terminal name.
+        // paper uses "A" as a rule name and "a" as a token name, which are then easily
+        // confused. Here we use "E" as the rule name, and keep "a" as the token name.
         let lexs = "%%
 \\( '('
 \\) ')'

--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -52,7 +52,7 @@ const TRY_PARSE_AT_MOST: usize = 250;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 enum Repair<StorageT> {
-    /// Insert a `Symbol::Term` with idx `term_idx`.
+    /// Insert a `Symbol::Term` with idx `token_idx`.
     InsertTerm(TIdx<StorageT>),
     /// Delete a symbol.
     Delete,
@@ -437,8 +437,8 @@ where usize: AsPrimitive<StorageT>
         from.iter()
             .map(|y| {
                  match *y {
-                     Repair::InsertTerm(term_idx) =>
-                         ParseRepair::Insert(term_idx),
+                     Repair::InsertTerm(token_idx) =>
+                         ParseRepair::Insert(token_idx),
                      Repair::Delete => ParseRepair::Delete,
                      Repair::Shift => ParseRepair::Shift,
                  }
@@ -833,8 +833,8 @@ mod test {
                     s.push_str("}");
                     out.push(s);
                 },
-                ParseRepair::Insert(term_idx) =>
-                    out.push(format!("Insert \"{}\"", grm.token_name(term_idx).unwrap())),
+                ParseRepair::Insert(token_idx) =>
+                    out.push(format!("Insert \"{}\"", grm.token_name(token_idx).unwrap())),
                 ParseRepair::Delete =>
                     out.push(format!("Delete")),
                 ParseRepair::Shift =>
@@ -858,52 +858,52 @@ A: '(' A ')'
         let (sgraph, stable) = from_yacc(&grm, Minimiser::Pager).unwrap();
         let d = Dist::new(&grm, &sgraph, &stable, |_| 1);
         let s0 = StIdx::from(0u32);
-        assert_eq!(d.dist(s0, grm.term_idx("(").unwrap()), 0);
-        assert_eq!(d.dist(s0, grm.term_idx(")").unwrap()), 1);
-        assert_eq!(d.dist(s0, grm.term_idx("a").unwrap()), 0);
-        assert_eq!(d.dist(s0, grm.term_idx("b").unwrap()), 0);
+        assert_eq!(d.dist(s0, grm.token_idx("(").unwrap()), 0);
+        assert_eq!(d.dist(s0, grm.token_idx(")").unwrap()), 1);
+        assert_eq!(d.dist(s0, grm.token_idx("a").unwrap()), 0);
+        assert_eq!(d.dist(s0, grm.token_idx("b").unwrap()), 0);
         assert_eq!(d.dist(s0, grm.eof_token_idx()), 1);
 
         let s1 = sgraph.edge(s0, Symbol::Rule(grm.rule_idx("A").unwrap())).unwrap();
-        assert_eq!(d.dist(s1, grm.term_idx("(").unwrap()), u16::max_value());
-        assert_eq!(d.dist(s1, grm.term_idx(")").unwrap()), u16::max_value());
-        assert_eq!(d.dist(s1, grm.term_idx("a").unwrap()), u16::max_value());
-        assert_eq!(d.dist(s1, grm.term_idx("b").unwrap()), u16::max_value());
+        assert_eq!(d.dist(s1, grm.token_idx("(").unwrap()), u16::max_value());
+        assert_eq!(d.dist(s1, grm.token_idx(")").unwrap()), u16::max_value());
+        assert_eq!(d.dist(s1, grm.token_idx("a").unwrap()), u16::max_value());
+        assert_eq!(d.dist(s1, grm.token_idx("b").unwrap()), u16::max_value());
         assert_eq!(d.dist(s1, grm.eof_token_idx()), 0);
 
-        let s2 = sgraph.edge(s0, Symbol::Term(grm.term_idx("a").unwrap())).unwrap();
-        assert_eq!(d.dist(s2, grm.term_idx("(").unwrap()), u16::max_value());
-        assert_eq!(d.dist(s2, grm.term_idx(")").unwrap()), 0);
-        assert_eq!(d.dist(s2, grm.term_idx("a").unwrap()), u16::max_value());
-        assert_eq!(d.dist(s2, grm.term_idx("b").unwrap()), u16::max_value());
+        let s2 = sgraph.edge(s0, Symbol::Term(grm.token_idx("a").unwrap())).unwrap();
+        assert_eq!(d.dist(s2, grm.token_idx("(").unwrap()), u16::max_value());
+        assert_eq!(d.dist(s2, grm.token_idx(")").unwrap()), 0);
+        assert_eq!(d.dist(s2, grm.token_idx("a").unwrap()), u16::max_value());
+        assert_eq!(d.dist(s2, grm.token_idx("b").unwrap()), u16::max_value());
         assert_eq!(d.dist(s2, grm.eof_token_idx()), 0);
 
-        let s3 = sgraph.edge(s0, Symbol::Term(grm.term_idx("b").unwrap())).unwrap();
-        assert_eq!(d.dist(s3, grm.term_idx("(").unwrap()), u16::max_value());
-        assert_eq!(d.dist(s3, grm.term_idx(")").unwrap()), 0);
-        assert_eq!(d.dist(s3, grm.term_idx("a").unwrap()), u16::max_value());
-        assert_eq!(d.dist(s3, grm.term_idx("b").unwrap()), u16::max_value());
+        let s3 = sgraph.edge(s0, Symbol::Term(grm.token_idx("b").unwrap())).unwrap();
+        assert_eq!(d.dist(s3, grm.token_idx("(").unwrap()), u16::max_value());
+        assert_eq!(d.dist(s3, grm.token_idx(")").unwrap()), 0);
+        assert_eq!(d.dist(s3, grm.token_idx("a").unwrap()), u16::max_value());
+        assert_eq!(d.dist(s3, grm.token_idx("b").unwrap()), u16::max_value());
         assert_eq!(d.dist(s3, grm.eof_token_idx()), 0);
 
-        let s5 = sgraph.edge(s0, Symbol::Term(grm.term_idx("(").unwrap())).unwrap();
-        assert_eq!(d.dist(s5, grm.term_idx("(").unwrap()), 0);
-        assert_eq!(d.dist(s5, grm.term_idx(")").unwrap()), 1);
-        assert_eq!(d.dist(s5, grm.term_idx("a").unwrap()), 0);
-        assert_eq!(d.dist(s5, grm.term_idx("b").unwrap()), 0);
+        let s5 = sgraph.edge(s0, Symbol::Term(grm.token_idx("(").unwrap())).unwrap();
+        assert_eq!(d.dist(s5, grm.token_idx("(").unwrap()), 0);
+        assert_eq!(d.dist(s5, grm.token_idx(")").unwrap()), 1);
+        assert_eq!(d.dist(s5, grm.token_idx("a").unwrap()), 0);
+        assert_eq!(d.dist(s5, grm.token_idx("b").unwrap()), 0);
         assert_eq!(d.dist(s5, grm.eof_token_idx()), 1);
 
         let s6 = sgraph.edge(s5, Symbol::Rule(grm.rule_idx("A").unwrap())).unwrap();
-        assert_eq!(d.dist(s6, grm.term_idx("(").unwrap()), u16::max_value());
-        assert_eq!(d.dist(s6, grm.term_idx(")").unwrap()), 0);
-        assert_eq!(d.dist(s6, grm.term_idx("a").unwrap()), u16::max_value());
-        assert_eq!(d.dist(s6, grm.term_idx("b").unwrap()), u16::max_value());
+        assert_eq!(d.dist(s6, grm.token_idx("(").unwrap()), u16::max_value());
+        assert_eq!(d.dist(s6, grm.token_idx(")").unwrap()), 0);
+        assert_eq!(d.dist(s6, grm.token_idx("a").unwrap()), u16::max_value());
+        assert_eq!(d.dist(s6, grm.token_idx("b").unwrap()), u16::max_value());
         assert_eq!(d.dist(s6, grm.eof_token_idx()), 1);
 
-        let s4 = sgraph.edge(s6, Symbol::Term(grm.term_idx(")").unwrap())).unwrap();
-        assert_eq!(d.dist(s4, grm.term_idx("(").unwrap()), u16::max_value());
-        assert_eq!(d.dist(s4, grm.term_idx(")").unwrap()), 0);
-        assert_eq!(d.dist(s4, grm.term_idx("a").unwrap()), u16::max_value());
-        assert_eq!(d.dist(s4, grm.term_idx("b").unwrap()), u16::max_value());
+        let s4 = sgraph.edge(s6, Symbol::Term(grm.token_idx(")").unwrap())).unwrap();
+        assert_eq!(d.dist(s4, grm.token_idx("(").unwrap()), u16::max_value());
+        assert_eq!(d.dist(s4, grm.token_idx(")").unwrap()), 0);
+        assert_eq!(d.dist(s4, grm.token_idx("a").unwrap()), u16::max_value());
+        assert_eq!(d.dist(s4, grm.token_idx("b").unwrap()), u16::max_value());
         assert_eq!(d.dist(s4, grm.eof_token_idx()), 0);
     }
 
@@ -924,39 +924,39 @@ U: 'B';
         // more interesting edge cases that the example from the Kim/Yi paper.
 
         let s0 = StIdx::from(0u32);
-        assert_eq!(d.dist(s0, grm.term_idx("A").unwrap()), 0);
-        assert_eq!(d.dist(s0, grm.term_idx("B").unwrap()), 1);
-        assert_eq!(d.dist(s0, grm.term_idx("C").unwrap()), 2);
+        assert_eq!(d.dist(s0, grm.token_idx("A").unwrap()), 0);
+        assert_eq!(d.dist(s0, grm.token_idx("B").unwrap()), 1);
+        assert_eq!(d.dist(s0, grm.token_idx("C").unwrap()), 2);
 
         let s1 = sgraph.edge(s0, Symbol::Rule(grm.rule_idx("T").unwrap())).unwrap();
-        assert_eq!(d.dist(s1, grm.term_idx("A").unwrap()), u16::max_value());
-        assert_eq!(d.dist(s1, grm.term_idx("B").unwrap()), 0);
-        assert_eq!(d.dist(s1, grm.term_idx("C").unwrap()), 1);
+        assert_eq!(d.dist(s1, grm.token_idx("A").unwrap()), u16::max_value());
+        assert_eq!(d.dist(s1, grm.token_idx("B").unwrap()), 0);
+        assert_eq!(d.dist(s1, grm.token_idx("C").unwrap()), 1);
 
         let s2 = sgraph.edge(s0, Symbol::Rule(grm.rule_idx("S").unwrap())).unwrap();
-        assert_eq!(d.dist(s2, grm.term_idx("A").unwrap()), u16::max_value());
-        assert_eq!(d.dist(s2, grm.term_idx("B").unwrap()), u16::max_value());
-        assert_eq!(d.dist(s2, grm.term_idx("C").unwrap()), u16::max_value());
+        assert_eq!(d.dist(s2, grm.token_idx("A").unwrap()), u16::max_value());
+        assert_eq!(d.dist(s2, grm.token_idx("B").unwrap()), u16::max_value());
+        assert_eq!(d.dist(s2, grm.token_idx("C").unwrap()), u16::max_value());
 
-        let s3 = sgraph.edge(s0, Symbol::Term(grm.term_idx("A").unwrap())).unwrap();
-        assert_eq!(d.dist(s3, grm.term_idx("A").unwrap()), u16::max_value());
-        assert_eq!(d.dist(s3, grm.term_idx("B").unwrap()), 0);
-        assert_eq!(d.dist(s3, grm.term_idx("C").unwrap()), 1);
+        let s3 = sgraph.edge(s0, Symbol::Term(grm.token_idx("A").unwrap())).unwrap();
+        assert_eq!(d.dist(s3, grm.token_idx("A").unwrap()), u16::max_value());
+        assert_eq!(d.dist(s3, grm.token_idx("B").unwrap()), 0);
+        assert_eq!(d.dist(s3, grm.token_idx("C").unwrap()), 1);
 
         let s4 = sgraph.edge(s1, Symbol::Rule(grm.rule_idx("U").unwrap())).unwrap();
-        assert_eq!(d.dist(s4, grm.term_idx("A").unwrap()), u16::max_value());
-        assert_eq!(d.dist(s4, grm.term_idx("B").unwrap()), u16::max_value());
-        assert_eq!(d.dist(s4, grm.term_idx("C").unwrap()), 0);
+        assert_eq!(d.dist(s4, grm.token_idx("A").unwrap()), u16::max_value());
+        assert_eq!(d.dist(s4, grm.token_idx("B").unwrap()), u16::max_value());
+        assert_eq!(d.dist(s4, grm.token_idx("C").unwrap()), 0);
 
-        let s5 = sgraph.edge(s1, Symbol::Term(grm.term_idx("B").unwrap())).unwrap();
-        assert_eq!(d.dist(s5, grm.term_idx("A").unwrap()), u16::max_value());
-        assert_eq!(d.dist(s5, grm.term_idx("B").unwrap()), u16::max_value());
-        assert_eq!(d.dist(s5, grm.term_idx("C").unwrap()), 0);
+        let s5 = sgraph.edge(s1, Symbol::Term(grm.token_idx("B").unwrap())).unwrap();
+        assert_eq!(d.dist(s5, grm.token_idx("A").unwrap()), u16::max_value());
+        assert_eq!(d.dist(s5, grm.token_idx("B").unwrap()), u16::max_value());
+        assert_eq!(d.dist(s5, grm.token_idx("C").unwrap()), 0);
 
-        let s6 = sgraph.edge(s4, Symbol::Term(grm.term_idx("C").unwrap())).unwrap();
-        assert_eq!(d.dist(s6, grm.term_idx("A").unwrap()), u16::max_value());
-        assert_eq!(d.dist(s6, grm.term_idx("B").unwrap()), u16::max_value());
-        assert_eq!(d.dist(s6, grm.term_idx("C").unwrap()), u16::max_value());
+        let s6 = sgraph.edge(s4, Symbol::Term(grm.token_idx("C").unwrap())).unwrap();
+        assert_eq!(d.dist(s6, grm.token_idx("A").unwrap()), u16::max_value());
+        assert_eq!(d.dist(s6, grm.token_idx("B").unwrap()), u16::max_value());
+        assert_eq!(d.dist(s6, grm.token_idx("C").unwrap()), u16::max_value());
     }
 
     #[test]
@@ -981,32 +981,32 @@ Factor: '(' Expr ')'
         // more interesting edge cases that the example from the Kim/Yi paper.
 
         let s0 = StIdx::from(0u32);
-        assert_eq!(d.dist(s0, grm.term_idx("+").unwrap()), 1);
-        assert_eq!(d.dist(s0, grm.term_idx("*").unwrap()), 1);
-        assert_eq!(d.dist(s0, grm.term_idx("(").unwrap()), 0);
-        assert_eq!(d.dist(s0, grm.term_idx(")").unwrap()), 1);
-        assert_eq!(d.dist(s0, grm.term_idx("INT").unwrap()), 0);
+        assert_eq!(d.dist(s0, grm.token_idx("+").unwrap()), 1);
+        assert_eq!(d.dist(s0, grm.token_idx("*").unwrap()), 1);
+        assert_eq!(d.dist(s0, grm.token_idx("(").unwrap()), 0);
+        assert_eq!(d.dist(s0, grm.token_idx(")").unwrap()), 1);
+        assert_eq!(d.dist(s0, grm.token_idx("INT").unwrap()), 0);
 
-        let s1 = sgraph.edge(s0, Symbol::Term(grm.term_idx("(").unwrap())).unwrap();
-        assert_eq!(d.dist(s1, grm.term_idx("+").unwrap()), 1);
-        assert_eq!(d.dist(s1, grm.term_idx("*").unwrap()), 1);
-        assert_eq!(d.dist(s1, grm.term_idx("(").unwrap()), 0);
-        assert_eq!(d.dist(s1, grm.term_idx(")").unwrap()), 1);
-        assert_eq!(d.dist(s1, grm.term_idx("INT").unwrap()), 0);
+        let s1 = sgraph.edge(s0, Symbol::Term(grm.token_idx("(").unwrap())).unwrap();
+        assert_eq!(d.dist(s1, grm.token_idx("+").unwrap()), 1);
+        assert_eq!(d.dist(s1, grm.token_idx("*").unwrap()), 1);
+        assert_eq!(d.dist(s1, grm.token_idx("(").unwrap()), 0);
+        assert_eq!(d.dist(s1, grm.token_idx(")").unwrap()), 1);
+        assert_eq!(d.dist(s1, grm.token_idx("INT").unwrap()), 0);
 
         let s2 = sgraph.edge(s0, Symbol::Rule(grm.rule_idx("Factor").unwrap())).unwrap();
-        assert_eq!(d.dist(s2, grm.term_idx("+").unwrap()), 0);
-        assert_eq!(d.dist(s2, grm.term_idx("*").unwrap()), 0);
-        assert_eq!(d.dist(s2, grm.term_idx("(").unwrap()), 1);
-        assert_eq!(d.dist(s2, grm.term_idx(")").unwrap()), 0);
-        assert_eq!(d.dist(s2, grm.term_idx("INT").unwrap()), 1);
+        assert_eq!(d.dist(s2, grm.token_idx("+").unwrap()), 0);
+        assert_eq!(d.dist(s2, grm.token_idx("*").unwrap()), 0);
+        assert_eq!(d.dist(s2, grm.token_idx("(").unwrap()), 1);
+        assert_eq!(d.dist(s2, grm.token_idx(")").unwrap()), 0);
+        assert_eq!(d.dist(s2, grm.token_idx("INT").unwrap()), 1);
 
-        let s3 = sgraph.edge(s0, Symbol::Term(grm.term_idx("INT").unwrap())).unwrap();
-        assert_eq!(d.dist(s3, grm.term_idx("+").unwrap()), 0);
-        assert_eq!(d.dist(s3, grm.term_idx("*").unwrap()), 0);
-        assert_eq!(d.dist(s3, grm.term_idx("(").unwrap()), 1);
-        assert_eq!(d.dist(s3, grm.term_idx(")").unwrap()), 0);
-        assert_eq!(d.dist(s3, grm.term_idx("INT").unwrap()), 1);
+        let s3 = sgraph.edge(s0, Symbol::Term(grm.token_idx("INT").unwrap())).unwrap();
+        assert_eq!(d.dist(s3, grm.token_idx("+").unwrap()), 0);
+        assert_eq!(d.dist(s3, grm.token_idx("*").unwrap()), 0);
+        assert_eq!(d.dist(s3, grm.token_idx("(").unwrap()), 1);
+        assert_eq!(d.dist(s3, grm.token_idx(")").unwrap()), 0);
+        assert_eq!(d.dist(s3, grm.token_idx("INT").unwrap()), 1);
     }
 
     #[test]
@@ -1042,43 +1042,43 @@ W: 'b' ;
         let d = Dist::new(&grm, &sgraph, &stable, |_| 1);
 
         let s0 = StIdx::from(0u32);
-        assert_eq!(d.dist(s0, grm.term_idx("a").unwrap()), 0);
-        assert_eq!(d.dist(s0, grm.term_idx("b").unwrap()), 1);
+        assert_eq!(d.dist(s0, grm.token_idx("a").unwrap()), 0);
+        assert_eq!(d.dist(s0, grm.token_idx("b").unwrap()), 1);
         assert_eq!(d.dist(s0, grm.eof_token_idx()), 0);
 
         let s1 = sgraph.edge(s0, Symbol::Rule(grm.rule_idx("T").unwrap())).unwrap();
-        assert_eq!(d.dist(s1, grm.term_idx("a").unwrap()), 0);
-        assert_eq!(d.dist(s1, grm.term_idx("b").unwrap()), 1);
+        assert_eq!(d.dist(s1, grm.token_idx("a").unwrap()), 0);
+        assert_eq!(d.dist(s1, grm.token_idx("b").unwrap()), 1);
         assert_eq!(d.dist(s1, grm.eof_token_idx()), 0);
 
         let s2 = sgraph.edge(s0, Symbol::Rule(grm.rule_idx("S").unwrap())).unwrap();
-        assert_eq!(d.dist(s2, grm.term_idx("a").unwrap()), u16::max_value());
-        assert_eq!(d.dist(s2, grm.term_idx("b").unwrap()), u16::max_value());
+        assert_eq!(d.dist(s2, grm.token_idx("a").unwrap()), u16::max_value());
+        assert_eq!(d.dist(s2, grm.token_idx("b").unwrap()), u16::max_value());
         assert_eq!(d.dist(s2, grm.eof_token_idx()), 0);
 
-        let s3 = sgraph.edge(s1, Symbol::Term(grm.term_idx("a").unwrap())).unwrap();
-        assert_eq!(d.dist(s3, grm.term_idx("a").unwrap()), 1);
-        assert_eq!(d.dist(s3, grm.term_idx("b").unwrap()), 0);
+        let s3 = sgraph.edge(s1, Symbol::Term(grm.token_idx("a").unwrap())).unwrap();
+        assert_eq!(d.dist(s3, grm.token_idx("a").unwrap()), 1);
+        assert_eq!(d.dist(s3, grm.token_idx("b").unwrap()), 0);
         assert_eq!(d.dist(s3, grm.eof_token_idx()), 1);
 
         let s4 = sgraph.edge(s1, Symbol::Rule(grm.rule_idx("U").unwrap())).unwrap();
-        assert_eq!(d.dist(s4, grm.term_idx("a").unwrap()), 0);
-        assert_eq!(d.dist(s4, grm.term_idx("b").unwrap()), 1);
+        assert_eq!(d.dist(s4, grm.token_idx("a").unwrap()), 0);
+        assert_eq!(d.dist(s4, grm.token_idx("b").unwrap()), 1);
         assert_eq!(d.dist(s4, grm.eof_token_idx()), 0);
 
         let s5 = sgraph.edge(s1, Symbol::Rule(grm.rule_idx("V").unwrap())).unwrap();
-        assert_eq!(d.dist(s5, grm.term_idx("a").unwrap()), 1);
-        assert_eq!(d.dist(s5, grm.term_idx("b").unwrap()), 0);
+        assert_eq!(d.dist(s5, grm.token_idx("a").unwrap()), 1);
+        assert_eq!(d.dist(s5, grm.token_idx("b").unwrap()), 0);
         assert_eq!(d.dist(s5, grm.eof_token_idx()), 1);
 
-        let s6 = sgraph.edge(s5, Symbol::Term(grm.term_idx("b").unwrap())).unwrap();
-        assert_eq!(d.dist(s6, grm.term_idx("a").unwrap()), 0);
-        assert_eq!(d.dist(s6, grm.term_idx("b").unwrap()), 1);
+        let s6 = sgraph.edge(s5, Symbol::Term(grm.token_idx("b").unwrap())).unwrap();
+        assert_eq!(d.dist(s6, grm.token_idx("a").unwrap()), 0);
+        assert_eq!(d.dist(s6, grm.token_idx("b").unwrap()), 1);
         assert_eq!(d.dist(s6, grm.eof_token_idx()), 0);
 
         let s7 = sgraph.edge(s5, Symbol::Rule(grm.rule_idx("W").unwrap())).unwrap();
-        assert_eq!(d.dist(s7, grm.term_idx("a").unwrap()), 0);
-        assert_eq!(d.dist(s7, grm.term_idx("b").unwrap()), 1);
+        assert_eq!(d.dist(s7, grm.token_idx("a").unwrap()), 0);
+        assert_eq!(d.dist(s7, grm.token_idx("b").unwrap()), 1);
         assert_eq!(d.dist(s7, grm.eof_token_idx()), 0);
     }
 
@@ -1182,7 +1182,7 @@ E : 'N'
         }
 
         assert_eq!(errs.len(), 1);
-        let err_tok_id = u32::from(grm.term_idx("N").unwrap()).to_u16().unwrap();
+        let err_tok_id = u32::from(grm.token_idx("N").unwrap()).to_u16().unwrap();
         assert_eq!(errs[0].lexeme(), &Lexeme::new(err_tok_id, 2, 1));
         check_all_repairs(&grm,
                           errs[0].repairs(),

--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -293,7 +293,7 @@ where usize: AsPrimitive<StorageT>
         let top_pstack = *n.pstack.val().unwrap();
         for p_idx in self.parser.stable.core_reduces(top_pstack) {
             let sym_off = self.parser.grm.prod(p_idx).len();
-            let nt_idx = self.parser.grm.prod_to_nonterm(p_idx);
+            let nt_idx = self.parser.grm.prod_to_rule(p_idx);
             let mut qi_minus_alpha = n.pstack.clone();
             for _ in 0..sym_off {
                 qi_minus_alpha = qi_minus_alpha.parent().unwrap();
@@ -307,7 +307,7 @@ where usize: AsPrimitive<StorageT>
                 while self.parser.stable.reduce_only_state(goto_st_idx) {
                     let p_idx = self.parser.stable.core_reduces(goto_st_idx).last().unwrap();
                     let sym_off = self.parser.grm.prod(p_idx).len();
-                    let nt_idx = self.parser.grm.prod_to_nonterm(p_idx);
+                    let nt_idx = self.parser.grm.prod_to_rule(p_idx);
                     // Technically we should push goto_st_idx, and then pop sym_off elements, but
                     // we can avoid the push in cases where sym_off is greater than 0, compensating
                     // for that by poping (sym_off - 1) elements.
@@ -758,7 +758,7 @@ where usize: AsPrimitive<StorageT>
                 if usize::from(sym_off) < prod.len() {
                     continue;
                 }
-                let nt_idx = grm.prod_to_nonterm(p_idx);
+                let nt_idx = grm.prod_to_rule(p_idx);
 
                 // We've found an item in a core state where the dot is at the end of the rule:
                 // what we now do is reach backwards in the stategraph to find all of the

--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -827,14 +827,14 @@ mod test {
                             if j > 0 {
                                 s.push_str(" ");
                             }
-                            s.push_str(&format!("\"{}\"", grm.term_name(*t_idx).unwrap()));
+                            s.push_str(&format!("\"{}\"", grm.token_name(*t_idx).unwrap()));
                         }
                     }
                     s.push_str("}");
                     out.push(s);
                 },
                 ParseRepair::Insert(term_idx) =>
-                    out.push(format!("Insert \"{}\"", grm.term_name(term_idx).unwrap())),
+                    out.push(format!("Insert \"{}\"", grm.token_name(term_idx).unwrap())),
                 ParseRepair::Delete =>
                     out.push(format!("Delete")),
                 ParseRepair::Shift =>

--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -864,7 +864,7 @@ A: '(' A ')'
         assert_eq!(d.dist(s0, grm.term_idx("b").unwrap()), 0);
         assert_eq!(d.dist(s0, grm.eof_term_idx()), 1);
 
-        let s1 = sgraph.edge(s0, Symbol::Nonterm(grm.nonterm_idx("A").unwrap())).unwrap();
+        let s1 = sgraph.edge(s0, Symbol::Nonterm(grm.rule_idx("A").unwrap())).unwrap();
         assert_eq!(d.dist(s1, grm.term_idx("(").unwrap()), u16::max_value());
         assert_eq!(d.dist(s1, grm.term_idx(")").unwrap()), u16::max_value());
         assert_eq!(d.dist(s1, grm.term_idx("a").unwrap()), u16::max_value());
@@ -892,7 +892,7 @@ A: '(' A ')'
         assert_eq!(d.dist(s5, grm.term_idx("b").unwrap()), 0);
         assert_eq!(d.dist(s5, grm.eof_term_idx()), 1);
 
-        let s6 = sgraph.edge(s5, Symbol::Nonterm(grm.nonterm_idx("A").unwrap())).unwrap();
+        let s6 = sgraph.edge(s5, Symbol::Nonterm(grm.rule_idx("A").unwrap())).unwrap();
         assert_eq!(d.dist(s6, grm.term_idx("(").unwrap()), u16::max_value());
         assert_eq!(d.dist(s6, grm.term_idx(")").unwrap()), 0);
         assert_eq!(d.dist(s6, grm.term_idx("a").unwrap()), u16::max_value());
@@ -928,12 +928,12 @@ U: 'B';
         assert_eq!(d.dist(s0, grm.term_idx("B").unwrap()), 1);
         assert_eq!(d.dist(s0, grm.term_idx("C").unwrap()), 2);
 
-        let s1 = sgraph.edge(s0, Symbol::Nonterm(grm.nonterm_idx("T").unwrap())).unwrap();
+        let s1 = sgraph.edge(s0, Symbol::Nonterm(grm.rule_idx("T").unwrap())).unwrap();
         assert_eq!(d.dist(s1, grm.term_idx("A").unwrap()), u16::max_value());
         assert_eq!(d.dist(s1, grm.term_idx("B").unwrap()), 0);
         assert_eq!(d.dist(s1, grm.term_idx("C").unwrap()), 1);
 
-        let s2 = sgraph.edge(s0, Symbol::Nonterm(grm.nonterm_idx("S").unwrap())).unwrap();
+        let s2 = sgraph.edge(s0, Symbol::Nonterm(grm.rule_idx("S").unwrap())).unwrap();
         assert_eq!(d.dist(s2, grm.term_idx("A").unwrap()), u16::max_value());
         assert_eq!(d.dist(s2, grm.term_idx("B").unwrap()), u16::max_value());
         assert_eq!(d.dist(s2, grm.term_idx("C").unwrap()), u16::max_value());
@@ -943,7 +943,7 @@ U: 'B';
         assert_eq!(d.dist(s3, grm.term_idx("B").unwrap()), 0);
         assert_eq!(d.dist(s3, grm.term_idx("C").unwrap()), 1);
 
-        let s4 = sgraph.edge(s1, Symbol::Nonterm(grm.nonterm_idx("U").unwrap())).unwrap();
+        let s4 = sgraph.edge(s1, Symbol::Nonterm(grm.rule_idx("U").unwrap())).unwrap();
         assert_eq!(d.dist(s4, grm.term_idx("A").unwrap()), u16::max_value());
         assert_eq!(d.dist(s4, grm.term_idx("B").unwrap()), u16::max_value());
         assert_eq!(d.dist(s4, grm.term_idx("C").unwrap()), 0);
@@ -994,7 +994,7 @@ Factor: '(' Expr ')'
         assert_eq!(d.dist(s1, grm.term_idx(")").unwrap()), 1);
         assert_eq!(d.dist(s1, grm.term_idx("INT").unwrap()), 0);
 
-        let s2 = sgraph.edge(s0, Symbol::Nonterm(grm.nonterm_idx("Factor").unwrap())).unwrap();
+        let s2 = sgraph.edge(s0, Symbol::Nonterm(grm.rule_idx("Factor").unwrap())).unwrap();
         assert_eq!(d.dist(s2, grm.term_idx("+").unwrap()), 0);
         assert_eq!(d.dist(s2, grm.term_idx("*").unwrap()), 0);
         assert_eq!(d.dist(s2, grm.term_idx("(").unwrap()), 1);
@@ -1046,12 +1046,12 @@ W: 'b' ;
         assert_eq!(d.dist(s0, grm.term_idx("b").unwrap()), 1);
         assert_eq!(d.dist(s0, grm.eof_term_idx()), 0);
 
-        let s1 = sgraph.edge(s0, Symbol::Nonterm(grm.nonterm_idx("T").unwrap())).unwrap();
+        let s1 = sgraph.edge(s0, Symbol::Nonterm(grm.rule_idx("T").unwrap())).unwrap();
         assert_eq!(d.dist(s1, grm.term_idx("a").unwrap()), 0);
         assert_eq!(d.dist(s1, grm.term_idx("b").unwrap()), 1);
         assert_eq!(d.dist(s1, grm.eof_term_idx()), 0);
 
-        let s2 = sgraph.edge(s0, Symbol::Nonterm(grm.nonterm_idx("S").unwrap())).unwrap();
+        let s2 = sgraph.edge(s0, Symbol::Nonterm(grm.rule_idx("S").unwrap())).unwrap();
         assert_eq!(d.dist(s2, grm.term_idx("a").unwrap()), u16::max_value());
         assert_eq!(d.dist(s2, grm.term_idx("b").unwrap()), u16::max_value());
         assert_eq!(d.dist(s2, grm.eof_term_idx()), 0);
@@ -1061,12 +1061,12 @@ W: 'b' ;
         assert_eq!(d.dist(s3, grm.term_idx("b").unwrap()), 0);
         assert_eq!(d.dist(s3, grm.eof_term_idx()), 1);
 
-        let s4 = sgraph.edge(s1, Symbol::Nonterm(grm.nonterm_idx("U").unwrap())).unwrap();
+        let s4 = sgraph.edge(s1, Symbol::Nonterm(grm.rule_idx("U").unwrap())).unwrap();
         assert_eq!(d.dist(s4, grm.term_idx("a").unwrap()), 0);
         assert_eq!(d.dist(s4, grm.term_idx("b").unwrap()), 1);
         assert_eq!(d.dist(s4, grm.eof_term_idx()), 0);
 
-        let s5 = sgraph.edge(s1, Symbol::Nonterm(grm.nonterm_idx("V").unwrap())).unwrap();
+        let s5 = sgraph.edge(s1, Symbol::Nonterm(grm.rule_idx("V").unwrap())).unwrap();
         assert_eq!(d.dist(s5, grm.term_idx("a").unwrap()), 1);
         assert_eq!(d.dist(s5, grm.term_idx("b").unwrap()), 0);
         assert_eq!(d.dist(s5, grm.eof_term_idx()), 1);
@@ -1076,7 +1076,7 @@ W: 'b' ;
         assert_eq!(d.dist(s6, grm.term_idx("b").unwrap()), 1);
         assert_eq!(d.dist(s6, grm.eof_term_idx()), 0);
 
-        let s7 = sgraph.edge(s5, Symbol::Nonterm(grm.nonterm_idx("W").unwrap())).unwrap();
+        let s7 = sgraph.edge(s5, Symbol::Nonterm(grm.rule_idx("W").unwrap())).unwrap();
         assert_eq!(d.dist(s7, grm.term_idx("a").unwrap()), 0);
         assert_eq!(d.dist(s7, grm.term_idx("b").unwrap()), 1);
         assert_eq!(d.dist(s7, grm.eof_term_idx()), 0);

--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -264,7 +264,7 @@ where usize: AsPrimitive<StorageT>
     {
         let top_pstack = *n.pstack.val().unwrap();
         for t_idx in self.parser.stable.state_shifts(top_pstack) {
-            if t_idx == self.parser.grm.eof_term_idx() {
+            if t_idx == self.parser.grm.eof_token_idx() {
                 continue;
             }
 
@@ -662,7 +662,7 @@ where usize: AsPrimitive<StorageT>
 
         let mut table = Vec::new();
         table.resize(states_len * tokens_len, u16::max_value());
-        table[usize::from(stable.final_state) * tokens_len + usize::from(grm.eof_term_idx())] = 0;
+        table[usize::from(stable.final_state) * tokens_len + usize::from(grm.eof_token_idx())] = 0;
         loop {
             let mut chgd = false;
             for st_idx in sgraph.iter_stidxs() {
@@ -862,49 +862,49 @@ A: '(' A ')'
         assert_eq!(d.dist(s0, grm.term_idx(")").unwrap()), 1);
         assert_eq!(d.dist(s0, grm.term_idx("a").unwrap()), 0);
         assert_eq!(d.dist(s0, grm.term_idx("b").unwrap()), 0);
-        assert_eq!(d.dist(s0, grm.eof_term_idx()), 1);
+        assert_eq!(d.dist(s0, grm.eof_token_idx()), 1);
 
         let s1 = sgraph.edge(s0, Symbol::Rule(grm.rule_idx("A").unwrap())).unwrap();
         assert_eq!(d.dist(s1, grm.term_idx("(").unwrap()), u16::max_value());
         assert_eq!(d.dist(s1, grm.term_idx(")").unwrap()), u16::max_value());
         assert_eq!(d.dist(s1, grm.term_idx("a").unwrap()), u16::max_value());
         assert_eq!(d.dist(s1, grm.term_idx("b").unwrap()), u16::max_value());
-        assert_eq!(d.dist(s1, grm.eof_term_idx()), 0);
+        assert_eq!(d.dist(s1, grm.eof_token_idx()), 0);
 
         let s2 = sgraph.edge(s0, Symbol::Term(grm.term_idx("a").unwrap())).unwrap();
         assert_eq!(d.dist(s2, grm.term_idx("(").unwrap()), u16::max_value());
         assert_eq!(d.dist(s2, grm.term_idx(")").unwrap()), 0);
         assert_eq!(d.dist(s2, grm.term_idx("a").unwrap()), u16::max_value());
         assert_eq!(d.dist(s2, grm.term_idx("b").unwrap()), u16::max_value());
-        assert_eq!(d.dist(s2, grm.eof_term_idx()), 0);
+        assert_eq!(d.dist(s2, grm.eof_token_idx()), 0);
 
         let s3 = sgraph.edge(s0, Symbol::Term(grm.term_idx("b").unwrap())).unwrap();
         assert_eq!(d.dist(s3, grm.term_idx("(").unwrap()), u16::max_value());
         assert_eq!(d.dist(s3, grm.term_idx(")").unwrap()), 0);
         assert_eq!(d.dist(s3, grm.term_idx("a").unwrap()), u16::max_value());
         assert_eq!(d.dist(s3, grm.term_idx("b").unwrap()), u16::max_value());
-        assert_eq!(d.dist(s3, grm.eof_term_idx()), 0);
+        assert_eq!(d.dist(s3, grm.eof_token_idx()), 0);
 
         let s5 = sgraph.edge(s0, Symbol::Term(grm.term_idx("(").unwrap())).unwrap();
         assert_eq!(d.dist(s5, grm.term_idx("(").unwrap()), 0);
         assert_eq!(d.dist(s5, grm.term_idx(")").unwrap()), 1);
         assert_eq!(d.dist(s5, grm.term_idx("a").unwrap()), 0);
         assert_eq!(d.dist(s5, grm.term_idx("b").unwrap()), 0);
-        assert_eq!(d.dist(s5, grm.eof_term_idx()), 1);
+        assert_eq!(d.dist(s5, grm.eof_token_idx()), 1);
 
         let s6 = sgraph.edge(s5, Symbol::Rule(grm.rule_idx("A").unwrap())).unwrap();
         assert_eq!(d.dist(s6, grm.term_idx("(").unwrap()), u16::max_value());
         assert_eq!(d.dist(s6, grm.term_idx(")").unwrap()), 0);
         assert_eq!(d.dist(s6, grm.term_idx("a").unwrap()), u16::max_value());
         assert_eq!(d.dist(s6, grm.term_idx("b").unwrap()), u16::max_value());
-        assert_eq!(d.dist(s6, grm.eof_term_idx()), 1);
+        assert_eq!(d.dist(s6, grm.eof_token_idx()), 1);
 
         let s4 = sgraph.edge(s6, Symbol::Term(grm.term_idx(")").unwrap())).unwrap();
         assert_eq!(d.dist(s4, grm.term_idx("(").unwrap()), u16::max_value());
         assert_eq!(d.dist(s4, grm.term_idx(")").unwrap()), 0);
         assert_eq!(d.dist(s4, grm.term_idx("a").unwrap()), u16::max_value());
         assert_eq!(d.dist(s4, grm.term_idx("b").unwrap()), u16::max_value());
-        assert_eq!(d.dist(s4, grm.eof_term_idx()), 0);
+        assert_eq!(d.dist(s4, grm.eof_token_idx()), 0);
     }
 
     #[test]
@@ -1044,42 +1044,42 @@ W: 'b' ;
         let s0 = StIdx::from(0u32);
         assert_eq!(d.dist(s0, grm.term_idx("a").unwrap()), 0);
         assert_eq!(d.dist(s0, grm.term_idx("b").unwrap()), 1);
-        assert_eq!(d.dist(s0, grm.eof_term_idx()), 0);
+        assert_eq!(d.dist(s0, grm.eof_token_idx()), 0);
 
         let s1 = sgraph.edge(s0, Symbol::Rule(grm.rule_idx("T").unwrap())).unwrap();
         assert_eq!(d.dist(s1, grm.term_idx("a").unwrap()), 0);
         assert_eq!(d.dist(s1, grm.term_idx("b").unwrap()), 1);
-        assert_eq!(d.dist(s1, grm.eof_term_idx()), 0);
+        assert_eq!(d.dist(s1, grm.eof_token_idx()), 0);
 
         let s2 = sgraph.edge(s0, Symbol::Rule(grm.rule_idx("S").unwrap())).unwrap();
         assert_eq!(d.dist(s2, grm.term_idx("a").unwrap()), u16::max_value());
         assert_eq!(d.dist(s2, grm.term_idx("b").unwrap()), u16::max_value());
-        assert_eq!(d.dist(s2, grm.eof_term_idx()), 0);
+        assert_eq!(d.dist(s2, grm.eof_token_idx()), 0);
 
         let s3 = sgraph.edge(s1, Symbol::Term(grm.term_idx("a").unwrap())).unwrap();
         assert_eq!(d.dist(s3, grm.term_idx("a").unwrap()), 1);
         assert_eq!(d.dist(s3, grm.term_idx("b").unwrap()), 0);
-        assert_eq!(d.dist(s3, grm.eof_term_idx()), 1);
+        assert_eq!(d.dist(s3, grm.eof_token_idx()), 1);
 
         let s4 = sgraph.edge(s1, Symbol::Rule(grm.rule_idx("U").unwrap())).unwrap();
         assert_eq!(d.dist(s4, grm.term_idx("a").unwrap()), 0);
         assert_eq!(d.dist(s4, grm.term_idx("b").unwrap()), 1);
-        assert_eq!(d.dist(s4, grm.eof_term_idx()), 0);
+        assert_eq!(d.dist(s4, grm.eof_token_idx()), 0);
 
         let s5 = sgraph.edge(s1, Symbol::Rule(grm.rule_idx("V").unwrap())).unwrap();
         assert_eq!(d.dist(s5, grm.term_idx("a").unwrap()), 1);
         assert_eq!(d.dist(s5, grm.term_idx("b").unwrap()), 0);
-        assert_eq!(d.dist(s5, grm.eof_term_idx()), 1);
+        assert_eq!(d.dist(s5, grm.eof_token_idx()), 1);
 
         let s6 = sgraph.edge(s5, Symbol::Term(grm.term_idx("b").unwrap())).unwrap();
         assert_eq!(d.dist(s6, grm.term_idx("a").unwrap()), 0);
         assert_eq!(d.dist(s6, grm.term_idx("b").unwrap()), 1);
-        assert_eq!(d.dist(s6, grm.eof_term_idx()), 0);
+        assert_eq!(d.dist(s6, grm.eof_token_idx()), 0);
 
         let s7 = sgraph.edge(s5, Symbol::Rule(grm.rule_idx("W").unwrap())).unwrap();
         assert_eq!(d.dist(s7, grm.term_idx("a").unwrap()), 0);
         assert_eq!(d.dist(s7, grm.term_idx("b").unwrap()), 1);
-        assert_eq!(d.dist(s7, grm.eof_term_idx()), 0);
+        assert_eq!(d.dist(s7, grm.eof_token_idx()), 0);
     }
 
     #[bench]
@@ -1263,7 +1263,7 @@ E: '(' E ')'
             panic!("Can't find a match for {}", pp);
         }
         assert_eq!(errs.len(), 1);
-        let err_tok_id = u32::from(grm.eof_term_idx()).to_u16().unwrap();
+        let err_tok_id = u32::from(grm.eof_token_idx()).to_u16().unwrap();
         assert_eq!(errs[0].lexeme(), &Lexeme::new(err_tok_id, 2, 0));
         check_all_repairs(&grm,
                           errs[0].repairs(),

--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -1214,8 +1214,8 @@ E : 'N'
 
     fn kimyi_lex_grm() -> (&'static str, &'static str) {
         // The example from the KimYi paper, with a bit of alpha-renaming to make it clearer. The
-        // paper uses "A" as a nonterminal name and "a" as a terminal name, which are then easily
-        // confused. Here we use "E" as the nonterminal name, and keep "a" as the terminal name.
+        // paper uses "A" as a rule name and "a" as a terminal name, which are then easily
+        // confused. Here we use "E" as the rule name, and keep "a" as the terminal name.
         let lexs = "%%
 \\( '('
 \\) ')'

--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -52,7 +52,7 @@ const TRY_PARSE_AT_MOST: usize = 250;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 enum Repair<StorageT> {
-    /// Insert a `Symbol::Term` with idx `token_idx`.
+    /// Insert a `Symbol::Token` with idx `token_idx`.
     InsertTerm(TIdx<StorageT>),
     /// Delete a symbol.
     Delete,
@@ -670,7 +670,7 @@ where usize: AsPrimitive<StorageT>
                 for (&sym, &sym_st_idx) in sgraph.edges(st_idx).iter() {
                     let d = match sym {
                         Symbol::Rule(nt_idx) => sengen.min_sentence_cost(nt_idx),
-                        Symbol::Term(t_idx) => {
+                        Symbol::Token(t_idx) => {
                             let off = usize::from(st_idx) * tokens_len + usize::from(t_idx);
                             if table[off] != 0 {
                                 table[off] = 0;
@@ -871,21 +871,21 @@ A: '(' A ')'
         assert_eq!(d.dist(s1, grm.token_idx("b").unwrap()), u16::max_value());
         assert_eq!(d.dist(s1, grm.eof_token_idx()), 0);
 
-        let s2 = sgraph.edge(s0, Symbol::Term(grm.token_idx("a").unwrap())).unwrap();
+        let s2 = sgraph.edge(s0, Symbol::Token(grm.token_idx("a").unwrap())).unwrap();
         assert_eq!(d.dist(s2, grm.token_idx("(").unwrap()), u16::max_value());
         assert_eq!(d.dist(s2, grm.token_idx(")").unwrap()), 0);
         assert_eq!(d.dist(s2, grm.token_idx("a").unwrap()), u16::max_value());
         assert_eq!(d.dist(s2, grm.token_idx("b").unwrap()), u16::max_value());
         assert_eq!(d.dist(s2, grm.eof_token_idx()), 0);
 
-        let s3 = sgraph.edge(s0, Symbol::Term(grm.token_idx("b").unwrap())).unwrap();
+        let s3 = sgraph.edge(s0, Symbol::Token(grm.token_idx("b").unwrap())).unwrap();
         assert_eq!(d.dist(s3, grm.token_idx("(").unwrap()), u16::max_value());
         assert_eq!(d.dist(s3, grm.token_idx(")").unwrap()), 0);
         assert_eq!(d.dist(s3, grm.token_idx("a").unwrap()), u16::max_value());
         assert_eq!(d.dist(s3, grm.token_idx("b").unwrap()), u16::max_value());
         assert_eq!(d.dist(s3, grm.eof_token_idx()), 0);
 
-        let s5 = sgraph.edge(s0, Symbol::Term(grm.token_idx("(").unwrap())).unwrap();
+        let s5 = sgraph.edge(s0, Symbol::Token(grm.token_idx("(").unwrap())).unwrap();
         assert_eq!(d.dist(s5, grm.token_idx("(").unwrap()), 0);
         assert_eq!(d.dist(s5, grm.token_idx(")").unwrap()), 1);
         assert_eq!(d.dist(s5, grm.token_idx("a").unwrap()), 0);
@@ -899,7 +899,7 @@ A: '(' A ')'
         assert_eq!(d.dist(s6, grm.token_idx("b").unwrap()), u16::max_value());
         assert_eq!(d.dist(s6, grm.eof_token_idx()), 1);
 
-        let s4 = sgraph.edge(s6, Symbol::Term(grm.token_idx(")").unwrap())).unwrap();
+        let s4 = sgraph.edge(s6, Symbol::Token(grm.token_idx(")").unwrap())).unwrap();
         assert_eq!(d.dist(s4, grm.token_idx("(").unwrap()), u16::max_value());
         assert_eq!(d.dist(s4, grm.token_idx(")").unwrap()), 0);
         assert_eq!(d.dist(s4, grm.token_idx("a").unwrap()), u16::max_value());
@@ -938,7 +938,7 @@ U: 'B';
         assert_eq!(d.dist(s2, grm.token_idx("B").unwrap()), u16::max_value());
         assert_eq!(d.dist(s2, grm.token_idx("C").unwrap()), u16::max_value());
 
-        let s3 = sgraph.edge(s0, Symbol::Term(grm.token_idx("A").unwrap())).unwrap();
+        let s3 = sgraph.edge(s0, Symbol::Token(grm.token_idx("A").unwrap())).unwrap();
         assert_eq!(d.dist(s3, grm.token_idx("A").unwrap()), u16::max_value());
         assert_eq!(d.dist(s3, grm.token_idx("B").unwrap()), 0);
         assert_eq!(d.dist(s3, grm.token_idx("C").unwrap()), 1);
@@ -948,12 +948,12 @@ U: 'B';
         assert_eq!(d.dist(s4, grm.token_idx("B").unwrap()), u16::max_value());
         assert_eq!(d.dist(s4, grm.token_idx("C").unwrap()), 0);
 
-        let s5 = sgraph.edge(s1, Symbol::Term(grm.token_idx("B").unwrap())).unwrap();
+        let s5 = sgraph.edge(s1, Symbol::Token(grm.token_idx("B").unwrap())).unwrap();
         assert_eq!(d.dist(s5, grm.token_idx("A").unwrap()), u16::max_value());
         assert_eq!(d.dist(s5, grm.token_idx("B").unwrap()), u16::max_value());
         assert_eq!(d.dist(s5, grm.token_idx("C").unwrap()), 0);
 
-        let s6 = sgraph.edge(s4, Symbol::Term(grm.token_idx("C").unwrap())).unwrap();
+        let s6 = sgraph.edge(s4, Symbol::Token(grm.token_idx("C").unwrap())).unwrap();
         assert_eq!(d.dist(s6, grm.token_idx("A").unwrap()), u16::max_value());
         assert_eq!(d.dist(s6, grm.token_idx("B").unwrap()), u16::max_value());
         assert_eq!(d.dist(s6, grm.token_idx("C").unwrap()), u16::max_value());
@@ -987,7 +987,7 @@ Factor: '(' Expr ')'
         assert_eq!(d.dist(s0, grm.token_idx(")").unwrap()), 1);
         assert_eq!(d.dist(s0, grm.token_idx("INT").unwrap()), 0);
 
-        let s1 = sgraph.edge(s0, Symbol::Term(grm.token_idx("(").unwrap())).unwrap();
+        let s1 = sgraph.edge(s0, Symbol::Token(grm.token_idx("(").unwrap())).unwrap();
         assert_eq!(d.dist(s1, grm.token_idx("+").unwrap()), 1);
         assert_eq!(d.dist(s1, grm.token_idx("*").unwrap()), 1);
         assert_eq!(d.dist(s1, grm.token_idx("(").unwrap()), 0);
@@ -1001,7 +1001,7 @@ Factor: '(' Expr ')'
         assert_eq!(d.dist(s2, grm.token_idx(")").unwrap()), 0);
         assert_eq!(d.dist(s2, grm.token_idx("INT").unwrap()), 1);
 
-        let s3 = sgraph.edge(s0, Symbol::Term(grm.token_idx("INT").unwrap())).unwrap();
+        let s3 = sgraph.edge(s0, Symbol::Token(grm.token_idx("INT").unwrap())).unwrap();
         assert_eq!(d.dist(s3, grm.token_idx("+").unwrap()), 0);
         assert_eq!(d.dist(s3, grm.token_idx("*").unwrap()), 0);
         assert_eq!(d.dist(s3, grm.token_idx("(").unwrap()), 1);
@@ -1056,7 +1056,7 @@ W: 'b' ;
         assert_eq!(d.dist(s2, grm.token_idx("b").unwrap()), u16::max_value());
         assert_eq!(d.dist(s2, grm.eof_token_idx()), 0);
 
-        let s3 = sgraph.edge(s1, Symbol::Term(grm.token_idx("a").unwrap())).unwrap();
+        let s3 = sgraph.edge(s1, Symbol::Token(grm.token_idx("a").unwrap())).unwrap();
         assert_eq!(d.dist(s3, grm.token_idx("a").unwrap()), 1);
         assert_eq!(d.dist(s3, grm.token_idx("b").unwrap()), 0);
         assert_eq!(d.dist(s3, grm.eof_token_idx()), 1);
@@ -1071,7 +1071,7 @@ W: 'b' ;
         assert_eq!(d.dist(s5, grm.token_idx("b").unwrap()), 0);
         assert_eq!(d.dist(s5, grm.eof_token_idx()), 1);
 
-        let s6 = sgraph.edge(s5, Symbol::Term(grm.token_idx("b").unwrap())).unwrap();
+        let s6 = sgraph.edge(s5, Symbol::Token(grm.token_idx("b").unwrap())).unwrap();
         assert_eq!(d.dist(s6, grm.token_idx("a").unwrap()), 0);
         assert_eq!(d.dist(s6, grm.token_idx("b").unwrap()), 1);
         assert_eq!(d.dist(s6, grm.eof_token_idx()), 0);

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -64,4 +64,4 @@ macro_rules! lrpar_mod {
 }
 
 #[doc(hidden)]
-pub use cfgrammar::NTIdx;
+pub use cfgrammar::RIdx;

--- a/lrpar/src/lib/panic.rs
+++ b/lrpar/src/lib/panic.rs
@@ -55,7 +55,7 @@ where usize: AsPrimitive<StorageT>
     fn recover(&self,
                finish_by: Instant,
                parser: &Parser<StorageT>,
-               in_la_idx: usize,
+               in_laidx: usize,
                in_pstack: &mut Vec<StIdx>,
                _: &mut Vec<Node<StorageT>>)
            -> (usize, Vec<Vec<ParseRepair<StorageT>>>)
@@ -67,25 +67,25 @@ where usize: AsPrimitive<StorageT>
         // is no way the user can adjust their input to get the parser into the same state as the
         // recovery algorithm manages).
         let iter_pstack = in_pstack.clone();
-        for la_idx in in_la_idx..parser.lexemes.len() {
+        for laidx in in_laidx..parser.lexemes.len() {
             if Instant::now() >= finish_by {
                 break;
             }
             for (st_i, st) in iter_pstack.iter().enumerate().rev().skip(1) {
-                if parser.stable.action(*st, parser.next_tidx(la_idx)).is_some() {
-                    let mut rprs = Vec::with_capacity(la_idx - in_la_idx);
+                if parser.stable.action(*st, parser.next_tidx(laidx)).is_some() {
+                    let mut rprs = Vec::with_capacity(laidx - in_laidx);
                     // It's often possible that we found a state that will accept the lexeme at
-                    // in_la_idx, at which point there are no repairs the user can make which will
+                    // in_laidx, at which point there are no repairs the user can make which will
                     // emulate this panic mode (i.e. the list of actions they are advised to take
                     // will be empty). There isn't much we can do about this.
-                    for _ in in_la_idx..la_idx {
+                    for _ in in_laidx..laidx {
                         rprs.push(ParseRepair::Delete);
                     }
                     in_pstack.drain(st_i + 1..);
-                    return (la_idx, vec![rprs]);
+                    return (laidx, vec![rprs]);
                 }
             }
         }
-        return (in_la_idx, vec![]);
+        return (in_laidx, vec![]);
     }
 }

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -278,7 +278,7 @@ where usize: AsPrimitive<StorageT>
     }
 
     /// Return a `Lexeme` for the next lemexe (if `la_idx` == `self.lexemes.len()` this will be
-    /// a lexeme constructed to look as if contains the EOF terminal).
+    /// a lexeme constructed to look as if contains the EOF token).
     pub(crate) fn next_lexeme(&self, la_idx: usize) -> Lexeme<StorageT>
     {
         let llen = self.lexemes.len();

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -520,7 +520,7 @@ pub(crate) mod test {
         }
         let lexemes = lexerdef.lexer(&input).lexemes().unwrap();
         let costs_tidx = costs.iter()
-                              .map(|(k, v)| (grm.term_idx(k).unwrap(), v))
+                              .map(|(k, v)| (grm.token_idx(k).unwrap(), v))
                               .collect::<HashMap<_, _>>();
         let pr = parse_rcvry(rcvry_kind,
                              &grm,
@@ -654,7 +654,7 @@ Call: 'ID' '(' ')';";
         let (grm, pr) = do_parse(RecoveryKind::MF, &lexs, &grms, "f(f(");
         let (_, errs) = pr.unwrap_err();
         assert_eq!(errs.len(), 1);
-        let err_tok_id = usize::from(grm.term_idx("ID").unwrap()).to_u16().unwrap();
+        let err_tok_id = usize::from(grm.token_idx("ID").unwrap()).to_u16().unwrap();
         assert_eq!(errs[0].lexeme(), &Lexeme::new(err_tok_id, 2, 1));
      }
 }

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -429,9 +429,9 @@ pub fn parse_rcvry
 /// in the sequence of repairs is represented by a `ParseRepair`.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum ParseRepair<StorageT> {
-    /// Insert a `Symbol::Term`.
+    /// Insert a `Symbol::Token`.
     Insert(TIdx<StorageT>),
-    /// Insert one of the sequences of `Symbol::Term`s.
+    /// Insert one of the sequences of `Symbol::Token`s.
     InsertSeq(Vec<Vec<TIdx<StorageT>>>),
     /// Delete a symbol.
     Delete,

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -173,7 +173,7 @@ where usize: AsPrimitive<StorageT>
                     la_idx += 1;
                 },
                 Some(Action::Accept) => {
-                    debug_assert_eq!(la_tidx, self.grm.eof_term_idx());
+                    debug_assert_eq!(la_tidx, self.grm.eof_token_idx());
                     debug_assert_eq!(tstack.len(), 1);
                     return true;
                 },
@@ -295,7 +295,7 @@ where usize: AsPrimitive<StorageT>
                     last_la.start() + last_la.len()
                 };
 
-            Lexeme::new(StorageT::from(u32::from(self.grm.eof_term_idx())).unwrap(), last_la_end, 0)
+            Lexeme::new(StorageT::from(u32::from(self.grm.eof_token_idx())).unwrap(), last_la_end, 0)
         }
     }
 
@@ -307,7 +307,7 @@ where usize: AsPrimitive<StorageT>
         if la_idx < ll {
             TIdx(self.lexemes[la_idx].tok_id())
         } else {
-            self.grm.eof_term_idx()
+            self.grm.eof_token_idx()
         }
     }
 
@@ -364,7 +364,7 @@ where usize: AsPrimitive<StorageT>
                     la_idx += 1;
                 },
                 Some(Action::Accept) => {
-                    debug_assert_eq!(la_tidx, self.grm.eof_term_idx());
+                    debug_assert_eq!(la_tidx, self.grm.eof_token_idx());
                     if let Some(ref mut tstack_uw) = *tstack {
                         debug_assert_eq!(tstack_uw.len(), 1);
                     }
@@ -648,7 +648,7 @@ Call: 'ID' '(' ')';";
         let (grm, pr) = do_parse(RecoveryKind::MF, &lexs, &grms, "f(");
         let (_, errs) = pr.unwrap_err();
         assert_eq!(errs.len(), 1);
-        let err_tok_id = usize::from(grm.eof_term_idx()).to_u16().unwrap();
+        let err_tok_id = usize::from(grm.eof_token_idx()).to_u16().unwrap();
         assert_eq!(errs[0].lexeme(), &Lexeme::new(err_tok_id, 2, 0));
 
         let (grm, pr) = do_parse(RecoveryKind::MF, &lexs, &grms, "f(f(");

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -36,7 +36,7 @@ use std::hash::Hash;
 use std::time::{Duration, Instant};
 
 use cactus::Cactus;
-use cfgrammar::{Grammar, NTIdx, TIdx};
+use cfgrammar::{Grammar, RIdx, TIdx};
 use cfgrammar::yacc::YaccGrammar;
 use lrlex::Lexeme;
 use lrtable::{Action, StateGraph, StateTable, StIdx};
@@ -51,7 +51,7 @@ const RECOVERY_TIME_BUDGET: u64 = 500; // milliseconds
 #[derive(Debug, Clone, PartialEq)]
 pub enum Node<StorageT> {
     Term{lexeme: Lexeme<StorageT>},
-    Nonterm{nonterm_idx: NTIdx<StorageT>, nodes: Vec<Node<StorageT>>}
+    Nonterm{nonterm_idx: RIdx<StorageT>, nodes: Vec<Node<StorageT>>}
 }
 
 impl<StorageT: 'static + PrimInt + Unsigned> Node<StorageT>

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -74,7 +74,7 @@ where usize: AsPrimitive<StorageT>
                     s.push_str(&format!("{} {}\n", tn, lt));
                 }
                 Node::Nonterm{nonterm_idx, ref nodes} => {
-                    s.push_str(&format!("{}\n", grm.nonterm_name(nonterm_idx)));
+                    s.push_str(&format!("{}\n", grm.rule_name(nonterm_idx)));
                     for x in nodes.iter().rev() {
                         st.push((indent + 1, x));
                     }

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -69,7 +69,7 @@ where usize: AsPrimitive<StorageT>
             match *e {
                 Node::Term{lexeme} => {
                     let t_idx = TIdx(lexeme.tok_id());
-                    let tn = grm.term_name(t_idx).unwrap();
+                    let tn = grm.token_name(t_idx).unwrap();
                     let lt = &input[lexeme.start()..lexeme.start() + lexeme.len()];
                     s.push_str(&format!("{} {}\n", tn, lt));
                 }

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -93,7 +93,7 @@ pub(crate) type Errors<StorageT> = Vec<ParseError<StorageT>>;
 pub struct Parser<'a, StorageT: 'a + Eq + Hash> {
     pub rcvry_kind: RecoveryKind,
     pub grm: &'a YaccGrammar<StorageT>,
-    pub term_cost: &'a Fn(TIdx<StorageT>) -> u8,
+    pub token_cost: &'a Fn(TIdx<StorageT>) -> u8,
     pub sgraph: &'a StateGraph<StorageT>,
     pub stable: &'a StateTable<StorageT>,
     pub lexemes: &'a [Lexeme<StorageT>]
@@ -105,7 +105,7 @@ where usize: AsPrimitive<StorageT>
 {
     fn parse<F>(rcvry_kind: RecoveryKind,
                 grm: &YaccGrammar<StorageT>,
-                term_cost: F,
+                token_cost: F,
                 sgraph: &StateGraph<StorageT>,
                 stable: &StateTable<StorageT>,
                 lexemes: &[Lexeme<StorageT>])
@@ -114,9 +114,9 @@ where usize: AsPrimitive<StorageT>
           where F: Fn(TIdx<StorageT>) -> u8
     {
         for tidx in grm.iter_tidxs() {
-            assert!(term_cost(tidx) > 0);
+            assert!(token_cost(tidx) > 0);
         }
-        let psr = Parser{rcvry_kind, grm, term_cost: &term_cost, sgraph, stable, lexemes};
+        let psr = Parser{rcvry_kind, grm, token_cost: &token_cost, sgraph, stable, lexemes};
         let mut pstack = vec![StIdx::from(0u32)];
         let mut tstack: Vec<Node<StorageT>> = Vec::new();
         let mut errors: Vec<ParseError<StorageT>> = Vec::new();
@@ -414,7 +414,7 @@ pub fn parse_rcvry
        <StorageT: 'static + Debug + Hash + PrimInt + Unsigned, F>
        (rcvry_kind: RecoveryKind,
         grm: &YaccGrammar<StorageT>,
-        term_cost: F,
+        token_cost: F,
         sgraph: &StateGraph<StorageT>,
         stable: &StateTable<StorageT>,
         lexemes: &[Lexeme<StorageT>])
@@ -422,7 +422,7 @@ pub fn parse_rcvry
     where F: Fn(TIdx<StorageT>) -> u8,
           usize: AsPrimitive<StorageT>
 {
-    Parser::parse(rcvry_kind, grm, term_cost, sgraph, stable, lexemes)
+    Parser::parse(rcvry_kind, grm, token_cost, sgraph, stable, lexemes)
 }
 
 /// After a parse error is encountered, the parser attempts to find a way of recovering. Each entry

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -513,7 +513,7 @@ pub(crate) mod test {
         let grm = YaccGrammar::<u16>::new_with_storaget(YaccKind::Original, grms).unwrap();
         let (sgraph, stable) = from_yacc(&grm, Minimiser::Pager).unwrap();
         {
-            let rule_ids = grm.terms_map().iter()
+            let rule_ids = grm.tokens_map().iter()
                                           .map(|(&n, &i)| (n, u32::from(i).to_u16().unwrap()))
                                           .collect();
             lexerdef.set_rule_ids(&rule_ids);

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -157,7 +157,7 @@ where usize: AsPrimitive<StorageT>
 
             match self.stable.action(st, la_tidx) {
                 Some(Action::Reduce(prod_id)) => {
-                    let nonterm_idx = self.grm.prod_to_nonterm(prod_id);
+                    let nonterm_idx = self.grm.prod_to_rule(prod_id);
                     let pop_idx = pstack.len() - self.grm.prod(prod_id).len();
                     let nodes = tstack.drain(pop_idx - 1..).collect::<Vec<Node<StorageT>>>();
                     tstack.push(Node::Nonterm{nonterm_idx, nodes});
@@ -243,7 +243,7 @@ where usize: AsPrimitive<StorageT>
 
             match self.stable.action(st, la_tidx) {
                 Some(Action::Reduce(prod_id)) => {
-                    let nonterm_idx = self.grm.prod_to_nonterm(prod_id);
+                    let nonterm_idx = self.grm.prod_to_rule(prod_id);
                     let pop_idx = pstack.len() - self.grm.prod(prod_id).len();
                     if let Some(ref mut tstack_uw) = *tstack {
                         let nodes = tstack_uw.drain(pop_idx - 1..).collect::<Vec<Node<StorageT>>>();
@@ -337,7 +337,7 @@ where usize: AsPrimitive<StorageT>
 
             match self.stable.action(st, la_tidx) {
                 Some(Action::Reduce(prod_id)) => {
-                    let nonterm_idx = self.grm.prod_to_nonterm(prod_id);
+                    let nonterm_idx = self.grm.prod_to_rule(prod_id);
                     let pop_num = self.grm.prod(prod_id).len();
                     if let Some(ref mut tstack_uw) = *tstack {
                         let nodes = tstack_uw.drain(pstack.len() - pop_num - 1..)

--- a/lrpar/src/main.rs
+++ b/lrpar/src/main.rs
@@ -181,7 +181,7 @@ fn main() {
     let input = read_file(&matches.free[2]);
     let lexer = lexerdef.lexer(&input);
     let lexemes = lexer.lexemes().unwrap();
-    let term_cost = |_| 1; // Cost of inserting/deleting a terminal
+    let term_cost = |_| 1; // Cost of inserting/deleting a token
     match parse_rcvry::<u16, _>(recoverykind, &grm, &term_cost, &sgraph, &stable, &lexemes) {
         Ok(pt) => println!("{}", pt.pp(&grm, &input)),
         Err((o_pt, errs)) => {

--- a/lrpar/src/main.rs
+++ b/lrpar/src/main.rs
@@ -212,14 +212,14 @@ fn main() {
                                         if j > 0 {
                                             s.push_str(" ");
                                         }
-                                        s.push_str(grm.term_name(*t_idx).unwrap());
+                                        s.push_str(grm.token_name(*t_idx).unwrap());
                                     }
                                 }
                                 s.push_str("}");
                                 out.push(s);
                             },
                             ParseRepair::Insert(term_idx) =>
-                                out.push(format!("Insert \"{}\"", grm.term_name(term_idx).unwrap())),
+                                out.push(format!("Insert \"{}\"", grm.token_name(term_idx).unwrap())),
                             ParseRepair::Delete | ParseRepair::Shift => {
                                 let l = lexemes[lex_idx];
                                 let t = &input[l.start()..l.start() + l.len()].replace("\n", "\\n");

--- a/lrpar/src/main.rs
+++ b/lrpar/src/main.rs
@@ -151,7 +151,7 @@ fn main() {
     };
 
     {
-        let rule_ids = grm.terms_map().iter()
+        let rule_ids = grm.tokens_map().iter()
                                       .map(|(&n, &i)| (n, usize::from(i).to_u16().unwrap()))
                                       .collect();
         let (missing_from_lexer, missing_from_parser) = lexerdef.set_rule_ids(&rule_ids);

--- a/lrpar/src/main.rs
+++ b/lrpar/src/main.rs
@@ -208,11 +208,11 @@ fn main() {
                                     if i > 0 {
                                         s.push_str(", ");
                                     }
-                                    for (j, t_idx) in seq.iter().enumerate() {
+                                    for (j, tidx) in seq.iter().enumerate() {
                                         if j > 0 {
                                             s.push_str(" ");
                                         }
-                                        s.push_str(grm.token_name(*t_idx).unwrap());
+                                        s.push_str(grm.token_name(*tidx).unwrap());
                                     }
                                 }
                                 s.push_str("}");

--- a/lrpar/src/main.rs
+++ b/lrpar/src/main.rs
@@ -218,8 +218,8 @@ fn main() {
                                 s.push_str("}");
                                 out.push(s);
                             },
-                            ParseRepair::Insert(term_idx) =>
-                                out.push(format!("Insert \"{}\"", grm.token_name(term_idx).unwrap())),
+                            ParseRepair::Insert(token_idx) =>
+                                out.push(format!("Insert \"{}\"", grm.token_name(token_idx).unwrap())),
                             ParseRepair::Delete | ParseRepair::Shift => {
                                 let l = lexemes[lex_idx];
                                 let t = &input[l.start()..l.start() + l.len()].replace("\n", "\\n");

--- a/lrpar/src/main.rs
+++ b/lrpar/src/main.rs
@@ -181,8 +181,8 @@ fn main() {
     let input = read_file(&matches.free[2]);
     let lexer = lexerdef.lexer(&input);
     let lexemes = lexer.lexemes().unwrap();
-    let term_cost = |_| 1; // Cost of inserting/deleting a token
-    match parse_rcvry::<u16, _>(recoverykind, &grm, &term_cost, &sgraph, &stable, &lexemes) {
+    let token_cost = |_| 1; // Cost of inserting/deleting a token
+    match parse_rcvry::<u16, _>(recoverykind, &grm, &token_cost, &sgraph, &stable, &lexemes) {
         Ok(pt) => println!("{}", pt.pp(&grm, &input)),
         Err((o_pt, errs)) => {
             match o_pt {

--- a/lrtable/src/lib/itemset.rs
+++ b/lrtable/src/lib/itemset.rs
@@ -136,7 +136,7 @@ where usize: AsPrimitive<StorageT>
                 let mut nullable = true;
                 for sym in prod.iter().skip(usize::from(dot) + 1) {
                     match *sym {
-                        Symbol::Term(term_j) => {
+                        Symbol::Token(term_j) => {
                             new_ctx.set(usize::from(term_j), true);
                             nullable = false;
                             break;
@@ -321,11 +321,11 @@ mod test {
         state_exists(&grm, &goto1, "S", 0, SIdx(1), vec!["$", "b"]);
 
         // follow 'b' from start set
-        let goto2 = cls_is.goto(&grm, &Symbol::Term(grm.token_idx("b").unwrap()));
+        let goto2 = cls_is.goto(&grm, &Symbol::Token(grm.token_idx("b").unwrap()));
         state_exists(&grm, &goto2, "S", 1, SIdx(1), vec!["$", "b"]);
 
         // continue by following 'a' from last goto, after it's been closed
-        let goto3 = goto2.close(&grm, &firsts).goto(&grm, &Symbol::Term(grm.token_idx("a").unwrap()));
+        let goto3 = goto2.close(&grm, &firsts).goto(&grm, &Symbol::Token(grm.token_idx("a").unwrap()));
         state_exists(&grm, &goto3, "A", 1, SIdx(1), vec!["a"]);
         state_exists(&grm, &goto3, "A", 2, SIdx(1), vec!["a"]);
     }

--- a/lrtable/src/lib/itemset.rs
+++ b/lrtable/src/lib/itemset.rs
@@ -203,7 +203,7 @@ mod test {
         let mut is = Itemset::new(&grm);
         let mut la = Vob::from_elem(usize::from(grm.terms_len()), false);
         la.set(usize::from(grm.eof_term_idx()), true);
-        is.add(grm.rule_to_prods(grm.nonterm_idx("^").unwrap())[0], SIdx(0), &la);
+        is.add(grm.rule_to_prods(grm.rule_idx("^").unwrap())[0], SIdx(0), &la);
         let cls_is = is.close(&grm, &firsts);
         println!("{:?}", cls_is);
         assert_eq!(cls_is.items.len(), 6);
@@ -237,7 +237,7 @@ mod test {
         let mut is = Itemset::new(&grm);
         let mut la = Vob::from_elem(usize::from(grm.terms_len()), false);
         la.set(usize::from(grm.eof_term_idx()), true);
-        is.add(grm.rule_to_prods(grm.nonterm_idx("^").unwrap())[0], SIdx(0), &la);
+        is.add(grm.rule_to_prods(grm.rule_idx("^").unwrap())[0], SIdx(0), &la);
         let mut cls_is = is.close(&grm, &firsts);
 
         state_exists(&grm, &cls_is, "^", 0, SIdx(0), vec!["$"]);
@@ -246,7 +246,7 @@ mod test {
         state_exists(&grm, &cls_is, "S", 2, SIdx(0), vec!["b", "$"]);
 
         is = Itemset::new(&grm);
-        is.add(grm.rule_to_prods(grm.nonterm_idx("F").unwrap())[0], SIdx(0), &la);
+        is.add(grm.rule_to_prods(grm.rule_idx("F").unwrap())[0], SIdx(0), &la);
         cls_is = is.close(&grm, &firsts);
         state_exists(&grm, &cls_is, "F", 0, SIdx(0), vec!["$"]);
         state_exists(&grm, &cls_is, "C", 0, SIdx(0), vec!["d", "f"]);
@@ -279,7 +279,7 @@ mod test {
         let mut is = Itemset::new(&grm);
         let mut la = Vob::from_elem(usize::from(grm.terms_len()), false);
         la.set(usize::from(grm.eof_term_idx()), true);
-        is.add(grm.rule_to_prods(grm.nonterm_idx("^").unwrap())[0], SIdx(0), &la);
+        is.add(grm.rule_to_prods(grm.rule_idx("^").unwrap())[0], SIdx(0), &la);
         let mut cls_is = is.close(&grm, &firsts);
 
         state_exists(&grm, &cls_is, "^", 0, SIdx(0), vec!["$"]);
@@ -290,7 +290,7 @@ mod test {
         la = Vob::from_elem(usize::from(grm.terms_len()), false);
         la.set(usize::from(grm.term_idx("b").unwrap()), true);
         la.set(usize::from(grm.eof_term_idx()), true);
-        is.add(grm.rule_to_prods(grm.nonterm_idx("S").unwrap())[1], SIdx(1), &la);
+        is.add(grm.rule_to_prods(grm.rule_idx("S").unwrap())[1], SIdx(1), &la);
         cls_is = is.close(&grm, &firsts);
         state_exists(&grm, &cls_is, "A", 0, SIdx(0), vec!["a"]);
         state_exists(&grm, &cls_is, "A", 1, SIdx(0), vec!["a"]);
@@ -299,7 +299,7 @@ mod test {
         is = Itemset::new(&grm);
         la = Vob::from_elem(usize::from(grm.terms_len()), false);
         la.set(usize::from(grm.term_idx("a").unwrap()), true);
-        is.add(grm.rule_to_prods(grm.nonterm_idx("A").unwrap())[0], SIdx(1), &la);
+        is.add(grm.rule_to_prods(grm.rule_idx("A").unwrap())[0], SIdx(1), &la);
         cls_is = is.close(&grm, &firsts);
         state_exists(&grm, &cls_is, "S", 0, SIdx(0), vec!["b", "c"]);
         state_exists(&grm, &cls_is, "S", 1, SIdx(0), vec!["b", "c"]);
@@ -313,10 +313,10 @@ mod test {
         let mut is = Itemset::new(&grm);
         let mut la = Vob::from_elem(usize::from(grm.terms_len()), false);
         la.set(usize::from(grm.eof_term_idx()), true);
-        is.add(grm.rule_to_prods(grm.nonterm_idx("^").unwrap())[0], SIdx(0), &la);
+        is.add(grm.rule_to_prods(grm.rule_idx("^").unwrap())[0], SIdx(0), &la);
         let cls_is = is.close(&grm, &firsts);
 
-        let goto1 = cls_is.goto(&grm, &Symbol::Nonterm(grm.nonterm_idx("S").unwrap()));
+        let goto1 = cls_is.goto(&grm, &Symbol::Nonterm(grm.rule_idx("S").unwrap()));
         state_exists(&grm, &goto1, "^", 0, SIdx(1), vec!["$"]);
         state_exists(&grm, &goto1, "S", 0, SIdx(1), vec!["$", "b"]);
 

--- a/lrtable/src/lib/itemset.rs
+++ b/lrtable/src/lib/itemset.rs
@@ -288,7 +288,7 @@ mod test {
 
         is = Itemset::new(&grm);
         la = Vob::from_elem(usize::from(grm.tokens_len()), false);
-        la.set(usize::from(grm.term_idx("b").unwrap()), true);
+        la.set(usize::from(grm.token_idx("b").unwrap()), true);
         la.set(usize::from(grm.eof_token_idx()), true);
         is.add(grm.rule_to_prods(grm.rule_idx("S").unwrap())[1], SIdx(1), &la);
         cls_is = is.close(&grm, &firsts);
@@ -298,7 +298,7 @@ mod test {
 
         is = Itemset::new(&grm);
         la = Vob::from_elem(usize::from(grm.tokens_len()), false);
-        la.set(usize::from(grm.term_idx("a").unwrap()), true);
+        la.set(usize::from(grm.token_idx("a").unwrap()), true);
         is.add(grm.rule_to_prods(grm.rule_idx("A").unwrap())[0], SIdx(1), &la);
         cls_is = is.close(&grm, &firsts);
         state_exists(&grm, &cls_is, "S", 0, SIdx(0), vec!["b", "c"]);
@@ -321,11 +321,11 @@ mod test {
         state_exists(&grm, &goto1, "S", 0, SIdx(1), vec!["$", "b"]);
 
         // follow 'b' from start set
-        let goto2 = cls_is.goto(&grm, &Symbol::Term(grm.term_idx("b").unwrap()));
+        let goto2 = cls_is.goto(&grm, &Symbol::Term(grm.token_idx("b").unwrap()));
         state_exists(&grm, &goto2, "S", 1, SIdx(1), vec!["$", "b"]);
 
         // continue by following 'a' from last goto, after it's been closed
-        let goto3 = goto2.close(&grm, &firsts).goto(&grm, &Symbol::Term(grm.term_idx("a").unwrap()));
+        let goto3 = goto2.close(&grm, &firsts).goto(&grm, &Symbol::Term(grm.token_idx("a").unwrap()));
         state_exists(&grm, &goto3, "A", 1, SIdx(1), vec!["a"]);
         state_exists(&grm, &goto3, "A", 2, SIdx(1), vec!["a"]);
     }

--- a/lrtable/src/lib/itemset.rs
+++ b/lrtable/src/lib/itemset.rs
@@ -154,7 +154,7 @@ where usize: AsPrimitive<StorageT>
                     new_ctx.or(&new_is.items[&(prod_i, dot)]);
                 }
 
-                for ref_prod_i in grm.nonterm_to_prods(nonterm_i).iter() {
+                for ref_prod_i in grm.rule_to_prods(nonterm_i).iter() {
                     if new_is.add(*ref_prod_i, SIdx(StorageT::zero()), &new_ctx) {
                         zero_todos.set(usize::from(*ref_prod_i), true);
                     }
@@ -203,7 +203,7 @@ mod test {
         let mut is = Itemset::new(&grm);
         let mut la = Vob::from_elem(usize::from(grm.terms_len()), false);
         la.set(usize::from(grm.eof_term_idx()), true);
-        is.add(grm.nonterm_to_prods(grm.nonterm_idx("^").unwrap())[0], SIdx(0), &la);
+        is.add(grm.rule_to_prods(grm.nonterm_idx("^").unwrap())[0], SIdx(0), &la);
         let cls_is = is.close(&grm, &firsts);
         println!("{:?}", cls_is);
         assert_eq!(cls_is.items.len(), 6);
@@ -237,7 +237,7 @@ mod test {
         let mut is = Itemset::new(&grm);
         let mut la = Vob::from_elem(usize::from(grm.terms_len()), false);
         la.set(usize::from(grm.eof_term_idx()), true);
-        is.add(grm.nonterm_to_prods(grm.nonterm_idx("^").unwrap())[0], SIdx(0), &la);
+        is.add(grm.rule_to_prods(grm.nonterm_idx("^").unwrap())[0], SIdx(0), &la);
         let mut cls_is = is.close(&grm, &firsts);
 
         state_exists(&grm, &cls_is, "^", 0, SIdx(0), vec!["$"]);
@@ -246,7 +246,7 @@ mod test {
         state_exists(&grm, &cls_is, "S", 2, SIdx(0), vec!["b", "$"]);
 
         is = Itemset::new(&grm);
-        is.add(grm.nonterm_to_prods(grm.nonterm_idx("F").unwrap())[0], SIdx(0), &la);
+        is.add(grm.rule_to_prods(grm.nonterm_idx("F").unwrap())[0], SIdx(0), &la);
         cls_is = is.close(&grm, &firsts);
         state_exists(&grm, &cls_is, "F", 0, SIdx(0), vec!["$"]);
         state_exists(&grm, &cls_is, "C", 0, SIdx(0), vec!["d", "f"]);
@@ -279,7 +279,7 @@ mod test {
         let mut is = Itemset::new(&grm);
         let mut la = Vob::from_elem(usize::from(grm.terms_len()), false);
         la.set(usize::from(grm.eof_term_idx()), true);
-        is.add(grm.nonterm_to_prods(grm.nonterm_idx("^").unwrap())[0], SIdx(0), &la);
+        is.add(grm.rule_to_prods(grm.nonterm_idx("^").unwrap())[0], SIdx(0), &la);
         let mut cls_is = is.close(&grm, &firsts);
 
         state_exists(&grm, &cls_is, "^", 0, SIdx(0), vec!["$"]);
@@ -290,7 +290,7 @@ mod test {
         la = Vob::from_elem(usize::from(grm.terms_len()), false);
         la.set(usize::from(grm.term_idx("b").unwrap()), true);
         la.set(usize::from(grm.eof_term_idx()), true);
-        is.add(grm.nonterm_to_prods(grm.nonterm_idx("S").unwrap())[1], SIdx(1), &la);
+        is.add(grm.rule_to_prods(grm.nonterm_idx("S").unwrap())[1], SIdx(1), &la);
         cls_is = is.close(&grm, &firsts);
         state_exists(&grm, &cls_is, "A", 0, SIdx(0), vec!["a"]);
         state_exists(&grm, &cls_is, "A", 1, SIdx(0), vec!["a"]);
@@ -299,7 +299,7 @@ mod test {
         is = Itemset::new(&grm);
         la = Vob::from_elem(usize::from(grm.terms_len()), false);
         la.set(usize::from(grm.term_idx("a").unwrap()), true);
-        is.add(grm.nonterm_to_prods(grm.nonterm_idx("A").unwrap())[0], SIdx(1), &la);
+        is.add(grm.rule_to_prods(grm.nonterm_idx("A").unwrap())[0], SIdx(1), &la);
         cls_is = is.close(&grm, &firsts);
         state_exists(&grm, &cls_is, "S", 0, SIdx(0), vec!["b", "c"]);
         state_exists(&grm, &cls_is, "S", 1, SIdx(0), vec!["b", "c"]);
@@ -313,7 +313,7 @@ mod test {
         let mut is = Itemset::new(&grm);
         let mut la = Vob::from_elem(usize::from(grm.terms_len()), false);
         la.set(usize::from(grm.eof_term_idx()), true);
-        is.add(grm.nonterm_to_prods(grm.nonterm_idx("^").unwrap())[0], SIdx(0), &la);
+        is.add(grm.rule_to_prods(grm.nonterm_idx("^").unwrap())[0], SIdx(0), &la);
         let cls_is = is.close(&grm, &firsts);
 
         let goto1 = cls_is.goto(&grm, &Symbol::Nonterm(grm.nonterm_idx("S").unwrap()));

--- a/lrtable/src/lib/itemset.rs
+++ b/lrtable/src/lib/itemset.rs
@@ -61,8 +61,8 @@ where usize: AsPrimitive<StorageT>
 
     /// Add an item `(prod, dot)` with context `ctx` to this itemset. Returns true if this led to
     /// any changes in the itemset.
-    pub fn add(&mut self, prod: PIdx<StorageT>, dot: SIdx<StorageT>, ctx: &Ctx) -> bool {
-        let entry = self.items.entry((prod, dot));
+    pub fn add(&mut self, pidx: PIdx<StorageT>, dot: SIdx<StorageT>, ctx: &Ctx) -> bool {
+        let entry = self.items.entry((pidx, dot));
         match entry {
             Entry::Occupied(mut e) => {
                 e.get_mut().or(ctx)
@@ -82,14 +82,14 @@ where usize: AsPrimitive<StorageT>
         let mut new_is = self.clone(); // The new itemset we're building up
 
         // In a typical description of this algorithm, one would have a todo set which contains
-        // pairs (prod_i, dot). Unfortunately this is a slow way of doing things. Searching the set
+        // pairs (pidx, dot). Unfortunately this is a slow way of doing things. Searching the set
         // for the next item and removing it is slow; and, since we don't know how many potential
         // dots there are in a production, the set is of potentially unbounded size, so we can end
         // up resizing memory. Since this function is the most expensive in the table generation,
         // using a HashSet (which is the "obvious" solution) is slow.
         //
         // However, we can reduce these costs through two observations:
-        //   1) The initial todo set is populated with (prod_i, dot) pairs that all come from
+        //   1) The initial todo set is populated with (pidx, dot) pairs that all come from
         //      self.items.keys(). There's no point copying these into a todo list.
         //   2) All subsequent todo items are of the form (prod_off, 0). Since the dot in these
         //      cases is always 0, we don't need to store pairs: simply knowing which prod_off's we
@@ -101,31 +101,31 @@ where usize: AsPrimitive<StorageT>
         let mut zero_todos = Vob::from_elem(usize::from(grm.prods_len()), false); // Subsequent todos
         let mut new_ctx = Vob::from_elem(usize::from(grm.tokens_len()), false);
         loop {
-            let prod_i;
+            let pidx;
             let dot;
             // Find the next todo item or, if there are none, break the loop. First of all we try
             // pumping keys_iter for its next value. If there is none (i.e. we've exhausted that
             // part of the todo set), we iterate over zero_todos.
             match keys_iter.next() {
                 Some(&(x, y)) => {
-                    prod_i = x;
+                    pidx = x;
                     dot = y;
                 }
                 None => {
                     match zero_todos.iter_set_bits(..).next() {
                         Some(i) => {
                             // Since zero_todos.len() == grm.prods_len, the call to as_ is safe.
-                            prod_i = PIdx(i.as_())
+                            pidx = PIdx(i.as_())
                         },
                         None => break
                     }
                     dot = SIdx(StorageT::zero());
-                    zero_todos.set(prod_i.into(), false);
+                    zero_todos.set(pidx.into(), false);
                 }
             }
-            let prod = grm.prod(prod_i);
-            if dot == grm.prod_len(prod_i) { continue; }
-            if let Symbol::Rule(nonterm_i) = prod[usize::from(dot)] {
+            let prod = grm.prod(pidx);
+            if dot == grm.prod_len(pidx) { continue; }
+            if let Symbol::Rule(s_ridx) = prod[usize::from(dot)] {
                 // This if statement is, in essence, a fast version of what's called getContext in
                 // Chen's dissertation, folding in getTHeads at the same time. The particular
                 // formulation here is based as much on
@@ -136,14 +136,14 @@ where usize: AsPrimitive<StorageT>
                 let mut nullable = true;
                 for sym in prod.iter().skip(usize::from(dot) + 1) {
                     match *sym {
-                        Symbol::Token(term_j) => {
-                            new_ctx.set(usize::from(term_j), true);
+                        Symbol::Token(s_tidx) => {
+                            new_ctx.set(usize::from(s_tidx), true);
                             nullable = false;
                             break;
                         },
-                        Symbol::Rule(nonterm_j) => {
-                            new_ctx.or(firsts.firsts(nonterm_j));
-                            if !firsts.is_epsilon_set(nonterm_j) {
+                        Symbol::Rule(s_ridx) => {
+                            new_ctx.or(firsts.firsts(s_ridx));
+                            if !firsts.is_epsilon_set(s_ridx) {
                                 nullable = false;
                                 break;
                             }
@@ -151,12 +151,12 @@ where usize: AsPrimitive<StorageT>
                     }
                 }
                 if nullable {
-                    new_ctx.or(&new_is.items[&(prod_i, dot)]);
+                    new_ctx.or(&new_is.items[&(pidx, dot)]);
                 }
 
-                for ref_prod_i in grm.rule_to_prods(nonterm_i).iter() {
-                    if new_is.add(*ref_prod_i, SIdx(StorageT::zero()), &new_ctx) {
-                        zero_todos.set(usize::from(*ref_prod_i), true);
+                for ref_pidx in grm.rule_to_prods(s_ridx).iter() {
+                    if new_is.add(*ref_pidx, SIdx(StorageT::zero()), &new_ctx) {
+                        zero_todos.set(usize::from(*ref_pidx), true);
                     }
                 }
             }
@@ -169,11 +169,11 @@ where usize: AsPrimitive<StorageT>
         // This is called 'transition' in Chen's dissertation, though note that the definition
         // therein appears to get the dot in the input/output the wrong way around.
         let mut newis = Itemset::new(grm);
-        for (&(prod_i, dot), ctx) in &self.items {
-            let prod = grm.prod(prod_i);
-            if dot == grm.prod_len(prod_i) { continue; }
+        for (&(pidx, dot), ctx) in &self.items {
+            let prod = grm.prod(pidx);
+            if dot == grm.prod_len(pidx) { continue; }
             if sym == &prod[usize::from(dot)] {
-                newis.add(prod_i, SIdx(dot.as_storaget() + StorageT::one()), ctx);
+                newis.add(pidx, SIdx(dot.as_storaget() + StorageT::one()), ctx);
             }
         }
         newis

--- a/lrtable/src/lib/itemset.rs
+++ b/lrtable/src/lib/itemset.rs
@@ -202,7 +202,7 @@ mod test {
 
         let mut is = Itemset::new(&grm);
         let mut la = Vob::from_elem(usize::from(grm.tokens_len()), false);
-        la.set(usize::from(grm.eof_term_idx()), true);
+        la.set(usize::from(grm.eof_token_idx()), true);
         is.add(grm.rule_to_prods(grm.rule_idx("^").unwrap())[0], SIdx(0), &la);
         let cls_is = is.close(&grm, &firsts);
         println!("{:?}", cls_is);
@@ -236,7 +236,7 @@ mod test {
 
         let mut is = Itemset::new(&grm);
         let mut la = Vob::from_elem(usize::from(grm.tokens_len()), false);
-        la.set(usize::from(grm.eof_term_idx()), true);
+        la.set(usize::from(grm.eof_token_idx()), true);
         is.add(grm.rule_to_prods(grm.rule_idx("^").unwrap())[0], SIdx(0), &la);
         let mut cls_is = is.close(&grm, &firsts);
 
@@ -278,7 +278,7 @@ mod test {
 
         let mut is = Itemset::new(&grm);
         let mut la = Vob::from_elem(usize::from(grm.tokens_len()), false);
-        la.set(usize::from(grm.eof_term_idx()), true);
+        la.set(usize::from(grm.eof_token_idx()), true);
         is.add(grm.rule_to_prods(grm.rule_idx("^").unwrap())[0], SIdx(0), &la);
         let mut cls_is = is.close(&grm, &firsts);
 
@@ -289,7 +289,7 @@ mod test {
         is = Itemset::new(&grm);
         la = Vob::from_elem(usize::from(grm.tokens_len()), false);
         la.set(usize::from(grm.term_idx("b").unwrap()), true);
-        la.set(usize::from(grm.eof_term_idx()), true);
+        la.set(usize::from(grm.eof_token_idx()), true);
         is.add(grm.rule_to_prods(grm.rule_idx("S").unwrap())[1], SIdx(1), &la);
         cls_is = is.close(&grm, &firsts);
         state_exists(&grm, &cls_is, "A", 0, SIdx(0), vec!["a"]);
@@ -312,7 +312,7 @@ mod test {
 
         let mut is = Itemset::new(&grm);
         let mut la = Vob::from_elem(usize::from(grm.tokens_len()), false);
-        la.set(usize::from(grm.eof_term_idx()), true);
+        la.set(usize::from(grm.eof_token_idx()), true);
         is.add(grm.rule_to_prods(grm.rule_idx("^").unwrap())[0], SIdx(0), &la);
         let cls_is = is.close(&grm, &firsts);
 

--- a/lrtable/src/lib/itemset.rs
+++ b/lrtable/src/lib/itemset.rs
@@ -125,7 +125,7 @@ where usize: AsPrimitive<StorageT>
             }
             let prod = grm.prod(prod_i);
             if dot == grm.prod_len(prod_i) { continue; }
-            if let Symbol::Nonterm(nonterm_i) = prod[usize::from(dot)] {
+            if let Symbol::Rule(nonterm_i) = prod[usize::from(dot)] {
                 // This if statement is, in essence, a fast version of what's called getContext in
                 // Chen's dissertation, folding in getTHeads at the same time. The particular
                 // formulation here is based as much on
@@ -141,7 +141,7 @@ where usize: AsPrimitive<StorageT>
                             nullable = false;
                             break;
                         },
-                        Symbol::Nonterm(nonterm_j) => {
+                        Symbol::Rule(nonterm_j) => {
                             new_ctx.or(firsts.firsts(nonterm_j));
                             if !firsts.is_epsilon_set(nonterm_j) {
                                 nullable = false;
@@ -316,7 +316,7 @@ mod test {
         is.add(grm.rule_to_prods(grm.rule_idx("^").unwrap())[0], SIdx(0), &la);
         let cls_is = is.close(&grm, &firsts);
 
-        let goto1 = cls_is.goto(&grm, &Symbol::Nonterm(grm.rule_idx("S").unwrap()));
+        let goto1 = cls_is.goto(&grm, &Symbol::Rule(grm.rule_idx("S").unwrap()));
         state_exists(&grm, &goto1, "^", 0, SIdx(1), vec!["$"]);
         state_exists(&grm, &goto1, "S", 0, SIdx(1), vec!["$", "b"]);
 

--- a/lrtable/src/lib/itemset.rs
+++ b/lrtable/src/lib/itemset.rs
@@ -99,7 +99,7 @@ where usize: AsPrimitive<StorageT>
 
         let mut keys_iter = self.items.keys(); // The initial todo list
         let mut zero_todos = Vob::from_elem(usize::from(grm.prods_len()), false); // Subsequent todos
-        let mut new_ctx = Vob::from_elem(usize::from(grm.terms_len()), false);
+        let mut new_ctx = Vob::from_elem(usize::from(grm.tokens_len()), false);
         loop {
             let prod_i;
             let dot;
@@ -201,7 +201,7 @@ mod test {
         let firsts = grm.yacc_firsts();
 
         let mut is = Itemset::new(&grm);
-        let mut la = Vob::from_elem(usize::from(grm.terms_len()), false);
+        let mut la = Vob::from_elem(usize::from(grm.tokens_len()), false);
         la.set(usize::from(grm.eof_term_idx()), true);
         is.add(grm.rule_to_prods(grm.rule_idx("^").unwrap())[0], SIdx(0), &la);
         let cls_is = is.close(&grm, &firsts);
@@ -235,7 +235,7 @@ mod test {
         let firsts = grm.yacc_firsts();
 
         let mut is = Itemset::new(&grm);
-        let mut la = Vob::from_elem(usize::from(grm.terms_len()), false);
+        let mut la = Vob::from_elem(usize::from(grm.tokens_len()), false);
         la.set(usize::from(grm.eof_term_idx()), true);
         is.add(grm.rule_to_prods(grm.rule_idx("^").unwrap())[0], SIdx(0), &la);
         let mut cls_is = is.close(&grm, &firsts);
@@ -277,7 +277,7 @@ mod test {
         let firsts = grm.yacc_firsts();
 
         let mut is = Itemset::new(&grm);
-        let mut la = Vob::from_elem(usize::from(grm.terms_len()), false);
+        let mut la = Vob::from_elem(usize::from(grm.tokens_len()), false);
         la.set(usize::from(grm.eof_term_idx()), true);
         is.add(grm.rule_to_prods(grm.rule_idx("^").unwrap())[0], SIdx(0), &la);
         let mut cls_is = is.close(&grm, &firsts);
@@ -287,7 +287,7 @@ mod test {
         state_exists(&grm, &cls_is, "S", 1, SIdx(0), vec!["b", "$"]);
 
         is = Itemset::new(&grm);
-        la = Vob::from_elem(usize::from(grm.terms_len()), false);
+        la = Vob::from_elem(usize::from(grm.tokens_len()), false);
         la.set(usize::from(grm.term_idx("b").unwrap()), true);
         la.set(usize::from(grm.eof_term_idx()), true);
         is.add(grm.rule_to_prods(grm.rule_idx("S").unwrap())[1], SIdx(1), &la);
@@ -297,7 +297,7 @@ mod test {
         state_exists(&grm, &cls_is, "A", 2, SIdx(0), vec!["a"]);
 
         is = Itemset::new(&grm);
-        la = Vob::from_elem(usize::from(grm.terms_len()), false);
+        la = Vob::from_elem(usize::from(grm.tokens_len()), false);
         la.set(usize::from(grm.term_idx("a").unwrap()), true);
         is.add(grm.rule_to_prods(grm.rule_idx("A").unwrap())[0], SIdx(1), &la);
         cls_is = is.close(&grm, &firsts);
@@ -311,7 +311,7 @@ mod test {
         let firsts = grm.yacc_firsts();
 
         let mut is = Itemset::new(&grm);
-        let mut la = Vob::from_elem(usize::from(grm.terms_len()), false);
+        let mut la = Vob::from_elem(usize::from(grm.tokens_len()), false);
         la.set(usize::from(grm.eof_term_idx()), true);
         is.add(grm.rule_to_prods(grm.rule_idx("^").unwrap())[0], SIdx(0), &la);
         let cls_is = is.close(&grm, &firsts);

--- a/lrtable/src/lib/pager.rs
+++ b/lrtable/src/lib/pager.rs
@@ -439,7 +439,7 @@ mod test {
         state_exists(&grm, &sg.closed_state(StIdx(0)), "S", 0, SIdx(0), vec!["$", "b"]);
         state_exists(&grm, &sg.closed_state(StIdx(0)), "S", 1, SIdx(0), vec!["$", "b"]);
 
-        let s1 = sg.edge(StIdx(0), Symbol::Nonterm(grm.nonterm_idx("S").unwrap())).unwrap();
+        let s1 = sg.edge(StIdx(0), Symbol::Nonterm(grm.rule_idx("S").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s1).items.len(), 2);
         state_exists(&grm, &sg.closed_state(s1), "^", 0, SIdx(1), vec!["$"]);
         state_exists(&grm, &sg.closed_state(s1), "S", 0, SIdx(1), vec!["$", "b"]);
@@ -455,7 +455,7 @@ mod test {
         state_exists(&grm, &sg.closed_state(s3), "A", 1, SIdx(0), vec!["a"]);
         state_exists(&grm, &sg.closed_state(s3), "A", 2, SIdx(0), vec!["a"]);
 
-        let s4 = sg.edge(s3, Symbol::Nonterm(grm.nonterm_idx("A").unwrap())).unwrap();
+        let s4 = sg.edge(s3, Symbol::Nonterm(grm.rule_idx("A").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s4).items.len(), 1);
         state_exists(&grm, &sg.closed_state(s4), "S", 1, SIdx(2), vec!["$", "b", "c"]);
 
@@ -473,7 +473,7 @@ mod test {
         state_exists(&grm, &sg.closed_state(s6), "S", 0, SIdx(0), vec!["b", "c"]);
         state_exists(&grm, &sg.closed_state(s6), "S", 1, SIdx(0), vec!["b", "c"]);
 
-        let s7 = sg.edge(s6, Symbol::Nonterm(grm.nonterm_idx("S").unwrap())).unwrap();
+        let s7 = sg.edge(s6, Symbol::Nonterm(grm.rule_idx("S").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s7).items.len(), 3);
         state_exists(&grm, &sg.closed_state(s7), "A", 0, SIdx(2), vec!["a"]);
         state_exists(&grm, &sg.closed_state(s7), "A", 2, SIdx(2), vec!["a"]);
@@ -566,7 +566,7 @@ mod test {
         state_exists(&grm, &sg.closed_state(s3), "W", 0, SIdx(1), vec!["d"]);
         state_exists(&grm, &sg.closed_state(s3), "V", 0, SIdx(0), vec!["d"]);
 
-        let s5 = sg.edge(s4, Symbol::Nonterm(grm.nonterm_idx("X").unwrap())).unwrap();
+        let s5 = sg.edge(s4, Symbol::Nonterm(grm.rule_idx("X").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s5).items.len(), 2);
         state_exists(&grm, &sg.closed_state(s5), "Y", 1, SIdx(2), vec!["d", "e"]);
         state_exists(&grm, &sg.closed_state(s5), "T", 0, SIdx(2), vec!["a", "d", "e", "$"]);
@@ -590,49 +590,49 @@ mod test {
         // Ommitted successors from the graph in Fig.3
 
         // X-successor of S0
-        let s0x = sg.edge(StIdx(0), Symbol::Nonterm(grm.nonterm_idx("X").unwrap())).unwrap();
+        let s0x = sg.edge(StIdx(0), Symbol::Nonterm(grm.rule_idx("X").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s0x), "^", 0, SIdx(1), vec!["$"]);
 
         // Y-successor of S1 (and it's d-successor)
-        let s1y = sg.edge(s1, Symbol::Nonterm(grm.nonterm_idx("Y").unwrap())).unwrap();
+        let s1y = sg.edge(s1, Symbol::Nonterm(grm.rule_idx("Y").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s1y), "X", 0, SIdx(2), vec!["a", "d", "e", "$"]);
         let s1yd = sg.edge(s1y, Symbol::Term(grm.term_idx("d").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s1yd), "X", 0, SIdx(3), vec!["a", "d", "e", "$"]);
 
         // Z-successor of S1 (and it's successor)
-        let s1z = sg.edge(s1, Symbol::Nonterm(grm.nonterm_idx("Z").unwrap())).unwrap();
+        let s1z = sg.edge(s1, Symbol::Nonterm(grm.rule_idx("Z").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s1z), "X", 1, SIdx(2), vec!["a", "d", "e", "$"]);
         let s1zc = sg.edge(s1z, Symbol::Term(grm.term_idx("c").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s1zc), "X", 1, SIdx(3), vec!["a", "d", "e", "$"]);
 
         // T-successor of S1
-        let s1t = sg.edge(s1, Symbol::Nonterm(grm.nonterm_idx("T").unwrap())).unwrap();
+        let s1t = sg.edge(s1, Symbol::Nonterm(grm.rule_idx("T").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s1t), "X", 2, SIdx(2), vec!["a", "d", "e", "$"]);
 
         // Y-successor of S7 (and it's d-successor)
-        let s7y = sg.edge(s7, Symbol::Nonterm(grm.nonterm_idx("Y").unwrap())).unwrap();
+        let s7y = sg.edge(s7, Symbol::Nonterm(grm.rule_idx("Y").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s7y), "X", 3, SIdx(2), vec!["a", "d", "e", "$"]);
         let s7ye = sg.edge(s7y, Symbol::Term(grm.term_idx("e").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s7ye), "X", 3, SIdx(3), vec!["a", "d", "e", "$"]);
 
         // Z-successor of S7 (and it's successor)
-        let s7z = sg.edge(s7, Symbol::Nonterm(grm.nonterm_idx("Z").unwrap())).unwrap();
+        let s7z = sg.edge(s7, Symbol::Nonterm(grm.rule_idx("Z").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s7z), "X", 4, SIdx(2), vec!["a", "d", "e", "$"]);
         let s7zd = sg.edge(s7z, Symbol::Term(grm.term_idx("d").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s7zd), "X", 4, SIdx(3), vec!["a", "d", "e", "$"]);
 
         // T-successor of S7
-        let s7t = sg.edge(s7, Symbol::Nonterm(grm.nonterm_idx("T").unwrap())).unwrap();
+        let s7t = sg.edge(s7, Symbol::Nonterm(grm.rule_idx("T").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s7t), "X", 5, SIdx(2), vec!["a", "d", "e", "$"]);
 
         // W-successor of S2 and S8 (merged)
-        let s8w = sg.edge(s8, Symbol::Nonterm(grm.nonterm_idx("W").unwrap())).unwrap();
-        assert_eq!(s8w, sg.edge(s2, Symbol::Nonterm(grm.nonterm_idx("W").unwrap())).unwrap());
+        let s8w = sg.edge(s8, Symbol::Nonterm(grm.rule_idx("W").unwrap())).unwrap();
+        assert_eq!(s8w, sg.edge(s2, Symbol::Nonterm(grm.rule_idx("W").unwrap())).unwrap());
         state_exists(&grm, &sg.closed_state(s8w), "Y", 0, SIdx(2), vec!["d", "e"]);
 
         // V-successor of S3 and S9 (merged)
-        let s9v = sg.edge(s9, Symbol::Nonterm(grm.nonterm_idx("V").unwrap())).unwrap();
-        assert_eq!(s9v, sg.edge(s3, Symbol::Nonterm(grm.nonterm_idx("V").unwrap())).unwrap());
+        let s9v = sg.edge(s9, Symbol::Nonterm(grm.rule_idx("V").unwrap())).unwrap();
+        assert_eq!(s9v, sg.edge(s3, Symbol::Nonterm(grm.rule_idx("V").unwrap())).unwrap());
         state_exists(&grm, &sg.closed_state(s9v), "W", 0, SIdx(2), vec!["d", "e"]);
     }
 

--- a/lrtable/src/lib/pager.rs
+++ b/lrtable/src/lib/pager.rs
@@ -444,11 +444,11 @@ mod test {
         state_exists(&grm, &sg.closed_state(s1), "^", 0, SIdx(1), vec!["$"]);
         state_exists(&grm, &sg.closed_state(s1), "S", 0, SIdx(1), vec!["$", "b"]);
 
-        let s2 = sg.edge(s1, Symbol::Term(grm.term_idx("b").unwrap())).unwrap();
+        let s2 = sg.edge(s1, Symbol::Term(grm.token_idx("b").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s2).items.len(), 1);
         state_exists(&grm, &sg.closed_state(s2), "S", 0, SIdx(2), vec!["$", "b"]);
 
-        let s3 = sg.edge(StIdx(0), Symbol::Term(grm.term_idx("b").unwrap())).unwrap();
+        let s3 = sg.edge(StIdx(0), Symbol::Term(grm.token_idx("b").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s3).items.len(), 4);
         state_exists(&grm, &sg.closed_state(s3), "S", 1, SIdx(1), vec!["$", "b", "c"]);
         state_exists(&grm, &sg.closed_state(s3), "A", 0, SIdx(0), vec!["a"]);
@@ -459,13 +459,13 @@ mod test {
         assert_eq!(sg.closed_state(s4).items.len(), 1);
         state_exists(&grm, &sg.closed_state(s4), "S", 1, SIdx(2), vec!["$", "b", "c"]);
 
-        let s5 = sg.edge(s4, Symbol::Term(grm.term_idx("a").unwrap())).unwrap();
+        let s5 = sg.edge(s4, Symbol::Term(grm.token_idx("a").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s5).items.len(), 1);
         state_exists(&grm, &sg.closed_state(s5), "S", 1, SIdx(3), vec!["$", "b", "c"]);
 
-        let s6 = sg.edge(s3, Symbol::Term(grm.term_idx("a").unwrap())).unwrap();
+        let s6 = sg.edge(s3, Symbol::Term(grm.token_idx("a").unwrap())).unwrap();
         // result from merging 10 into 3
-        assert_eq!(s3, sg.edge(s6, Symbol::Term(grm.term_idx("b").unwrap())).unwrap());
+        assert_eq!(s3, sg.edge(s6, Symbol::Term(grm.token_idx("b").unwrap())).unwrap());
         assert_eq!(sg.closed_state(s6).items.len(), 5);
         state_exists(&grm, &sg.closed_state(s6), "A", 0, SIdx(1), vec!["a"]);
         state_exists(&grm, &sg.closed_state(s6), "A", 1, SIdx(1), vec!["a"]);
@@ -479,11 +479,11 @@ mod test {
         state_exists(&grm, &sg.closed_state(s7), "A", 2, SIdx(2), vec!["a"]);
         state_exists(&grm, &sg.closed_state(s7), "S", 0, SIdx(1), vec!["b", "c"]);
 
-        let s8 = sg.edge(s7, Symbol::Term(grm.term_idx("c").unwrap())).unwrap();
+        let s8 = sg.edge(s7, Symbol::Term(grm.token_idx("c").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s8).items.len(), 1);
         state_exists(&grm, &sg.closed_state(s8), "A", 0, SIdx(3), vec!["a"]);
 
-        let s9 = sg.edge(s7, Symbol::Term(grm.term_idx("b").unwrap())).unwrap();
+        let s9 = sg.edge(s7, Symbol::Term(grm.token_idx("b").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s9).items.len(), 2);
         state_exists(&grm, &sg.closed_state(s9), "A", 2, SIdx(3), vec!["a"]);
         state_exists(&grm, &sg.closed_state(s9), "S", 0, SIdx(2), vec!["b", "c"]);
@@ -519,7 +519,7 @@ mod test {
         state_exists(&grm, &sg.closed_state(StIdx(0)), "X", 4, SIdx(0), vec!["$"]);
         state_exists(&grm, &sg.closed_state(StIdx(0)), "X", 5, SIdx(0), vec!["$"]);
 
-        let s1 = sg.edge(StIdx(0), Symbol::Term(grm.term_idx("a").unwrap())).unwrap();
+        let s1 = sg.edge(StIdx(0), Symbol::Term(grm.token_idx("a").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s1).items.len(), 7);
         state_exists(&grm, &sg.closed_state(s1), "X", 0, SIdx(1), vec!["a", "d", "e", "$"]);
         state_exists(&grm, &sg.closed_state(s1), "X", 1, SIdx(1), vec!["a", "d", "e", "$"]);
@@ -529,7 +529,7 @@ mod test {
         state_exists(&grm, &sg.closed_state(s1), "Z", 0, SIdx(0), vec!["c"]);
         state_exists(&grm, &sg.closed_state(s1), "T", 0, SIdx(0), vec!["a", "d", "e", "$"]);
 
-        let s7 = sg.edge(StIdx(0), Symbol::Term(grm.term_idx("b").unwrap())).unwrap();
+        let s7 = sg.edge(StIdx(0), Symbol::Term(grm.token_idx("b").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s7).items.len(), 7);
         state_exists(&grm, &sg.closed_state(s7), "X", 3, SIdx(1), vec!["a", "d", "e", "$"]);
         state_exists(&grm, &sg.closed_state(s7), "X", 4, SIdx(1), vec!["a", "d", "e", "$"]);
@@ -539,9 +539,9 @@ mod test {
         state_exists(&grm, &sg.closed_state(s1), "Z", 0, SIdx(0), vec!["c"]);
         state_exists(&grm, &sg.closed_state(s1), "T", 0, SIdx(0), vec!["a", "d", "e", "$"]);
 
-        let s4 = sg.edge(s1, Symbol::Term(grm.term_idx("u").unwrap())).unwrap();
+        let s4 = sg.edge(s1, Symbol::Term(grm.token_idx("u").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s4).items.len(), 8);
-        assert_eq!(s4, sg.edge(s7, Symbol::Term(grm.term_idx("u").unwrap())).unwrap());
+        assert_eq!(s4, sg.edge(s7, Symbol::Term(grm.token_idx("u").unwrap())).unwrap());
         state_exists(&grm, &sg.closed_state(s4), "Y", 1, SIdx(1), vec!["d", "e"]);
         state_exists(&grm, &sg.closed_state(s4), "T", 0, SIdx(1), vec!["a", "d", "e", "$"]);
         state_exists(&grm, &sg.closed_state(s4), "X", 0, SIdx(0), vec!["a", "d", "e"]);
@@ -551,16 +551,16 @@ mod test {
         state_exists(&grm, &sg.closed_state(s4), "X", 4, SIdx(0), vec!["a", "d", "e"]);
         state_exists(&grm, &sg.closed_state(s4), "X", 5, SIdx(0), vec!["a", "d", "e"]);
 
-        assert_eq!(s1, sg.edge(s4, Symbol::Term(grm.term_idx("a").unwrap())).unwrap());
-        assert_eq!(s7, sg.edge(s4, Symbol::Term(grm.term_idx("b").unwrap())).unwrap());
+        assert_eq!(s1, sg.edge(s4, Symbol::Term(grm.token_idx("a").unwrap())).unwrap());
+        assert_eq!(s7, sg.edge(s4, Symbol::Term(grm.token_idx("b").unwrap())).unwrap());
 
-        let s2 = sg.edge(s1, Symbol::Term(grm.term_idx("t").unwrap())).unwrap();
+        let s2 = sg.edge(s1, Symbol::Term(grm.token_idx("t").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s2).items.len(), 3);
         state_exists(&grm, &sg.closed_state(s2), "Y", 0, SIdx(1), vec!["d"]);
         state_exists(&grm, &sg.closed_state(s2), "Z", 0, SIdx(1), vec!["c"]);
         state_exists(&grm, &sg.closed_state(s2), "W", 0, SIdx(0), vec!["d"]);
 
-        let s3 = sg.edge(s2, Symbol::Term(grm.term_idx("u").unwrap())).unwrap();
+        let s3 = sg.edge(s2, Symbol::Term(grm.token_idx("u").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s3).items.len(), 3);
         state_exists(&grm, &sg.closed_state(s3), "Z", 0, SIdx(2), vec!["c"]);
         state_exists(&grm, &sg.closed_state(s3), "W", 0, SIdx(1), vec!["d"]);
@@ -571,17 +571,17 @@ mod test {
         state_exists(&grm, &sg.closed_state(s5), "Y", 1, SIdx(2), vec!["d", "e"]);
         state_exists(&grm, &sg.closed_state(s5), "T", 0, SIdx(2), vec!["a", "d", "e", "$"]);
 
-        let s6 = sg.edge(s5, Symbol::Term(grm.term_idx("a").unwrap())).unwrap();
+        let s6 = sg.edge(s5, Symbol::Term(grm.token_idx("a").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s6).items.len(), 1);
         state_exists(&grm, &sg.closed_state(s6), "T", 0, SIdx(3), vec!["a", "d", "e", "$"]);
 
-        let s8 = sg.edge(s7, Symbol::Term(grm.term_idx("t").unwrap())).unwrap();
+        let s8 = sg.edge(s7, Symbol::Term(grm.token_idx("t").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s8).items.len(), 3);
         state_exists(&grm, &sg.closed_state(s8), "Y", 0, SIdx(1), vec!["e"]);
         state_exists(&grm, &sg.closed_state(s8), "Z", 0, SIdx(1), vec!["d"]);
         state_exists(&grm, &sg.closed_state(s8), "W", 0, SIdx(0), vec!["e"]);
 
-        let s9 = sg.edge(s8, Symbol::Term(grm.term_idx("u").unwrap())).unwrap();
+        let s9 = sg.edge(s8, Symbol::Term(grm.token_idx("u").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s9).items.len(), 3);
         state_exists(&grm, &sg.closed_state(s9), "Z", 0, SIdx(2), vec!["d"]);
         state_exists(&grm, &sg.closed_state(s9), "W", 0, SIdx(1), vec!["e"]);
@@ -596,13 +596,13 @@ mod test {
         // Y-successor of S1 (and it's d-successor)
         let s1y = sg.edge(s1, Symbol::Rule(grm.rule_idx("Y").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s1y), "X", 0, SIdx(2), vec!["a", "d", "e", "$"]);
-        let s1yd = sg.edge(s1y, Symbol::Term(grm.term_idx("d").unwrap())).unwrap();
+        let s1yd = sg.edge(s1y, Symbol::Term(grm.token_idx("d").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s1yd), "X", 0, SIdx(3), vec!["a", "d", "e", "$"]);
 
         // Z-successor of S1 (and it's successor)
         let s1z = sg.edge(s1, Symbol::Rule(grm.rule_idx("Z").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s1z), "X", 1, SIdx(2), vec!["a", "d", "e", "$"]);
-        let s1zc = sg.edge(s1z, Symbol::Term(grm.term_idx("c").unwrap())).unwrap();
+        let s1zc = sg.edge(s1z, Symbol::Term(grm.token_idx("c").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s1zc), "X", 1, SIdx(3), vec!["a", "d", "e", "$"]);
 
         // T-successor of S1
@@ -612,13 +612,13 @@ mod test {
         // Y-successor of S7 (and it's d-successor)
         let s7y = sg.edge(s7, Symbol::Rule(grm.rule_idx("Y").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s7y), "X", 3, SIdx(2), vec!["a", "d", "e", "$"]);
-        let s7ye = sg.edge(s7y, Symbol::Term(grm.term_idx("e").unwrap())).unwrap();
+        let s7ye = sg.edge(s7y, Symbol::Term(grm.token_idx("e").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s7ye), "X", 3, SIdx(3), vec!["a", "d", "e", "$"]);
 
         // Z-successor of S7 (and it's successor)
         let s7z = sg.edge(s7, Symbol::Rule(grm.rule_idx("Z").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s7z), "X", 4, SIdx(2), vec!["a", "d", "e", "$"]);
-        let s7zd = sg.edge(s7z, Symbol::Term(grm.term_idx("d").unwrap())).unwrap();
+        let s7zd = sg.edge(s7z, Symbol::Term(grm.token_idx("d").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s7zd), "X", 4, SIdx(3), vec!["a", "d", "e", "$"]);
 
         // T-successor of S7

--- a/lrtable/src/lib/pager.rs
+++ b/lrtable/src/lib/pager.rs
@@ -160,7 +160,7 @@ where usize: AsPrimitive<StorageT>
     let mut edges: Vec<HashMap<Symbol<StorageT>, StIdx>> = Vec::new();
 
     let mut state0 = Itemset::new(grm);
-    let mut ctx = Vob::from_elem(usize::from(grm.terms_len()), false);
+    let mut ctx = Vob::from_elem(usize::from(grm.tokens_len()), false);
     ctx.set(usize::from(grm.eof_term_idx()), true);
     state0.add(grm.start_prod(), SIdx(StorageT::zero()), &ctx);
     closed_states.push(None);
@@ -170,14 +170,14 @@ where usize: AsPrimitive<StorageT>
     // We maintain two lists of which nonterms and terms we've seen; when processing a given
     // state there's no point processing a nonterm or term more than once.
     let mut seen_nonterms = Vob::from_elem(usize::from(grm.rules_len()), false);
-    let mut seen_terms = Vob::from_elem(usize::from(grm.terms_len()), false);
+    let mut seen_terms = Vob::from_elem(usize::from(grm.tokens_len()), false);
     // new_states is used to separate out iterating over states vs. mutating it
     let mut new_states = Vec::new();
     // cnd_[nonterm|term]_weaklies represent which states are possible weakly compatible
     // matches for a given symbol.
     let mut cnd_nonterm_weaklies: Vec<Vec<StIdx>> = Vec::with_capacity(usize::from(grm.rules_len()));
-    let mut cnd_term_weaklies: Vec<Vec<StIdx>> = Vec::with_capacity(usize::from(grm.terms_len()));
-    for _ in 0..usize::from(grm.terms_len()).checked_add(1).unwrap(){
+    let mut cnd_term_weaklies: Vec<Vec<StIdx>> = Vec::with_capacity(usize::from(grm.tokens_len()));
+    for _ in 0..usize::from(grm.tokens_len()).checked_add(1).unwrap(){
         cnd_term_weaklies.push(Vec::new());
     }
     for _ in grm.iter_rules() { cnd_nonterm_weaklies.push(Vec::new()); }

--- a/lrtable/src/lib/pager.rs
+++ b/lrtable/src/lib/pager.rs
@@ -208,7 +208,7 @@ where usize: AsPrimitive<StorageT>
                 if dot == grm.prod_len(prod_i) { continue; }
                 let sym = prod[usize::from(dot)];
                 match sym {
-                    Symbol::Nonterm(nonterm_i) => {
+                    Symbol::Rule(nonterm_i) => {
                         if seen_nonterms[usize::from(nonterm_i)] {
                             continue;
                         }
@@ -231,7 +231,7 @@ where usize: AsPrimitive<StorageT>
             {
                 // Try and compatible match for this state.
                 let cnd_states = match sym {
-                    Symbol::Nonterm(nonterm_i) => &cnd_nonterm_weaklies[usize::from(nonterm_i)],
+                    Symbol::Rule(nonterm_i) => &cnd_nonterm_weaklies[usize::from(nonterm_i)],
                     Symbol::Term(term_i) => &cnd_term_weaklies[usize::from(term_i)]
                 };
                 // First of all see if any of the candidate states are exactly the same as the
@@ -276,7 +276,7 @@ where usize: AsPrimitive<StorageT>
                 },
                 None    => {
                     match sym {
-                        Symbol::Nonterm(nonterm_i) =>
+                        Symbol::Rule(nonterm_i) =>
                             cnd_nonterm_weaklies[usize::from(nonterm_i)].push(core_states.len().into()),
                         Symbol::Term(term_i) =>
                             cnd_term_weaklies[usize::from(term_i)].push(core_states.len().into())
@@ -439,7 +439,7 @@ mod test {
         state_exists(&grm, &sg.closed_state(StIdx(0)), "S", 0, SIdx(0), vec!["$", "b"]);
         state_exists(&grm, &sg.closed_state(StIdx(0)), "S", 1, SIdx(0), vec!["$", "b"]);
 
-        let s1 = sg.edge(StIdx(0), Symbol::Nonterm(grm.rule_idx("S").unwrap())).unwrap();
+        let s1 = sg.edge(StIdx(0), Symbol::Rule(grm.rule_idx("S").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s1).items.len(), 2);
         state_exists(&grm, &sg.closed_state(s1), "^", 0, SIdx(1), vec!["$"]);
         state_exists(&grm, &sg.closed_state(s1), "S", 0, SIdx(1), vec!["$", "b"]);
@@ -455,7 +455,7 @@ mod test {
         state_exists(&grm, &sg.closed_state(s3), "A", 1, SIdx(0), vec!["a"]);
         state_exists(&grm, &sg.closed_state(s3), "A", 2, SIdx(0), vec!["a"]);
 
-        let s4 = sg.edge(s3, Symbol::Nonterm(grm.rule_idx("A").unwrap())).unwrap();
+        let s4 = sg.edge(s3, Symbol::Rule(grm.rule_idx("A").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s4).items.len(), 1);
         state_exists(&grm, &sg.closed_state(s4), "S", 1, SIdx(2), vec!["$", "b", "c"]);
 
@@ -473,7 +473,7 @@ mod test {
         state_exists(&grm, &sg.closed_state(s6), "S", 0, SIdx(0), vec!["b", "c"]);
         state_exists(&grm, &sg.closed_state(s6), "S", 1, SIdx(0), vec!["b", "c"]);
 
-        let s7 = sg.edge(s6, Symbol::Nonterm(grm.rule_idx("S").unwrap())).unwrap();
+        let s7 = sg.edge(s6, Symbol::Rule(grm.rule_idx("S").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s7).items.len(), 3);
         state_exists(&grm, &sg.closed_state(s7), "A", 0, SIdx(2), vec!["a"]);
         state_exists(&grm, &sg.closed_state(s7), "A", 2, SIdx(2), vec!["a"]);
@@ -566,7 +566,7 @@ mod test {
         state_exists(&grm, &sg.closed_state(s3), "W", 0, SIdx(1), vec!["d"]);
         state_exists(&grm, &sg.closed_state(s3), "V", 0, SIdx(0), vec!["d"]);
 
-        let s5 = sg.edge(s4, Symbol::Nonterm(grm.rule_idx("X").unwrap())).unwrap();
+        let s5 = sg.edge(s4, Symbol::Rule(grm.rule_idx("X").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s5).items.len(), 2);
         state_exists(&grm, &sg.closed_state(s5), "Y", 1, SIdx(2), vec!["d", "e"]);
         state_exists(&grm, &sg.closed_state(s5), "T", 0, SIdx(2), vec!["a", "d", "e", "$"]);
@@ -590,49 +590,49 @@ mod test {
         // Ommitted successors from the graph in Fig.3
 
         // X-successor of S0
-        let s0x = sg.edge(StIdx(0), Symbol::Nonterm(grm.rule_idx("X").unwrap())).unwrap();
+        let s0x = sg.edge(StIdx(0), Symbol::Rule(grm.rule_idx("X").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s0x), "^", 0, SIdx(1), vec!["$"]);
 
         // Y-successor of S1 (and it's d-successor)
-        let s1y = sg.edge(s1, Symbol::Nonterm(grm.rule_idx("Y").unwrap())).unwrap();
+        let s1y = sg.edge(s1, Symbol::Rule(grm.rule_idx("Y").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s1y), "X", 0, SIdx(2), vec!["a", "d", "e", "$"]);
         let s1yd = sg.edge(s1y, Symbol::Term(grm.term_idx("d").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s1yd), "X", 0, SIdx(3), vec!["a", "d", "e", "$"]);
 
         // Z-successor of S1 (and it's successor)
-        let s1z = sg.edge(s1, Symbol::Nonterm(grm.rule_idx("Z").unwrap())).unwrap();
+        let s1z = sg.edge(s1, Symbol::Rule(grm.rule_idx("Z").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s1z), "X", 1, SIdx(2), vec!["a", "d", "e", "$"]);
         let s1zc = sg.edge(s1z, Symbol::Term(grm.term_idx("c").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s1zc), "X", 1, SIdx(3), vec!["a", "d", "e", "$"]);
 
         // T-successor of S1
-        let s1t = sg.edge(s1, Symbol::Nonterm(grm.rule_idx("T").unwrap())).unwrap();
+        let s1t = sg.edge(s1, Symbol::Rule(grm.rule_idx("T").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s1t), "X", 2, SIdx(2), vec!["a", "d", "e", "$"]);
 
         // Y-successor of S7 (and it's d-successor)
-        let s7y = sg.edge(s7, Symbol::Nonterm(grm.rule_idx("Y").unwrap())).unwrap();
+        let s7y = sg.edge(s7, Symbol::Rule(grm.rule_idx("Y").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s7y), "X", 3, SIdx(2), vec!["a", "d", "e", "$"]);
         let s7ye = sg.edge(s7y, Symbol::Term(grm.term_idx("e").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s7ye), "X", 3, SIdx(3), vec!["a", "d", "e", "$"]);
 
         // Z-successor of S7 (and it's successor)
-        let s7z = sg.edge(s7, Symbol::Nonterm(grm.rule_idx("Z").unwrap())).unwrap();
+        let s7z = sg.edge(s7, Symbol::Rule(grm.rule_idx("Z").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s7z), "X", 4, SIdx(2), vec!["a", "d", "e", "$"]);
         let s7zd = sg.edge(s7z, Symbol::Term(grm.term_idx("d").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s7zd), "X", 4, SIdx(3), vec!["a", "d", "e", "$"]);
 
         // T-successor of S7
-        let s7t = sg.edge(s7, Symbol::Nonterm(grm.rule_idx("T").unwrap())).unwrap();
+        let s7t = sg.edge(s7, Symbol::Rule(grm.rule_idx("T").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s7t), "X", 5, SIdx(2), vec!["a", "d", "e", "$"]);
 
         // W-successor of S2 and S8 (merged)
-        let s8w = sg.edge(s8, Symbol::Nonterm(grm.rule_idx("W").unwrap())).unwrap();
-        assert_eq!(s8w, sg.edge(s2, Symbol::Nonterm(grm.rule_idx("W").unwrap())).unwrap());
+        let s8w = sg.edge(s8, Symbol::Rule(grm.rule_idx("W").unwrap())).unwrap();
+        assert_eq!(s8w, sg.edge(s2, Symbol::Rule(grm.rule_idx("W").unwrap())).unwrap());
         state_exists(&grm, &sg.closed_state(s8w), "Y", 0, SIdx(2), vec!["d", "e"]);
 
         // V-successor of S3 and S9 (merged)
-        let s9v = sg.edge(s9, Symbol::Nonterm(grm.rule_idx("V").unwrap())).unwrap();
-        assert_eq!(s9v, sg.edge(s3, Symbol::Nonterm(grm.rule_idx("V").unwrap())).unwrap());
+        let s9v = sg.edge(s9, Symbol::Rule(grm.rule_idx("V").unwrap())).unwrap();
+        assert_eq!(s9v, sg.edge(s3, Symbol::Rule(grm.rule_idx("V").unwrap())).unwrap());
         state_exists(&grm, &sg.closed_state(s9v), "W", 0, SIdx(2), vec!["d", "e"]);
     }
 

--- a/lrtable/src/lib/pager.rs
+++ b/lrtable/src/lib/pager.rs
@@ -180,7 +180,7 @@ where usize: AsPrimitive<StorageT>
     for _ in 0..usize::from(grm.terms_len()).checked_add(1).unwrap(){
         cnd_term_weaklies.push(Vec::new());
     }
-    for _ in grm.iter_ntidxs() { cnd_nonterm_weaklies.push(Vec::new()); }
+    for _ in grm.iter_rules() { cnd_nonterm_weaklies.push(Vec::new()); }
 
     let mut todo = 1; // How many None values are there in closed_states?
     let mut todo_off = 0; // Offset in closed states to start searching for the next todo.

--- a/lrtable/src/lib/pager.rs
+++ b/lrtable/src/lib/pager.rs
@@ -169,13 +169,13 @@ where usize: AsPrimitive<StorageT>
 
     // We maintain two lists of which nonterms and terms we've seen; when processing a given
     // state there's no point processing a nonterm or term more than once.
-    let mut seen_nonterms = Vob::from_elem(usize::from(grm.nonterms_len()), false);
+    let mut seen_nonterms = Vob::from_elem(usize::from(grm.rules_len()), false);
     let mut seen_terms = Vob::from_elem(usize::from(grm.terms_len()), false);
     // new_states is used to separate out iterating over states vs. mutating it
     let mut new_states = Vec::new();
     // cnd_[nonterm|term]_weaklies represent which states are possible weakly compatible
     // matches for a given symbol.
-    let mut cnd_nonterm_weaklies: Vec<Vec<StIdx>> = Vec::with_capacity(usize::from(grm.nonterms_len()));
+    let mut cnd_nonterm_weaklies: Vec<Vec<StIdx>> = Vec::with_capacity(usize::from(grm.rules_len()));
     let mut cnd_term_weaklies: Vec<Vec<StIdx>> = Vec::with_capacity(usize::from(grm.terms_len()));
     for _ in 0..usize::from(grm.terms_len()).checked_add(1).unwrap(){
         cnd_term_weaklies.push(Vec::new());

--- a/lrtable/src/lib/pager.rs
+++ b/lrtable/src/lib/pager.rs
@@ -214,7 +214,7 @@ where usize: AsPrimitive<StorageT>
                         }
                         seen_nonterms.set(usize::from(nonterm_i), true);
                     },
-                    Symbol::Term(term_i) => {
+                    Symbol::Token(term_i) => {
                         if seen_terms[usize::from(term_i)] {
                             continue;
                         }
@@ -232,7 +232,7 @@ where usize: AsPrimitive<StorageT>
                 // Try and compatible match for this state.
                 let cnd_states = match sym {
                     Symbol::Rule(nonterm_i) => &cnd_nonterm_weaklies[usize::from(nonterm_i)],
-                    Symbol::Term(term_i) => &cnd_term_weaklies[usize::from(term_i)]
+                    Symbol::Token(term_i) => &cnd_term_weaklies[usize::from(term_i)]
                 };
                 // First of all see if any of the candidate states are exactly the same as the
                 // new state, in which case we only need to add an edge to the candidate
@@ -278,7 +278,7 @@ where usize: AsPrimitive<StorageT>
                     match sym {
                         Symbol::Rule(nonterm_i) =>
                             cnd_nonterm_weaklies[usize::from(nonterm_i)].push(core_states.len().into()),
-                        Symbol::Term(term_i) =>
+                        Symbol::Token(term_i) =>
                             cnd_term_weaklies[usize::from(term_i)].push(core_states.len().into())
                     }
                     edges[state_i].insert(sym, core_states.len().into());
@@ -444,11 +444,11 @@ mod test {
         state_exists(&grm, &sg.closed_state(s1), "^", 0, SIdx(1), vec!["$"]);
         state_exists(&grm, &sg.closed_state(s1), "S", 0, SIdx(1), vec!["$", "b"]);
 
-        let s2 = sg.edge(s1, Symbol::Term(grm.token_idx("b").unwrap())).unwrap();
+        let s2 = sg.edge(s1, Symbol::Token(grm.token_idx("b").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s2).items.len(), 1);
         state_exists(&grm, &sg.closed_state(s2), "S", 0, SIdx(2), vec!["$", "b"]);
 
-        let s3 = sg.edge(StIdx(0), Symbol::Term(grm.token_idx("b").unwrap())).unwrap();
+        let s3 = sg.edge(StIdx(0), Symbol::Token(grm.token_idx("b").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s3).items.len(), 4);
         state_exists(&grm, &sg.closed_state(s3), "S", 1, SIdx(1), vec!["$", "b", "c"]);
         state_exists(&grm, &sg.closed_state(s3), "A", 0, SIdx(0), vec!["a"]);
@@ -459,13 +459,13 @@ mod test {
         assert_eq!(sg.closed_state(s4).items.len(), 1);
         state_exists(&grm, &sg.closed_state(s4), "S", 1, SIdx(2), vec!["$", "b", "c"]);
 
-        let s5 = sg.edge(s4, Symbol::Term(grm.token_idx("a").unwrap())).unwrap();
+        let s5 = sg.edge(s4, Symbol::Token(grm.token_idx("a").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s5).items.len(), 1);
         state_exists(&grm, &sg.closed_state(s5), "S", 1, SIdx(3), vec!["$", "b", "c"]);
 
-        let s6 = sg.edge(s3, Symbol::Term(grm.token_idx("a").unwrap())).unwrap();
+        let s6 = sg.edge(s3, Symbol::Token(grm.token_idx("a").unwrap())).unwrap();
         // result from merging 10 into 3
-        assert_eq!(s3, sg.edge(s6, Symbol::Term(grm.token_idx("b").unwrap())).unwrap());
+        assert_eq!(s3, sg.edge(s6, Symbol::Token(grm.token_idx("b").unwrap())).unwrap());
         assert_eq!(sg.closed_state(s6).items.len(), 5);
         state_exists(&grm, &sg.closed_state(s6), "A", 0, SIdx(1), vec!["a"]);
         state_exists(&grm, &sg.closed_state(s6), "A", 1, SIdx(1), vec!["a"]);
@@ -479,11 +479,11 @@ mod test {
         state_exists(&grm, &sg.closed_state(s7), "A", 2, SIdx(2), vec!["a"]);
         state_exists(&grm, &sg.closed_state(s7), "S", 0, SIdx(1), vec!["b", "c"]);
 
-        let s8 = sg.edge(s7, Symbol::Term(grm.token_idx("c").unwrap())).unwrap();
+        let s8 = sg.edge(s7, Symbol::Token(grm.token_idx("c").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s8).items.len(), 1);
         state_exists(&grm, &sg.closed_state(s8), "A", 0, SIdx(3), vec!["a"]);
 
-        let s9 = sg.edge(s7, Symbol::Term(grm.token_idx("b").unwrap())).unwrap();
+        let s9 = sg.edge(s7, Symbol::Token(grm.token_idx("b").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s9).items.len(), 2);
         state_exists(&grm, &sg.closed_state(s9), "A", 2, SIdx(3), vec!["a"]);
         state_exists(&grm, &sg.closed_state(s9), "S", 0, SIdx(2), vec!["b", "c"]);
@@ -519,7 +519,7 @@ mod test {
         state_exists(&grm, &sg.closed_state(StIdx(0)), "X", 4, SIdx(0), vec!["$"]);
         state_exists(&grm, &sg.closed_state(StIdx(0)), "X", 5, SIdx(0), vec!["$"]);
 
-        let s1 = sg.edge(StIdx(0), Symbol::Term(grm.token_idx("a").unwrap())).unwrap();
+        let s1 = sg.edge(StIdx(0), Symbol::Token(grm.token_idx("a").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s1).items.len(), 7);
         state_exists(&grm, &sg.closed_state(s1), "X", 0, SIdx(1), vec!["a", "d", "e", "$"]);
         state_exists(&grm, &sg.closed_state(s1), "X", 1, SIdx(1), vec!["a", "d", "e", "$"]);
@@ -529,7 +529,7 @@ mod test {
         state_exists(&grm, &sg.closed_state(s1), "Z", 0, SIdx(0), vec!["c"]);
         state_exists(&grm, &sg.closed_state(s1), "T", 0, SIdx(0), vec!["a", "d", "e", "$"]);
 
-        let s7 = sg.edge(StIdx(0), Symbol::Term(grm.token_idx("b").unwrap())).unwrap();
+        let s7 = sg.edge(StIdx(0), Symbol::Token(grm.token_idx("b").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s7).items.len(), 7);
         state_exists(&grm, &sg.closed_state(s7), "X", 3, SIdx(1), vec!["a", "d", "e", "$"]);
         state_exists(&grm, &sg.closed_state(s7), "X", 4, SIdx(1), vec!["a", "d", "e", "$"]);
@@ -539,9 +539,9 @@ mod test {
         state_exists(&grm, &sg.closed_state(s1), "Z", 0, SIdx(0), vec!["c"]);
         state_exists(&grm, &sg.closed_state(s1), "T", 0, SIdx(0), vec!["a", "d", "e", "$"]);
 
-        let s4 = sg.edge(s1, Symbol::Term(grm.token_idx("u").unwrap())).unwrap();
+        let s4 = sg.edge(s1, Symbol::Token(grm.token_idx("u").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s4).items.len(), 8);
-        assert_eq!(s4, sg.edge(s7, Symbol::Term(grm.token_idx("u").unwrap())).unwrap());
+        assert_eq!(s4, sg.edge(s7, Symbol::Token(grm.token_idx("u").unwrap())).unwrap());
         state_exists(&grm, &sg.closed_state(s4), "Y", 1, SIdx(1), vec!["d", "e"]);
         state_exists(&grm, &sg.closed_state(s4), "T", 0, SIdx(1), vec!["a", "d", "e", "$"]);
         state_exists(&grm, &sg.closed_state(s4), "X", 0, SIdx(0), vec!["a", "d", "e"]);
@@ -551,16 +551,16 @@ mod test {
         state_exists(&grm, &sg.closed_state(s4), "X", 4, SIdx(0), vec!["a", "d", "e"]);
         state_exists(&grm, &sg.closed_state(s4), "X", 5, SIdx(0), vec!["a", "d", "e"]);
 
-        assert_eq!(s1, sg.edge(s4, Symbol::Term(grm.token_idx("a").unwrap())).unwrap());
-        assert_eq!(s7, sg.edge(s4, Symbol::Term(grm.token_idx("b").unwrap())).unwrap());
+        assert_eq!(s1, sg.edge(s4, Symbol::Token(grm.token_idx("a").unwrap())).unwrap());
+        assert_eq!(s7, sg.edge(s4, Symbol::Token(grm.token_idx("b").unwrap())).unwrap());
 
-        let s2 = sg.edge(s1, Symbol::Term(grm.token_idx("t").unwrap())).unwrap();
+        let s2 = sg.edge(s1, Symbol::Token(grm.token_idx("t").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s2).items.len(), 3);
         state_exists(&grm, &sg.closed_state(s2), "Y", 0, SIdx(1), vec!["d"]);
         state_exists(&grm, &sg.closed_state(s2), "Z", 0, SIdx(1), vec!["c"]);
         state_exists(&grm, &sg.closed_state(s2), "W", 0, SIdx(0), vec!["d"]);
 
-        let s3 = sg.edge(s2, Symbol::Term(grm.token_idx("u").unwrap())).unwrap();
+        let s3 = sg.edge(s2, Symbol::Token(grm.token_idx("u").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s3).items.len(), 3);
         state_exists(&grm, &sg.closed_state(s3), "Z", 0, SIdx(2), vec!["c"]);
         state_exists(&grm, &sg.closed_state(s3), "W", 0, SIdx(1), vec!["d"]);
@@ -571,17 +571,17 @@ mod test {
         state_exists(&grm, &sg.closed_state(s5), "Y", 1, SIdx(2), vec!["d", "e"]);
         state_exists(&grm, &sg.closed_state(s5), "T", 0, SIdx(2), vec!["a", "d", "e", "$"]);
 
-        let s6 = sg.edge(s5, Symbol::Term(grm.token_idx("a").unwrap())).unwrap();
+        let s6 = sg.edge(s5, Symbol::Token(grm.token_idx("a").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s6).items.len(), 1);
         state_exists(&grm, &sg.closed_state(s6), "T", 0, SIdx(3), vec!["a", "d", "e", "$"]);
 
-        let s8 = sg.edge(s7, Symbol::Term(grm.token_idx("t").unwrap())).unwrap();
+        let s8 = sg.edge(s7, Symbol::Token(grm.token_idx("t").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s8).items.len(), 3);
         state_exists(&grm, &sg.closed_state(s8), "Y", 0, SIdx(1), vec!["e"]);
         state_exists(&grm, &sg.closed_state(s8), "Z", 0, SIdx(1), vec!["d"]);
         state_exists(&grm, &sg.closed_state(s8), "W", 0, SIdx(0), vec!["e"]);
 
-        let s9 = sg.edge(s8, Symbol::Term(grm.token_idx("u").unwrap())).unwrap();
+        let s9 = sg.edge(s8, Symbol::Token(grm.token_idx("u").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s9).items.len(), 3);
         state_exists(&grm, &sg.closed_state(s9), "Z", 0, SIdx(2), vec!["d"]);
         state_exists(&grm, &sg.closed_state(s9), "W", 0, SIdx(1), vec!["e"]);
@@ -596,13 +596,13 @@ mod test {
         // Y-successor of S1 (and it's d-successor)
         let s1y = sg.edge(s1, Symbol::Rule(grm.rule_idx("Y").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s1y), "X", 0, SIdx(2), vec!["a", "d", "e", "$"]);
-        let s1yd = sg.edge(s1y, Symbol::Term(grm.token_idx("d").unwrap())).unwrap();
+        let s1yd = sg.edge(s1y, Symbol::Token(grm.token_idx("d").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s1yd), "X", 0, SIdx(3), vec!["a", "d", "e", "$"]);
 
         // Z-successor of S1 (and it's successor)
         let s1z = sg.edge(s1, Symbol::Rule(grm.rule_idx("Z").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s1z), "X", 1, SIdx(2), vec!["a", "d", "e", "$"]);
-        let s1zc = sg.edge(s1z, Symbol::Term(grm.token_idx("c").unwrap())).unwrap();
+        let s1zc = sg.edge(s1z, Symbol::Token(grm.token_idx("c").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s1zc), "X", 1, SIdx(3), vec!["a", "d", "e", "$"]);
 
         // T-successor of S1
@@ -612,13 +612,13 @@ mod test {
         // Y-successor of S7 (and it's d-successor)
         let s7y = sg.edge(s7, Symbol::Rule(grm.rule_idx("Y").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s7y), "X", 3, SIdx(2), vec!["a", "d", "e", "$"]);
-        let s7ye = sg.edge(s7y, Symbol::Term(grm.token_idx("e").unwrap())).unwrap();
+        let s7ye = sg.edge(s7y, Symbol::Token(grm.token_idx("e").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s7ye), "X", 3, SIdx(3), vec!["a", "d", "e", "$"]);
 
         // Z-successor of S7 (and it's successor)
         let s7z = sg.edge(s7, Symbol::Rule(grm.rule_idx("Z").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s7z), "X", 4, SIdx(2), vec!["a", "d", "e", "$"]);
-        let s7zd = sg.edge(s7z, Symbol::Term(grm.token_idx("d").unwrap())).unwrap();
+        let s7zd = sg.edge(s7z, Symbol::Token(grm.token_idx("d").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s7zd), "X", 4, SIdx(3), vec!["a", "d", "e", "$"]);
 
         // T-successor of S7

--- a/lrtable/src/lib/pager.rs
+++ b/lrtable/src/lib/pager.rs
@@ -161,7 +161,7 @@ where usize: AsPrimitive<StorageT>
 
     let mut state0 = Itemset::new(grm);
     let mut ctx = Vob::from_elem(usize::from(grm.tokens_len()), false);
-    ctx.set(usize::from(grm.eof_term_idx()), true);
+    ctx.set(usize::from(grm.eof_token_idx()), true);
     state0.add(grm.start_prod(), SIdx(StorageT::zero()), &ctx);
     closed_states.push(None);
     core_states.push(state0);

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -233,7 +233,7 @@ where usize: AsPrimitive<StorageT>
                 };
             if off == tidx {
                 if !bit {
-                    panic!("bit for terminal {}, dot {} is not set in production {} of {} when it should be",
+                    panic!("bit for token {}, dot {} is not set in production {} of {} when it should be",
                            t, usize::from(dot), prod_off, nt);
                 }
                 found = true;
@@ -241,7 +241,7 @@ where usize: AsPrimitive<StorageT>
             }
         }
         if !found && bit {
-            panic!("bit for terminal {}, dot {} is set in production {} of {} when it shouldn't be",
+            panic!("bit for token {}, dot {} is set in production {} of {} when it shouldn't be",
                    grm.term_name(tidx).unwrap(), usize::from(dot), prod_off, nt);
         }
     }

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -72,9 +72,9 @@ where usize: AsPrimitive<StorageT>
         Box::new((0..self.states.len()).map(|x| StIdx::from(x)))
     }
 
-    /// Return the itemset for closed state `st_idx`. Panics if `st_idx` doesn't exist.
-    pub fn closed_state(&self, st_idx: StIdx) -> &Itemset<StorageT> {
-        &self.states[usize::from(st_idx)].1
+    /// Return the itemset for closed state `stidx`. Panics if `stidx` doesn't exist.
+    pub fn closed_state(&self, stidx: StIdx) -> &Itemset<StorageT> {
+        &self.states[usize::from(stidx)].1
     }
 
     /// Return an iterator over all closed states in this `StateGraph`.
@@ -82,9 +82,9 @@ where usize: AsPrimitive<StorageT>
         Box::new(self.states.iter().map(|x| &x.1))
     }
 
-    /// Return the itemset for core state `st_idx` or `None` if it doesn't exist.
-    pub fn core_state(&self, st_idx: StIdx) -> &Itemset<StorageT> {
-        &self.states[usize::from(st_idx)].0
+    /// Return the itemset for core state `stidx` or `None` if it doesn't exist.
+    pub fn core_state(&self, stidx: StIdx) -> &Itemset<StorageT> {
+        &self.states[usize::from(stidx)].0
     }
 
     /// Return an iterator over all core states in this `StateGraph`.
@@ -99,16 +99,16 @@ where usize: AsPrimitive<StorageT>
         StIdx::from(self.states.len() as StIdxStorageT)
     }
 
-    /// Return the state pointed to by `sym` from `st_idx` or `None` otherwise.
-    pub fn edge(&self, st_idx: StIdx, sym: Symbol<StorageT>) -> Option<StIdx> {
-        self.edges.get(usize::from(st_idx))
+    /// Return the state pointed to by `sym` from `stidx` or `None` otherwise.
+    pub fn edge(&self, stidx: StIdx, sym: Symbol<StorageT>) -> Option<StIdx> {
+        self.edges.get(usize::from(stidx))
                   .and_then(|x| x.get(&sym))
                   .cloned()
     }
 
-    /// Return the edges for state `st_idx`. Panics if `st_idx` doesn't exist.
-    pub fn edges(&self, st_idx: StIdx) -> &HashMap<Symbol<StorageT>, StIdx> {
-        &self.edges[usize::from(st_idx)]
+    /// Return the edges for state `stidx`. Panics if `stidx` doesn't exist.
+    pub fn edges(&self, stidx: StIdx) -> &HashMap<Symbol<StorageT>, StIdx> {
+        &self.edges[usize::from(stidx)]
     }
 
     /// How many edges does this `StateGraph` contain?
@@ -128,20 +128,20 @@ where usize: AsPrimitive<StorageT>
              where usize: AsPrimitive<StorageT>
         {
             match sym {
-                Symbol::Rule(ntidx) => grm.rule_name(ntidx).to_string(),
+                Symbol::Rule(ridx) => grm.rule_name(ridx).to_string(),
                 Symbol::Token(tidx) => format!("'{}'", grm.token_name(tidx).unwrap_or(""))
             }
         }
 
         let mut o = String::new();
-        for (st_idx, &(ref core_st, ref closed_st)) in self.iter_stidxs()
+        for (stidx, &(ref core_st, ref closed_st)) in self.iter_stidxs()
                                                            .zip(self.states.iter()) {
-            if StIdxStorageT::from(st_idx) > 0 {
+            if StIdxStorageT::from(stidx) > 0 {
                 o.push_str(&"\n");
             }
             {
-                let padding = num_digits(self.all_states_len()) - num_digits(st_idx);
-                o.push_str(&format!("{}:{}", StIdxStorageT::from(st_idx), " ".repeat(padding)));
+                let padding = num_digits(self.all_states_len()) - num_digits(stidx);
+                o.push_str(&format!("{}:{}", StIdxStorageT::from(stidx), " ".repeat(padding)));
             }
 
             let st = if core_states {
@@ -149,7 +149,7 @@ where usize: AsPrimitive<StorageT>
             } else {
                 closed_st
             };
-            for (i, (&(p_idx, s_idx), ref ctx)) in st.items.iter().enumerate() {
+            for (i, (&(pidx, sidx), ref ctx)) in st.items.iter().enumerate() {
                 let padding = if i == 0 {
                     0
                 } else {
@@ -158,26 +158,26 @@ where usize: AsPrimitive<StorageT>
                 };
                 o.push_str(&format!("{} [{} ->",
                                     " ".repeat(padding),
-                                    grm.rule_name(grm.prod_to_rule(p_idx))));
-                for (is_idx, is_sym) in grm.prod(p_idx).iter().enumerate() {
-                    if is_idx == usize::from(s_idx) {
+                                    grm.rule_name(grm.prod_to_rule(pidx))));
+                for (i_sidx, i_ssym) in grm.prod(pidx).iter().enumerate() {
+                    if i_sidx == usize::from(sidx) {
                         o.push_str(" .");
                     }
-                    o.push_str(&format!(" {}", fmt_sym(&grm, *is_sym)));
+                    o.push_str(&format!(" {}", fmt_sym(&grm, *i_ssym)));
                 }
-                if usize::from(s_idx) == grm.prod(p_idx).len() {
+                if usize::from(sidx) == grm.prod(pidx).len() {
                     o.push_str(" .");
                 }
                 o.push_str(", {");
                 let mut seen_b = false;
-                for b_idx in ctx.iter_set_bits(..) {
+                for bidx in ctx.iter_set_bits(..) {
                     if seen_b {
                         o.push_str(", ");
                     } else {
                         seen_b = true;
                     }
-                    // Since ctx is exactly term_len bits long, the call to as_ is safe.
-                    let tidx = TIdx(b_idx.as_());
+                    // Since ctx is exactly tokens_len bits long, the call to as_ is safe.
+                    let tidx = TIdx(bidx.as_());
                     if tidx == grm.eof_token_idx() {
                         o.push_str("'$'");
                     } else {
@@ -186,11 +186,11 @@ where usize: AsPrimitive<StorageT>
                 }
                 o.push_str("}]");
             }
-            for (esym, e_st_idx) in self.edges(st_idx).iter() {
+            for (esym, e_stidx) in self.edges(stidx).iter() {
                 o.push_str(&format!("\n{}{} -> {}",
                                    " ".repeat(num_digits(self.all_states_len()) + 2),
                                    fmt_sym(&grm, *esym),
-                                   usize::from(*e_st_idx)));
+                                   usize::from(*e_stidx)));
             }
         }
         o

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -220,7 +220,7 @@ pub fn state_exists<StorageT: 'static + Hash + PrimInt + Unsigned>
                     la: Vec<&str>)
 where usize: AsPrimitive<StorageT>
 {
-    let ab_prod_off = grm.rule_to_prods(grm.nonterm_idx(nt).unwrap())[prod_off];
+    let ab_prod_off = grm.rule_to_prods(grm.rule_idx(nt).unwrap())[prod_off];
     let ctx = &is.items[&(ab_prod_off, dot)];
     for tidx in grm.iter_tidxs() {
         let bit = ctx[usize::from(tidx)];
@@ -271,14 +271,14 @@ mod test {
 
         // This follows the (not particularly logical) ordering of state numbers in the paper.
         let s0 = StIdx(0);
-        sg.edge(s0, Symbol::Nonterm(grm.nonterm_idx("A").unwrap())).unwrap(); // s1
+        sg.edge(s0, Symbol::Nonterm(grm.rule_idx("A").unwrap())).unwrap(); // s1
         let s2 = sg.edge(s0, Symbol::Term(grm.term_idx("a").unwrap())).unwrap();
         let s3 = sg.edge(s0, Symbol::Term(grm.term_idx("b").unwrap())).unwrap();
         let s5 = sg.edge(s0, Symbol::Term(grm.term_idx("OPEN_BRACKET").unwrap())).unwrap();
         assert_eq!(s2, sg.edge(s5, Symbol::Term(grm.term_idx("a").unwrap())).unwrap());
         assert_eq!(s3, sg.edge(s5, Symbol::Term(grm.term_idx("b").unwrap())).unwrap());
         assert_eq!(s5, sg.edge(s5, Symbol::Term(grm.term_idx("OPEN_BRACKET").unwrap())).unwrap());
-        let s4 = sg.edge(s5, Symbol::Nonterm(grm.nonterm_idx("A").unwrap())).unwrap();
+        let s4 = sg.edge(s5, Symbol::Nonterm(grm.rule_idx("A").unwrap())).unwrap();
         sg.edge(s4, Symbol::Term(grm.term_idx("CLOSE_BRACKET").unwrap())).unwrap(); // s6
     }
 }

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -220,7 +220,7 @@ pub fn state_exists<StorageT: 'static + Hash + PrimInt + Unsigned>
                     la: Vec<&str>)
 where usize: AsPrimitive<StorageT>
 {
-    let ab_prod_off = grm.nonterm_to_prods(grm.nonterm_idx(nt).unwrap())[prod_off];
+    let ab_prod_off = grm.rule_to_prods(grm.nonterm_idx(nt).unwrap())[prod_off];
     let ctx = &is.items[&(ab_prod_off, dot)];
     for tidx in grm.iter_tidxs() {
         let bit = ctx[usize::from(tidx)];

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -128,7 +128,7 @@ where usize: AsPrimitive<StorageT>
              where usize: AsPrimitive<StorageT>
         {
             match sym {
-                Symbol::Nonterm(ntidx) => grm.rule_name(ntidx).to_string(),
+                Symbol::Rule(ntidx) => grm.rule_name(ntidx).to_string(),
                 Symbol::Term(tidx) => format!("'{}'", grm.term_name(tidx).unwrap_or(""))
             }
         }
@@ -271,14 +271,14 @@ mod test {
 
         // This follows the (not particularly logical) ordering of state numbers in the paper.
         let s0 = StIdx(0);
-        sg.edge(s0, Symbol::Nonterm(grm.rule_idx("A").unwrap())).unwrap(); // s1
+        sg.edge(s0, Symbol::Rule(grm.rule_idx("A").unwrap())).unwrap(); // s1
         let s2 = sg.edge(s0, Symbol::Term(grm.term_idx("a").unwrap())).unwrap();
         let s3 = sg.edge(s0, Symbol::Term(grm.term_idx("b").unwrap())).unwrap();
         let s5 = sg.edge(s0, Symbol::Term(grm.term_idx("OPEN_BRACKET").unwrap())).unwrap();
         assert_eq!(s2, sg.edge(s5, Symbol::Term(grm.term_idx("a").unwrap())).unwrap());
         assert_eq!(s3, sg.edge(s5, Symbol::Term(grm.term_idx("b").unwrap())).unwrap());
         assert_eq!(s5, sg.edge(s5, Symbol::Term(grm.term_idx("OPEN_BRACKET").unwrap())).unwrap());
-        let s4 = sg.edge(s5, Symbol::Nonterm(grm.rule_idx("A").unwrap())).unwrap();
+        let s4 = sg.edge(s5, Symbol::Rule(grm.rule_idx("A").unwrap())).unwrap();
         sg.edge(s4, Symbol::Term(grm.term_idx("CLOSE_BRACKET").unwrap())).unwrap(); // s6
     }
 }

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -63,7 +63,7 @@ where usize: AsPrimitive<StorageT>
         StateGraph{states, edges}
     }
 
-    /// Return an iterator which produces (in order from `0..self.nonterms_len()`) all this
+    /// Return an iterator which produces (in order from `0..self.rules_len()`) all this
     /// grammar's valid `RIdx`s.
     pub fn iter_stidxs(&self) -> Box<dyn Iterator<Item=StIdx>>
     {

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -128,7 +128,7 @@ where usize: AsPrimitive<StorageT>
              where usize: AsPrimitive<StorageT>
         {
             match sym {
-                Symbol::Nonterm(ntidx) => grm.nonterm_name(ntidx).to_string(),
+                Symbol::Nonterm(ntidx) => grm.rule_name(ntidx).to_string(),
                 Symbol::Term(tidx) => format!("'{}'", grm.term_name(tidx).unwrap_or(""))
             }
         }
@@ -158,7 +158,7 @@ where usize: AsPrimitive<StorageT>
                 };
                 o.push_str(&format!("{} [{} ->",
                                     " ".repeat(padding),
-                                    grm.nonterm_name(grm.prod_to_nonterm(p_idx))));
+                                    grm.rule_name(grm.prod_to_nonterm(p_idx))));
                 for (is_idx, is_sym) in grm.prod(p_idx).iter().enumerate() {
                     if is_idx == usize::from(s_idx) {
                         o.push_str(" .");

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -129,7 +129,7 @@ where usize: AsPrimitive<StorageT>
         {
             match sym {
                 Symbol::Rule(ntidx) => grm.rule_name(ntidx).to_string(),
-                Symbol::Term(tidx) => format!("'{}'", grm.term_name(tidx).unwrap_or(""))
+                Symbol::Term(tidx) => format!("'{}'", grm.token_name(tidx).unwrap_or(""))
             }
         }
 
@@ -181,7 +181,7 @@ where usize: AsPrimitive<StorageT>
                     if tidx == grm.eof_token_idx() {
                         o.push_str("'$'");
                     } else {
-                        o.push_str(&format!("'{}'", grm.term_name(tidx).unwrap()));
+                        o.push_str(&format!("'{}'", grm.token_name(tidx).unwrap()));
                     }
                 }
                 o.push_str("}]");
@@ -242,7 +242,7 @@ where usize: AsPrimitive<StorageT>
         }
         if !found && bit {
             panic!("bit for token {}, dot {} is set in production {} of {} when it shouldn't be",
-                   grm.term_name(tidx).unwrap(), usize::from(dot), prod_off, nt);
+                   grm.token_name(tidx).unwrap(), usize::from(dot), prod_off, nt);
         }
     }
 }

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -229,7 +229,7 @@ where usize: AsPrimitive<StorageT>
             let off = if t == &"$" {
                     grm.eof_token_idx()
                 } else {
-                    grm.term_idx(t).unwrap()
+                    grm.token_idx(t).unwrap()
                 };
             if off == tidx {
                 if !bit {
@@ -272,13 +272,13 @@ mod test {
         // This follows the (not particularly logical) ordering of state numbers in the paper.
         let s0 = StIdx(0);
         sg.edge(s0, Symbol::Rule(grm.rule_idx("A").unwrap())).unwrap(); // s1
-        let s2 = sg.edge(s0, Symbol::Term(grm.term_idx("a").unwrap())).unwrap();
-        let s3 = sg.edge(s0, Symbol::Term(grm.term_idx("b").unwrap())).unwrap();
-        let s5 = sg.edge(s0, Symbol::Term(grm.term_idx("OPEN_BRACKET").unwrap())).unwrap();
-        assert_eq!(s2, sg.edge(s5, Symbol::Term(grm.term_idx("a").unwrap())).unwrap());
-        assert_eq!(s3, sg.edge(s5, Symbol::Term(grm.term_idx("b").unwrap())).unwrap());
-        assert_eq!(s5, sg.edge(s5, Symbol::Term(grm.term_idx("OPEN_BRACKET").unwrap())).unwrap());
+        let s2 = sg.edge(s0, Symbol::Term(grm.token_idx("a").unwrap())).unwrap();
+        let s3 = sg.edge(s0, Symbol::Term(grm.token_idx("b").unwrap())).unwrap();
+        let s5 = sg.edge(s0, Symbol::Term(grm.token_idx("OPEN_BRACKET").unwrap())).unwrap();
+        assert_eq!(s2, sg.edge(s5, Symbol::Term(grm.token_idx("a").unwrap())).unwrap());
+        assert_eq!(s3, sg.edge(s5, Symbol::Term(grm.token_idx("b").unwrap())).unwrap());
+        assert_eq!(s5, sg.edge(s5, Symbol::Term(grm.token_idx("OPEN_BRACKET").unwrap())).unwrap());
         let s4 = sg.edge(s5, Symbol::Rule(grm.rule_idx("A").unwrap())).unwrap();
-        sg.edge(s4, Symbol::Term(grm.term_idx("CLOSE_BRACKET").unwrap())).unwrap(); // s6
+        sg.edge(s4, Symbol::Term(grm.token_idx("CLOSE_BRACKET").unwrap())).unwrap(); // s6
     }
 }

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -64,7 +64,7 @@ where usize: AsPrimitive<StorageT>
     }
 
     /// Return an iterator which produces (in order from `0..self.nonterms_len()`) all this
-    /// grammar's valid `NTIdx`s.
+    /// grammar's valid `RIdx`s.
     pub fn iter_stidxs(&self) -> Box<dyn Iterator<Item=StIdx>>
     {
         // We can use as_ safely, because we know that we're only generating integers from

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -178,7 +178,7 @@ where usize: AsPrimitive<StorageT>
                     }
                     // Since ctx is exactly term_len bits long, the call to as_ is safe.
                     let tidx = TIdx(b_idx.as_());
-                    if tidx == grm.eof_term_idx() {
+                    if tidx == grm.eof_token_idx() {
                         o.push_str("'$'");
                     } else {
                         o.push_str(&format!("'{}'", grm.term_name(tidx).unwrap()));
@@ -227,7 +227,7 @@ where usize: AsPrimitive<StorageT>
         let mut found = false;
         for t in la.iter() {
             let off = if t == &"$" {
-                    grm.eof_term_idx()
+                    grm.eof_token_idx()
                 } else {
                     grm.term_idx(t).unwrap()
                 };

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -158,7 +158,7 @@ where usize: AsPrimitive<StorageT>
                 };
                 o.push_str(&format!("{} [{} ->",
                                     " ".repeat(padding),
-                                    grm.rule_name(grm.prod_to_nonterm(p_idx))));
+                                    grm.rule_name(grm.prod_to_rule(p_idx))));
                 for (is_idx, is_sym) in grm.prod(p_idx).iter().enumerate() {
                     if is_idx == usize::from(s_idx) {
                         o.push_str(" .");

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -129,7 +129,7 @@ where usize: AsPrimitive<StorageT>
         {
             match sym {
                 Symbol::Rule(ntidx) => grm.rule_name(ntidx).to_string(),
-                Symbol::Term(tidx) => format!("'{}'", grm.token_name(tidx).unwrap_or(""))
+                Symbol::Token(tidx) => format!("'{}'", grm.token_name(tidx).unwrap_or(""))
             }
         }
 
@@ -272,13 +272,13 @@ mod test {
         // This follows the (not particularly logical) ordering of state numbers in the paper.
         let s0 = StIdx(0);
         sg.edge(s0, Symbol::Rule(grm.rule_idx("A").unwrap())).unwrap(); // s1
-        let s2 = sg.edge(s0, Symbol::Term(grm.token_idx("a").unwrap())).unwrap();
-        let s3 = sg.edge(s0, Symbol::Term(grm.token_idx("b").unwrap())).unwrap();
-        let s5 = sg.edge(s0, Symbol::Term(grm.token_idx("OPEN_BRACKET").unwrap())).unwrap();
-        assert_eq!(s2, sg.edge(s5, Symbol::Term(grm.token_idx("a").unwrap())).unwrap());
-        assert_eq!(s3, sg.edge(s5, Symbol::Term(grm.token_idx("b").unwrap())).unwrap());
-        assert_eq!(s5, sg.edge(s5, Symbol::Term(grm.token_idx("OPEN_BRACKET").unwrap())).unwrap());
+        let s2 = sg.edge(s0, Symbol::Token(grm.token_idx("a").unwrap())).unwrap();
+        let s3 = sg.edge(s0, Symbol::Token(grm.token_idx("b").unwrap())).unwrap();
+        let s5 = sg.edge(s0, Symbol::Token(grm.token_idx("OPEN_BRACKET").unwrap())).unwrap();
+        assert_eq!(s2, sg.edge(s5, Symbol::Token(grm.token_idx("a").unwrap())).unwrap());
+        assert_eq!(s3, sg.edge(s5, Symbol::Token(grm.token_idx("b").unwrap())).unwrap());
+        assert_eq!(s5, sg.edge(s5, Symbol::Token(grm.token_idx("OPEN_BRACKET").unwrap())).unwrap());
         let s4 = sg.edge(s5, Symbol::Rule(grm.rule_idx("A").unwrap())).unwrap();
-        sg.edge(s4, Symbol::Term(grm.token_idx("CLOSE_BRACKET").unwrap())).unwrap(); // s6
+        sg.edge(s4, Symbol::Token(grm.token_idx("CLOSE_BRACKET").unwrap())).unwrap(); // s6
     }
 }

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -36,7 +36,7 @@ use std::hash::{Hash, BuildHasherDefault};
 use std::fmt::{self, Debug};
 use std::marker::PhantomData;
 
-use cfgrammar::{Grammar, PIdx, NTIdx, Symbol, TIdx};
+use cfgrammar::{Grammar, PIdx, RIdx, Symbol, TIdx};
 use cfgrammar::yacc::{AssocKind, YaccGrammar};
 use fnv::FnvHasher;
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
@@ -334,7 +334,7 @@ where usize: AsPrimitive<StorageT>
     }
 
     /// Return the goto state for `state_idx` and `nonterm_idx`, or `None` if there isn't any.
-    pub fn goto(&self, state_idx: StIdx, nonterm_idx: NTIdx<StorageT>) -> Option<StIdx> {
+    pub fn goto(&self, state_idx: StIdx, nonterm_idx: RIdx<StorageT>) -> Option<StIdx> {
         let off = (u32::from(state_idx) * self.nonterms_len) + u32::from(nonterm_idx);
         self.gotos.get(&off).and_then(|x| Some(*x))
     }

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -75,7 +75,7 @@ impl<StorageT> fmt::Display for StateTableError<StorageT> {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct StateTable<StorageT> {
     // For actions, we use a HashMap as a quick representation of a sparse table. We use the normal
-    // statetable representation where rows represent states and columns represent terminals. Thus
+    // statetable representation where rows represent states and columns represent tokens. Thus
     // the statetable:
     //        A         B
     //   0  shift 1
@@ -397,14 +397,14 @@ where usize: AsPrimitive<StorageT>
     let prod_k_prec = grm.prod_precedence(prod_k);
     match (term_k_prec, prod_k_prec) {
         (_, None) | (None, _) => {
-            // If the terminal and production don't both have precedences, we use Yacc's default
+            // If the token and production don't both have precedences, we use Yacc's default
             // resolution, which is in favour of the shift.
             e.insert(Action::Shift(state_j));
             shift_reduce += 1;
         },
         (Some(term_prec), Some(prod_prec)) => {
             if term_prec.level == prod_prec.level {
-                // Both terminal and production have the same level precedence, so we need to look
+                // Both token and production have the same level precedence, so we need to look
                 // at the precedence kind.
                 match (term_prec.kind, prod_prec.kind) {
                     (AssocKind::Left, AssocKind::Left) => {
@@ -425,7 +425,7 @@ where usize: AsPrimitive<StorageT>
                     }
                 }
             } else if term_prec.level > prod_prec.level {
-                // The terminal has higher level precedence, so resolve in favour of shift.
+                // The token has higher level precedence, so resolve in favour of shift.
                 e.insert(Action::Shift(state_j));
             }
             // If term_lev < prod_lev, then the production has higher level precedence and we keep

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -185,7 +185,7 @@ where usize: AsPrimitive<StorageT>
             assert!(StIdxStorageT::from(sg.all_states_len()).checked_mul(nt_len.into()).is_some());
             for (&sym, state_j) in sg.edges(state_i) {
                 match sym {
-                    Symbol::Nonterm(nonterm_i) => {
+                    Symbol::Rule(nonterm_i) => {
                         // Populate gotos
                         let off = (u32::from(state_i) * u32::from(nt_len)) + u32::from(nonterm_i);
                         debug_assert!(gotos.get(&off).is_none());
@@ -458,14 +458,14 @@ mod test {
         assert_eq!(sg.all_states_len(), StIdx(9));
 
         let s0 = StIdx(0);
-        let s1 = sg.edge(s0, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
-        let s2 = sg.edge(s0, Symbol::Nonterm(grm.rule_idx("Term").unwrap())).unwrap();
-        let s3 = sg.edge(s0, Symbol::Nonterm(grm.rule_idx("Factor").unwrap())).unwrap();
+        let s1 = sg.edge(s0, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
+        let s2 = sg.edge(s0, Symbol::Rule(grm.rule_idx("Term").unwrap())).unwrap();
+        let s3 = sg.edge(s0, Symbol::Rule(grm.rule_idx("Factor").unwrap())).unwrap();
         let s4 = sg.edge(s0, Symbol::Term(grm.term_idx("id").unwrap())).unwrap();
         let s5 = sg.edge(s2, Symbol::Term(grm.term_idx("-").unwrap())).unwrap();
         let s6 = sg.edge(s3, Symbol::Term(grm.term_idx("*").unwrap())).unwrap();
-        let s7 = sg.edge(s5, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
-        let s8 = sg.edge(s6, Symbol::Nonterm(grm.rule_idx("Term").unwrap())).unwrap();
+        let s7 = sg.edge(s5, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
+        let s8 = sg.edge(s6, Symbol::Rule(grm.rule_idx("Term").unwrap())).unwrap();
 
         let st = StateTable::new(&grm, &sg).unwrap();
 
@@ -558,11 +558,11 @@ mod test {
         assert_eq!(st.actions.len(), 15);
 
         let s0 = StIdx(0);
-        let s1 = sg.edge(s0, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
+        let s1 = sg.edge(s0, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
         let s3 = sg.edge(s1, Symbol::Term(grm.term_idx("+").unwrap())).unwrap();
         let s4 = sg.edge(s1, Symbol::Term(grm.term_idx("*").unwrap())).unwrap();
-        let s5 = sg.edge(s4, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
-        let s6 = sg.edge(s3, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
+        let s5 = sg.edge(s4, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
+        let s6 = sg.edge(s3, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
 
         assert_eq!(st.action(s5, grm.term_idx("+").unwrap()).unwrap(), Action::Shift(s3));
         assert_eq!(st.action(s5, grm.term_idx("*").unwrap()).unwrap(), Action::Shift(s4));
@@ -612,11 +612,11 @@ mod test {
         assert_eq!(st.actions.len(), 15);
 
         let s0 = StIdx(0);
-        let s1 = sg.edge(s0, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
+        let s1 = sg.edge(s0, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
         let s3 = sg.edge(s1, Symbol::Term(grm.term_idx("+").unwrap())).unwrap();
         let s4 = sg.edge(s1, Symbol::Term(grm.term_idx("*").unwrap())).unwrap();
-        let s5 = sg.edge(s4, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
-        let s6 = sg.edge(s3, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
+        let s5 = sg.edge(s4, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
+        let s6 = sg.edge(s3, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
 
         assert_eq!(st.action(s5, grm.term_idx("+").unwrap()).unwrap(),
                    Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[1]));
@@ -651,13 +651,13 @@ mod test {
         assert_eq!(st.actions.len(), 24);
 
         let s0 = StIdx(0);
-        let s1 = sg.edge(s0, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
+        let s1 = sg.edge(s0, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
         let s3 = sg.edge(s1, Symbol::Term(grm.term_idx("+").unwrap())).unwrap();
         let s4 = sg.edge(s1, Symbol::Term(grm.term_idx("*").unwrap())).unwrap();
         let s5 = sg.edge(s1, Symbol::Term(grm.term_idx("=").unwrap())).unwrap();
-        let s6 = sg.edge(s5, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
-        let s7 = sg.edge(s4, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
-        let s8 = sg.edge(s3, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
+        let s6 = sg.edge(s5, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
+        let s7 = sg.edge(s4, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
+        let s8 = sg.edge(s3, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
 
         assert_eq!(st.action(s6, grm.term_idx("+").unwrap()).unwrap(),
                    Action::Shift(s3));
@@ -707,15 +707,15 @@ mod test {
         assert_eq!(st.actions.len(), 34);
 
         let s0 = StIdx(0);
-        let s1 = sg.edge(s0, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
+        let s1 = sg.edge(s0, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
         let s3 = sg.edge(s1, Symbol::Term(grm.term_idx("+").unwrap())).unwrap();
         let s4 = sg.edge(s1, Symbol::Term(grm.term_idx("*").unwrap())).unwrap();
         let s5 = sg.edge(s1, Symbol::Term(grm.term_idx("=").unwrap())).unwrap();
         let s6 = sg.edge(s1, Symbol::Term(grm.term_idx("~").unwrap())).unwrap();
-        let s7 = sg.edge(s6, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
-        let s8 = sg.edge(s5, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
-        let s9 = sg.edge(s4, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
-        let s10 = sg.edge(s3, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
+        let s7 = sg.edge(s6, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
+        let s8 = sg.edge(s5, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
+        let s9 = sg.edge(s4, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
+        let s10 = sg.edge(s3, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
 
         assert_eq!(st.action(s7, grm.term_idx("+").unwrap()).unwrap(),
                    Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[3]));

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -333,9 +333,9 @@ where usize: AsPrimitive<StorageT>
                             phantom: PhantomData}
     }
 
-    /// Return the goto state for `state_idx` and `nonterm_idx`, or `None` if there isn't any.
-    pub fn goto(&self, state_idx: StIdx, nonterm_idx: RIdx<StorageT>) -> Option<StIdx> {
-        let off = (u32::from(state_idx) * self.rules_len) + u32::from(nonterm_idx);
+    /// Return the goto state for `state_idx` and `rule_idx`, or `None` if there isn't any.
+    pub fn goto(&self, state_idx: StIdx, rule_idx: RIdx<StorageT>) -> Option<StIdx> {
+        let off = (u32::from(state_idx) * self.rules_len) + u32::from(rule_idx);
         self.gotos.get(&off).and_then(|x| Some(*x))
     }
 }
@@ -458,21 +458,21 @@ mod test {
         assert_eq!(sg.all_states_len(), StIdx(9));
 
         let s0 = StIdx(0);
-        let s1 = sg.edge(s0, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
-        let s2 = sg.edge(s0, Symbol::Nonterm(grm.nonterm_idx("Term").unwrap())).unwrap();
-        let s3 = sg.edge(s0, Symbol::Nonterm(grm.nonterm_idx("Factor").unwrap())).unwrap();
+        let s1 = sg.edge(s0, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
+        let s2 = sg.edge(s0, Symbol::Nonterm(grm.rule_idx("Term").unwrap())).unwrap();
+        let s3 = sg.edge(s0, Symbol::Nonterm(grm.rule_idx("Factor").unwrap())).unwrap();
         let s4 = sg.edge(s0, Symbol::Term(grm.term_idx("id").unwrap())).unwrap();
         let s5 = sg.edge(s2, Symbol::Term(grm.term_idx("-").unwrap())).unwrap();
         let s6 = sg.edge(s3, Symbol::Term(grm.term_idx("*").unwrap())).unwrap();
-        let s7 = sg.edge(s5, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
-        let s8 = sg.edge(s6, Symbol::Nonterm(grm.nonterm_idx("Term").unwrap())).unwrap();
+        let s7 = sg.edge(s5, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
+        let s8 = sg.edge(s6, Symbol::Nonterm(grm.rule_idx("Term").unwrap())).unwrap();
 
         let st = StateTable::new(&grm, &sg).unwrap();
 
         // Actions
         assert_eq!(st.actions.len(), 15);
         let assert_reduce = |state_i: StIdx, term_i: TIdx<_>, rule: &str, prod_off: usize| {
-            let prod_i = grm.rule_to_prods(grm.nonterm_idx(rule).unwrap())[prod_off];
+            let prod_i = grm.rule_to_prods(grm.rule_idx(rule).unwrap())[prod_off];
             assert_eq!(st.action(state_i, term_i).unwrap(), Action::Reduce(prod_i.into()));
         };
 
@@ -505,7 +505,7 @@ mod test {
                                .collect::<HashSet<_>>();
         assert_eq!(st.state_shifts(s2).collect::<HashSet<_>>(), *s2_state_shifts);
 
-        let s4_core_reduces = &[grm.rule_to_prods(grm.nonterm_idx("Factor").unwrap())[0]]
+        let s4_core_reduces = &[grm.rule_to_prods(grm.rule_idx("Factor").unwrap())[0]]
                               .iter()
                               .cloned()
                               .collect::<HashSet<_>>();
@@ -513,14 +513,14 @@ mod test {
 
         // Gotos
         assert_eq!(st.gotos.len(), 8);
-        assert_eq!(st.goto(s0, grm.nonterm_idx("Expr").unwrap()).unwrap(), s1);
-        assert_eq!(st.goto(s0, grm.nonterm_idx("Term").unwrap()).unwrap(), s2);
-        assert_eq!(st.goto(s0, grm.nonterm_idx("Factor").unwrap()).unwrap(), s3);
-        assert_eq!(st.goto(s5, grm.nonterm_idx("Expr").unwrap()).unwrap(), s7);
-        assert_eq!(st.goto(s5, grm.nonterm_idx("Term").unwrap()).unwrap(), s2);
-        assert_eq!(st.goto(s5, grm.nonterm_idx("Factor").unwrap()).unwrap(), s3);
-        assert_eq!(st.goto(s6, grm.nonterm_idx("Term").unwrap()).unwrap(), s8);
-        assert_eq!(st.goto(s6, grm.nonterm_idx("Factor").unwrap()).unwrap(), s3);
+        assert_eq!(st.goto(s0, grm.rule_idx("Expr").unwrap()).unwrap(), s1);
+        assert_eq!(st.goto(s0, grm.rule_idx("Term").unwrap()).unwrap(), s2);
+        assert_eq!(st.goto(s0, grm.rule_idx("Factor").unwrap()).unwrap(), s3);
+        assert_eq!(st.goto(s5, grm.rule_idx("Expr").unwrap()).unwrap(), s7);
+        assert_eq!(st.goto(s5, grm.rule_idx("Term").unwrap()).unwrap(), s2);
+        assert_eq!(st.goto(s5, grm.rule_idx("Factor").unwrap()).unwrap(), s3);
+        assert_eq!(st.goto(s6, grm.rule_idx("Term").unwrap()).unwrap(), s8);
+        assert_eq!(st.goto(s6, grm.rule_idx("Factor").unwrap()).unwrap(), s3);
     }
 
     #[test]
@@ -541,7 +541,7 @@ mod test {
         let s4 = sg.edge(s0, Symbol::Term(grm.term_idx("a").unwrap())).unwrap();
 
         assert_eq!(st.action(s4, grm.term_idx("x").unwrap()).unwrap(),
-                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("B").unwrap())[0]));
+                   Action::Reduce(grm.rule_to_prods(grm.rule_idx("B").unwrap())[0]));
     }
 
     #[test]
@@ -558,11 +558,11 @@ mod test {
         assert_eq!(st.actions.len(), 15);
 
         let s0 = StIdx(0);
-        let s1 = sg.edge(s0, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
+        let s1 = sg.edge(s0, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
         let s3 = sg.edge(s1, Symbol::Term(grm.term_idx("+").unwrap())).unwrap();
         let s4 = sg.edge(s1, Symbol::Term(grm.term_idx("*").unwrap())).unwrap();
-        let s5 = sg.edge(s4, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
-        let s6 = sg.edge(s3, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
+        let s5 = sg.edge(s4, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
+        let s6 = sg.edge(s3, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
 
         assert_eq!(st.action(s5, grm.term_idx("+").unwrap()).unwrap(), Action::Shift(s3));
         assert_eq!(st.action(s5, grm.term_idx("*").unwrap()).unwrap(), Action::Shift(s4));
@@ -591,9 +591,9 @@ mod test {
         let s2 = sg.edge(s0, Symbol::Term(grm.term_idx("b").unwrap())).unwrap();
 
         assert_eq!(st.action(s1, grm.term_idx("c").unwrap()).unwrap(),
-                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("A").unwrap())[0]));
+                   Action::Reduce(grm.rule_to_prods(grm.rule_idx("A").unwrap())[0]));
         assert_eq!(st.action(s2, grm.term_idx("c").unwrap()).unwrap(),
-                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("B").unwrap())[1]));
+                   Action::Reduce(grm.rule_to_prods(grm.rule_idx("B").unwrap())[1]));
     }
 
     #[test]
@@ -612,25 +612,25 @@ mod test {
         assert_eq!(st.actions.len(), 15);
 
         let s0 = StIdx(0);
-        let s1 = sg.edge(s0, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
+        let s1 = sg.edge(s0, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
         let s3 = sg.edge(s1, Symbol::Term(grm.term_idx("+").unwrap())).unwrap();
         let s4 = sg.edge(s1, Symbol::Term(grm.term_idx("*").unwrap())).unwrap();
-        let s5 = sg.edge(s4, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
-        let s6 = sg.edge(s3, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
+        let s5 = sg.edge(s4, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
+        let s6 = sg.edge(s3, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
 
         assert_eq!(st.action(s5, grm.term_idx("+").unwrap()).unwrap(),
-                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
+                   Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[1]));
         assert_eq!(st.action(s5, grm.term_idx("*").unwrap()).unwrap(),
-                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
+                   Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[1]));
         assert_eq!(st.action(s5, grm.eof_term_idx()).unwrap(),
-                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
+                   Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[1]));
 
         assert_eq!(st.action(s6, grm.term_idx("+").unwrap()).unwrap(),
-                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[0]));
+                   Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[0]));
         assert_eq!(st.action(s6, grm.term_idx("*").unwrap()).unwrap(),
                    Action::Shift(s4));
         assert_eq!(st.action(s6, grm.eof_term_idx()).unwrap(),
-                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[0]));
+                   Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[0]));
     }
 
     #[test]
@@ -651,13 +651,13 @@ mod test {
         assert_eq!(st.actions.len(), 24);
 
         let s0 = StIdx(0);
-        let s1 = sg.edge(s0, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
+        let s1 = sg.edge(s0, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
         let s3 = sg.edge(s1, Symbol::Term(grm.term_idx("+").unwrap())).unwrap();
         let s4 = sg.edge(s1, Symbol::Term(grm.term_idx("*").unwrap())).unwrap();
         let s5 = sg.edge(s1, Symbol::Term(grm.term_idx("=").unwrap())).unwrap();
-        let s6 = sg.edge(s5, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
-        let s7 = sg.edge(s4, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
-        let s8 = sg.edge(s3, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
+        let s6 = sg.edge(s5, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
+        let s7 = sg.edge(s4, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
+        let s8 = sg.edge(s3, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
 
         assert_eq!(st.action(s6, grm.term_idx("+").unwrap()).unwrap(),
                    Action::Shift(s3));
@@ -666,25 +666,25 @@ mod test {
         assert_eq!(st.action(s6, grm.term_idx("=").unwrap()).unwrap(),
                    Action::Shift(s5));
         assert_eq!(st.action(s6, grm.eof_term_idx()).unwrap(),
-                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[2]));
+                   Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[2]));
 
         assert_eq!(st.action(s7, grm.term_idx("+").unwrap()).unwrap(),
-                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
+                   Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[1]));
         assert_eq!(st.action(s7, grm.term_idx("*").unwrap()).unwrap(),
-                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
+                   Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[1]));
         assert_eq!(st.action(s7, grm.term_idx("=").unwrap()).unwrap(),
-                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
+                   Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[1]));
         assert_eq!(st.action(s7, grm.eof_term_idx()).unwrap(),
-                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
+                   Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[1]));
 
         assert_eq!(st.action(s8, grm.term_idx("+").unwrap()).unwrap(),
-                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[0]));
+                   Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[0]));
         assert_eq!(st.action(s8, grm.term_idx("*").unwrap()).unwrap(),
                    Action::Shift(s4));
         assert_eq!(st.action(s8, grm.term_idx("=").unwrap()).unwrap(),
-                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[0]));
+                   Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[0]));
         assert_eq!(st.action(s8, grm.eof_term_idx()).unwrap(),
-                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[0]));
+                   Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[0]));
     }
 
     #[test]
@@ -707,24 +707,24 @@ mod test {
         assert_eq!(st.actions.len(), 34);
 
         let s0 = StIdx(0);
-        let s1 = sg.edge(s0, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
+        let s1 = sg.edge(s0, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
         let s3 = sg.edge(s1, Symbol::Term(grm.term_idx("+").unwrap())).unwrap();
         let s4 = sg.edge(s1, Symbol::Term(grm.term_idx("*").unwrap())).unwrap();
         let s5 = sg.edge(s1, Symbol::Term(grm.term_idx("=").unwrap())).unwrap();
         let s6 = sg.edge(s1, Symbol::Term(grm.term_idx("~").unwrap())).unwrap();
-        let s7 = sg.edge(s6, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
-        let s8 = sg.edge(s5, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
-        let s9 = sg.edge(s4, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
-        let s10 = sg.edge(s3, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
+        let s7 = sg.edge(s6, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
+        let s8 = sg.edge(s5, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
+        let s9 = sg.edge(s4, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
+        let s10 = sg.edge(s3, Symbol::Nonterm(grm.rule_idx("Expr").unwrap())).unwrap();
 
         assert_eq!(st.action(s7, grm.term_idx("+").unwrap()).unwrap(),
-                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[3]));
+                   Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[3]));
         assert_eq!(st.action(s7, grm.term_idx("*").unwrap()).unwrap(),
-                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[3]));
+                   Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[3]));
         assert_eq!(st.action(s7, grm.term_idx("=").unwrap()).unwrap(),
-                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[3]));
+                   Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[3]));
         assert_eq!(st.action(s7, grm.eof_term_idx()).unwrap(),
-                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[3]));
+                   Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[3]));
 
         assert_eq!(st.action(s8, grm.term_idx("+").unwrap()).unwrap(),
                    Action::Shift(s3));
@@ -735,29 +735,29 @@ mod test {
         assert_eq!(st.action(s8, grm.term_idx("~").unwrap()).unwrap(),
                    Action::Shift(s6));
         assert_eq!(st.action(s8, grm.eof_term_idx()).unwrap(),
-                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[2]));
+                   Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[2]));
 
         assert_eq!(st.action(s9, grm.term_idx("+").unwrap()).unwrap(),
-                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
+                   Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[1]));
         assert_eq!(st.action(s9, grm.term_idx("*").unwrap()).unwrap(),
-                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
+                   Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[1]));
         assert_eq!(st.action(s9, grm.term_idx("=").unwrap()).unwrap(),
-                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
+                   Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[1]));
         assert_eq!(st.action(s9, grm.term_idx("~").unwrap()).unwrap(),
                    Action::Shift(s6));
         assert_eq!(st.action(s9, grm.eof_term_idx()).unwrap(),
-                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
+                   Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[1]));
 
         assert_eq!(st.action(s10, grm.term_idx("+").unwrap()).unwrap(),
-                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[0]));
+                   Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[0]));
         assert_eq!(st.action(s10, grm.term_idx("*").unwrap()).unwrap(),
                    Action::Shift(s4));
         assert_eq!(st.action(s10, grm.term_idx("=").unwrap()).unwrap(),
-                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[0]));
+                   Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[0]));
         assert_eq!(st.action(s10, grm.term_idx("~").unwrap()).unwrap(),
                    Action::Shift(s6));
         assert_eq!(st.action(s10, grm.eof_term_idx()).unwrap(),
-                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[0]));
+                   Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[0]));
     }
 
     #[test]

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -472,7 +472,7 @@ mod test {
         // Actions
         assert_eq!(st.actions.len(), 15);
         let assert_reduce = |state_i: StIdx, term_i: TIdx<_>, rule: &str, prod_off: usize| {
-            let prod_i = grm.nonterm_to_prods(grm.nonterm_idx(rule).unwrap())[prod_off];
+            let prod_i = grm.rule_to_prods(grm.nonterm_idx(rule).unwrap())[prod_off];
             assert_eq!(st.action(state_i, term_i).unwrap(), Action::Reduce(prod_i.into()));
         };
 
@@ -505,7 +505,7 @@ mod test {
                                .collect::<HashSet<_>>();
         assert_eq!(st.state_shifts(s2).collect::<HashSet<_>>(), *s2_state_shifts);
 
-        let s4_core_reduces = &[grm.nonterm_to_prods(grm.nonterm_idx("Factor").unwrap())[0]]
+        let s4_core_reduces = &[grm.rule_to_prods(grm.nonterm_idx("Factor").unwrap())[0]]
                               .iter()
                               .cloned()
                               .collect::<HashSet<_>>();
@@ -541,7 +541,7 @@ mod test {
         let s4 = sg.edge(s0, Symbol::Term(grm.term_idx("a").unwrap())).unwrap();
 
         assert_eq!(st.action(s4, grm.term_idx("x").unwrap()).unwrap(),
-                   Action::Reduce(grm.nonterm_to_prods(grm.nonterm_idx("B").unwrap())[0]));
+                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("B").unwrap())[0]));
     }
 
     #[test]
@@ -591,9 +591,9 @@ mod test {
         let s2 = sg.edge(s0, Symbol::Term(grm.term_idx("b").unwrap())).unwrap();
 
         assert_eq!(st.action(s1, grm.term_idx("c").unwrap()).unwrap(),
-                   Action::Reduce(grm.nonterm_to_prods(grm.nonterm_idx("A").unwrap())[0]));
+                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("A").unwrap())[0]));
         assert_eq!(st.action(s2, grm.term_idx("c").unwrap()).unwrap(),
-                   Action::Reduce(grm.nonterm_to_prods(grm.nonterm_idx("B").unwrap())[1]));
+                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("B").unwrap())[1]));
     }
 
     #[test]
@@ -619,18 +619,18 @@ mod test {
         let s6 = sg.edge(s3, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
 
         assert_eq!(st.action(s5, grm.term_idx("+").unwrap()).unwrap(),
-                   Action::Reduce(grm.nonterm_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
+                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
         assert_eq!(st.action(s5, grm.term_idx("*").unwrap()).unwrap(),
-                   Action::Reduce(grm.nonterm_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
+                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
         assert_eq!(st.action(s5, grm.eof_term_idx()).unwrap(),
-                   Action::Reduce(grm.nonterm_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
+                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
 
         assert_eq!(st.action(s6, grm.term_idx("+").unwrap()).unwrap(),
-                   Action::Reduce(grm.nonterm_to_prods(grm.nonterm_idx("Expr").unwrap())[0]));
+                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[0]));
         assert_eq!(st.action(s6, grm.term_idx("*").unwrap()).unwrap(),
                    Action::Shift(s4));
         assert_eq!(st.action(s6, grm.eof_term_idx()).unwrap(),
-                   Action::Reduce(grm.nonterm_to_prods(grm.nonterm_idx("Expr").unwrap())[0]));
+                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[0]));
     }
 
     #[test]
@@ -666,25 +666,25 @@ mod test {
         assert_eq!(st.action(s6, grm.term_idx("=").unwrap()).unwrap(),
                    Action::Shift(s5));
         assert_eq!(st.action(s6, grm.eof_term_idx()).unwrap(),
-                   Action::Reduce(grm.nonterm_to_prods(grm.nonterm_idx("Expr").unwrap())[2]));
+                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[2]));
 
         assert_eq!(st.action(s7, grm.term_idx("+").unwrap()).unwrap(),
-                   Action::Reduce(grm.nonterm_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
+                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
         assert_eq!(st.action(s7, grm.term_idx("*").unwrap()).unwrap(),
-                   Action::Reduce(grm.nonterm_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
+                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
         assert_eq!(st.action(s7, grm.term_idx("=").unwrap()).unwrap(),
-                   Action::Reduce(grm.nonterm_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
+                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
         assert_eq!(st.action(s7, grm.eof_term_idx()).unwrap(),
-                   Action::Reduce(grm.nonterm_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
+                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
 
         assert_eq!(st.action(s8, grm.term_idx("+").unwrap()).unwrap(),
-                   Action::Reduce(grm.nonterm_to_prods(grm.nonterm_idx("Expr").unwrap())[0]));
+                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[0]));
         assert_eq!(st.action(s8, grm.term_idx("*").unwrap()).unwrap(),
                    Action::Shift(s4));
         assert_eq!(st.action(s8, grm.term_idx("=").unwrap()).unwrap(),
-                   Action::Reduce(grm.nonterm_to_prods(grm.nonterm_idx("Expr").unwrap())[0]));
+                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[0]));
         assert_eq!(st.action(s8, grm.eof_term_idx()).unwrap(),
-                   Action::Reduce(grm.nonterm_to_prods(grm.nonterm_idx("Expr").unwrap())[0]));
+                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[0]));
     }
 
     #[test]
@@ -718,13 +718,13 @@ mod test {
         let s10 = sg.edge(s3, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
 
         assert_eq!(st.action(s7, grm.term_idx("+").unwrap()).unwrap(),
-                   Action::Reduce(grm.nonterm_to_prods(grm.nonterm_idx("Expr").unwrap())[3]));
+                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[3]));
         assert_eq!(st.action(s7, grm.term_idx("*").unwrap()).unwrap(),
-                   Action::Reduce(grm.nonterm_to_prods(grm.nonterm_idx("Expr").unwrap())[3]));
+                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[3]));
         assert_eq!(st.action(s7, grm.term_idx("=").unwrap()).unwrap(),
-                   Action::Reduce(grm.nonterm_to_prods(grm.nonterm_idx("Expr").unwrap())[3]));
+                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[3]));
         assert_eq!(st.action(s7, grm.eof_term_idx()).unwrap(),
-                   Action::Reduce(grm.nonterm_to_prods(grm.nonterm_idx("Expr").unwrap())[3]));
+                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[3]));
 
         assert_eq!(st.action(s8, grm.term_idx("+").unwrap()).unwrap(),
                    Action::Shift(s3));
@@ -735,29 +735,29 @@ mod test {
         assert_eq!(st.action(s8, grm.term_idx("~").unwrap()).unwrap(),
                    Action::Shift(s6));
         assert_eq!(st.action(s8, grm.eof_term_idx()).unwrap(),
-                   Action::Reduce(grm.nonterm_to_prods(grm.nonterm_idx("Expr").unwrap())[2]));
+                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[2]));
 
         assert_eq!(st.action(s9, grm.term_idx("+").unwrap()).unwrap(),
-                   Action::Reduce(grm.nonterm_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
+                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
         assert_eq!(st.action(s9, grm.term_idx("*").unwrap()).unwrap(),
-                   Action::Reduce(grm.nonterm_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
+                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
         assert_eq!(st.action(s9, grm.term_idx("=").unwrap()).unwrap(),
-                   Action::Reduce(grm.nonterm_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
+                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
         assert_eq!(st.action(s9, grm.term_idx("~").unwrap()).unwrap(),
                    Action::Shift(s6));
         assert_eq!(st.action(s9, grm.eof_term_idx()).unwrap(),
-                   Action::Reduce(grm.nonterm_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
+                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[1]));
 
         assert_eq!(st.action(s10, grm.term_idx("+").unwrap()).unwrap(),
-                   Action::Reduce(grm.nonterm_to_prods(grm.nonterm_idx("Expr").unwrap())[0]));
+                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[0]));
         assert_eq!(st.action(s10, grm.term_idx("*").unwrap()).unwrap(),
                    Action::Shift(s4));
         assert_eq!(st.action(s10, grm.term_idx("=").unwrap()).unwrap(),
-                   Action::Reduce(grm.nonterm_to_prods(grm.nonterm_idx("Expr").unwrap())[0]));
+                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[0]));
         assert_eq!(st.action(s10, grm.term_idx("~").unwrap()).unwrap(),
                    Action::Shift(s6));
         assert_eq!(st.action(s10, grm.eof_term_idx()).unwrap(),
-                   Action::Reduce(grm.nonterm_to_prods(grm.nonterm_idx("Expr").unwrap())[0]));
+                   Action::Reduce(grm.rule_to_prods(grm.nonterm_idx("Expr").unwrap())[0]));
     }
 
     #[test]

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -141,7 +141,7 @@ where usize: AsPrimitive<StorageT>
                         Entry::Occupied(mut e) => {
                             match *e.get_mut() {
                                 Action::Reduce(prod_j) => {
-                                    if prod_i == grm.start_prod() && term_i == usize::from(grm.eof_term_idx()) {
+                                    if prod_i == grm.start_prod() && term_i == usize::from(grm.eof_token_idx()) {
                                         return Err(StateTableError{
                                             kind: StateTableErrorKind::AcceptReduceConflict,
                                             prod_idx: prod_i
@@ -167,7 +167,7 @@ where usize: AsPrimitive<StorageT>
                             }
                         }
                         Entry::Vacant(e) => {
-                            if prod_i == grm.start_prod() && term_i == usize::from(grm.eof_term_idx()) {
+                            if prod_i == grm.start_prod() && term_i == usize::from(grm.eof_token_idx()) {
                                 assert!(final_state.is_none());
                                 final_state = Some(state_i);
                                 e.insert(Action::Accept);
@@ -477,26 +477,26 @@ mod test {
         };
 
         assert_eq!(st.action(s0, grm.term_idx("id").unwrap()).unwrap(), Action::Shift(s4));
-        assert_eq!(st.action(s1, grm.eof_term_idx()).unwrap(), Action::Accept);
+        assert_eq!(st.action(s1, grm.eof_token_idx()).unwrap(), Action::Accept);
         assert_eq!(st.final_state, s1);
         assert_eq!(st.action(s2, grm.term_idx("-").unwrap()).unwrap(), Action::Shift(s5));
-        assert_reduce(s2, grm.eof_term_idx(), "Expr", 1);
+        assert_reduce(s2, grm.eof_token_idx(), "Expr", 1);
         assert_reduce(s3, grm.term_idx("-").unwrap(), "Term", 1);
         assert_eq!(st.action(s3, grm.term_idx("*").unwrap()).unwrap(), Action::Shift(s6));
-        assert_reduce(s3, grm.eof_term_idx(), "Term", 1);
+        assert_reduce(s3, grm.eof_token_idx(), "Term", 1);
         assert_reduce(s4, grm.term_idx("-").unwrap(), "Factor", 0);
         assert_reduce(s4, grm.term_idx("*").unwrap(), "Factor", 0);
-        assert_reduce(s4, grm.eof_term_idx(), "Factor", 0);
+        assert_reduce(s4, grm.eof_token_idx(), "Factor", 0);
         assert_eq!(st.action(s5, grm.term_idx("id").unwrap()).unwrap(), Action::Shift(s4));
         assert_eq!(st.action(s6, grm.term_idx("id").unwrap()).unwrap(), Action::Shift(s4));
-        assert_reduce(s7, grm.eof_term_idx(), "Expr", 0);
+        assert_reduce(s7, grm.eof_token_idx(), "Expr", 0);
         assert_reduce(s8, grm.term_idx("-").unwrap(), "Term", 0);
-        assert_reduce(s8, grm.eof_term_idx(), "Term", 0);
+        assert_reduce(s8, grm.eof_token_idx(), "Term", 0);
 
         let mut s4_actions = HashSet::new();
         s4_actions.extend(&[grm.term_idx("-").unwrap(),
                             grm.term_idx("*").unwrap(),
-                            grm.eof_term_idx()]);
+                            grm.eof_token_idx()]);
         assert_eq!(st.state_actions(s4).collect::<HashSet<_>>(), s4_actions);
 
         let s2_state_shifts = &[grm.term_idx("-").unwrap()]
@@ -622,14 +622,14 @@ mod test {
                    Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[1]));
         assert_eq!(st.action(s5, grm.term_idx("*").unwrap()).unwrap(),
                    Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[1]));
-        assert_eq!(st.action(s5, grm.eof_term_idx()).unwrap(),
+        assert_eq!(st.action(s5, grm.eof_token_idx()).unwrap(),
                    Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[1]));
 
         assert_eq!(st.action(s6, grm.term_idx("+").unwrap()).unwrap(),
                    Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[0]));
         assert_eq!(st.action(s6, grm.term_idx("*").unwrap()).unwrap(),
                    Action::Shift(s4));
-        assert_eq!(st.action(s6, grm.eof_term_idx()).unwrap(),
+        assert_eq!(st.action(s6, grm.eof_token_idx()).unwrap(),
                    Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[0]));
     }
 
@@ -665,7 +665,7 @@ mod test {
                    Action::Shift(s4));
         assert_eq!(st.action(s6, grm.term_idx("=").unwrap()).unwrap(),
                    Action::Shift(s5));
-        assert_eq!(st.action(s6, grm.eof_term_idx()).unwrap(),
+        assert_eq!(st.action(s6, grm.eof_token_idx()).unwrap(),
                    Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[2]));
 
         assert_eq!(st.action(s7, grm.term_idx("+").unwrap()).unwrap(),
@@ -674,7 +674,7 @@ mod test {
                    Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[1]));
         assert_eq!(st.action(s7, grm.term_idx("=").unwrap()).unwrap(),
                    Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[1]));
-        assert_eq!(st.action(s7, grm.eof_term_idx()).unwrap(),
+        assert_eq!(st.action(s7, grm.eof_token_idx()).unwrap(),
                    Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[1]));
 
         assert_eq!(st.action(s8, grm.term_idx("+").unwrap()).unwrap(),
@@ -683,7 +683,7 @@ mod test {
                    Action::Shift(s4));
         assert_eq!(st.action(s8, grm.term_idx("=").unwrap()).unwrap(),
                    Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[0]));
-        assert_eq!(st.action(s8, grm.eof_term_idx()).unwrap(),
+        assert_eq!(st.action(s8, grm.eof_token_idx()).unwrap(),
                    Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[0]));
     }
 
@@ -723,7 +723,7 @@ mod test {
                    Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[3]));
         assert_eq!(st.action(s7, grm.term_idx("=").unwrap()).unwrap(),
                    Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[3]));
-        assert_eq!(st.action(s7, grm.eof_term_idx()).unwrap(),
+        assert_eq!(st.action(s7, grm.eof_token_idx()).unwrap(),
                    Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[3]));
 
         assert_eq!(st.action(s8, grm.term_idx("+").unwrap()).unwrap(),
@@ -734,7 +734,7 @@ mod test {
                    Action::Shift(s5));
         assert_eq!(st.action(s8, grm.term_idx("~").unwrap()).unwrap(),
                    Action::Shift(s6));
-        assert_eq!(st.action(s8, grm.eof_term_idx()).unwrap(),
+        assert_eq!(st.action(s8, grm.eof_token_idx()).unwrap(),
                    Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[2]));
 
         assert_eq!(st.action(s9, grm.term_idx("+").unwrap()).unwrap(),
@@ -745,7 +745,7 @@ mod test {
                    Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[1]));
         assert_eq!(st.action(s9, grm.term_idx("~").unwrap()).unwrap(),
                    Action::Shift(s6));
-        assert_eq!(st.action(s9, grm.eof_term_idx()).unwrap(),
+        assert_eq!(st.action(s9, grm.eof_token_idx()).unwrap(),
                    Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[1]));
 
         assert_eq!(st.action(s10, grm.term_idx("+").unwrap()).unwrap(),
@@ -756,7 +756,7 @@ mod test {
                    Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[0]));
         assert_eq!(st.action(s10, grm.term_idx("~").unwrap()).unwrap(),
                    Action::Shift(s6));
-        assert_eq!(st.action(s10, grm.eof_term_idx()).unwrap(),
+        assert_eq!(st.action(s10, grm.eof_token_idx()).unwrap(),
                    Action::Reduce(grm.rule_to_prods(grm.rule_idx("Expr").unwrap())[0]));
     }
 

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -191,7 +191,7 @@ where usize: AsPrimitive<StorageT>
                         debug_assert!(gotos.get(&off).is_none());
                         gotos.insert(off, *state_j);
                     },
-                    Symbol::Term(term_k) => {
+                    Symbol::Token(term_k) => {
                         // Populate shifts
                         let off = actions_offset(grm.tokens_len(), state_i, term_k);
                         state_actions.set(off as usize, true);
@@ -461,9 +461,9 @@ mod test {
         let s1 = sg.edge(s0, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
         let s2 = sg.edge(s0, Symbol::Rule(grm.rule_idx("Term").unwrap())).unwrap();
         let s3 = sg.edge(s0, Symbol::Rule(grm.rule_idx("Factor").unwrap())).unwrap();
-        let s4 = sg.edge(s0, Symbol::Term(grm.token_idx("id").unwrap())).unwrap();
-        let s5 = sg.edge(s2, Symbol::Term(grm.token_idx("-").unwrap())).unwrap();
-        let s6 = sg.edge(s3, Symbol::Term(grm.token_idx("*").unwrap())).unwrap();
+        let s4 = sg.edge(s0, Symbol::Token(grm.token_idx("id").unwrap())).unwrap();
+        let s5 = sg.edge(s2, Symbol::Token(grm.token_idx("-").unwrap())).unwrap();
+        let s6 = sg.edge(s3, Symbol::Token(grm.token_idx("*").unwrap())).unwrap();
         let s7 = sg.edge(s5, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
         let s8 = sg.edge(s6, Symbol::Rule(grm.rule_idx("Term").unwrap())).unwrap();
 
@@ -538,7 +538,7 @@ mod test {
 
         // We only extract the states necessary to test those rules affected by the reduce/reduce.
         let s0 = StIdx(0);
-        let s4 = sg.edge(s0, Symbol::Term(grm.token_idx("a").unwrap())).unwrap();
+        let s4 = sg.edge(s0, Symbol::Token(grm.token_idx("a").unwrap())).unwrap();
 
         assert_eq!(st.action(s4, grm.token_idx("x").unwrap()).unwrap(),
                    Action::Reduce(grm.rule_to_prods(grm.rule_idx("B").unwrap())[0]));
@@ -559,8 +559,8 @@ mod test {
 
         let s0 = StIdx(0);
         let s1 = sg.edge(s0, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
-        let s3 = sg.edge(s1, Symbol::Term(grm.token_idx("+").unwrap())).unwrap();
-        let s4 = sg.edge(s1, Symbol::Term(grm.token_idx("*").unwrap())).unwrap();
+        let s3 = sg.edge(s1, Symbol::Token(grm.token_idx("+").unwrap())).unwrap();
+        let s4 = sg.edge(s1, Symbol::Token(grm.token_idx("*").unwrap())).unwrap();
         let s5 = sg.edge(s4, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
         let s6 = sg.edge(s3, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
 
@@ -587,8 +587,8 @@ mod test {
         let sg = pager_stategraph(&grm);
         let st = StateTable::new(&grm, &sg).unwrap();
         let s0 = StIdx(0);
-        let s1 = sg.edge(s0, Symbol::Term(grm.token_idx("a").unwrap())).unwrap();
-        let s2 = sg.edge(s0, Symbol::Term(grm.token_idx("b").unwrap())).unwrap();
+        let s1 = sg.edge(s0, Symbol::Token(grm.token_idx("a").unwrap())).unwrap();
+        let s2 = sg.edge(s0, Symbol::Token(grm.token_idx("b").unwrap())).unwrap();
 
         assert_eq!(st.action(s1, grm.token_idx("c").unwrap()).unwrap(),
                    Action::Reduce(grm.rule_to_prods(grm.rule_idx("A").unwrap())[0]));
@@ -613,8 +613,8 @@ mod test {
 
         let s0 = StIdx(0);
         let s1 = sg.edge(s0, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
-        let s3 = sg.edge(s1, Symbol::Term(grm.token_idx("+").unwrap())).unwrap();
-        let s4 = sg.edge(s1, Symbol::Term(grm.token_idx("*").unwrap())).unwrap();
+        let s3 = sg.edge(s1, Symbol::Token(grm.token_idx("+").unwrap())).unwrap();
+        let s4 = sg.edge(s1, Symbol::Token(grm.token_idx("*").unwrap())).unwrap();
         let s5 = sg.edge(s4, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
         let s6 = sg.edge(s3, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
 
@@ -652,9 +652,9 @@ mod test {
 
         let s0 = StIdx(0);
         let s1 = sg.edge(s0, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
-        let s3 = sg.edge(s1, Symbol::Term(grm.token_idx("+").unwrap())).unwrap();
-        let s4 = sg.edge(s1, Symbol::Term(grm.token_idx("*").unwrap())).unwrap();
-        let s5 = sg.edge(s1, Symbol::Term(grm.token_idx("=").unwrap())).unwrap();
+        let s3 = sg.edge(s1, Symbol::Token(grm.token_idx("+").unwrap())).unwrap();
+        let s4 = sg.edge(s1, Symbol::Token(grm.token_idx("*").unwrap())).unwrap();
+        let s5 = sg.edge(s1, Symbol::Token(grm.token_idx("=").unwrap())).unwrap();
         let s6 = sg.edge(s5, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
         let s7 = sg.edge(s4, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
         let s8 = sg.edge(s3, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
@@ -708,10 +708,10 @@ mod test {
 
         let s0 = StIdx(0);
         let s1 = sg.edge(s0, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
-        let s3 = sg.edge(s1, Symbol::Term(grm.token_idx("+").unwrap())).unwrap();
-        let s4 = sg.edge(s1, Symbol::Term(grm.token_idx("*").unwrap())).unwrap();
-        let s5 = sg.edge(s1, Symbol::Term(grm.token_idx("=").unwrap())).unwrap();
-        let s6 = sg.edge(s1, Symbol::Term(grm.token_idx("~").unwrap())).unwrap();
+        let s3 = sg.edge(s1, Symbol::Token(grm.token_idx("+").unwrap())).unwrap();
+        let s4 = sg.edge(s1, Symbol::Token(grm.token_idx("*").unwrap())).unwrap();
+        let s5 = sg.edge(s1, Symbol::Token(grm.token_idx("=").unwrap())).unwrap();
+        let s6 = sg.edge(s1, Symbol::Token(grm.token_idx("~").unwrap())).unwrap();
         let s7 = sg.edge(s6, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
         let s8 = sg.edge(s5, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
         let s9 = sg.edge(s4, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -87,7 +87,7 @@ pub struct StateTable<StorageT> {
     core_reduces     : Vob,
     state_shifts     : Vob,
     reduce_states    : Vob,
-    nonterms_len     : u32,
+    rules_len     : u32,
     prods_len        : PIdx<StorageT>,
     terms_len        : TIdx<StorageT>,
     /// The number of reduce/reduce errors encountered.
@@ -180,7 +180,7 @@ where usize: AsPrimitive<StorageT>
                 }
             }
 
-            let nt_len = grm.nonterms_len();
+            let nt_len = grm.rules_len();
             // Assert that we can fit the goto table into an StIdxStorageT
             assert!(StIdxStorageT::from(sg.all_states_len()).checked_mul(nt_len.into()).is_some());
             for (&sym, state_j) in sg.edges(state_i) {
@@ -271,7 +271,7 @@ where usize: AsPrimitive<StorageT>
                        state_shifts,
                        core_reduces,
                        reduce_states,
-                       nonterms_len: u32::from(grm.nonterms_len()),
+                       rules_len: u32::from(grm.rules_len()),
                        prods_len: grm.prods_len(),
                        terms_len: grm.terms_len(),
                        reduce_reduce,
@@ -335,7 +335,7 @@ where usize: AsPrimitive<StorageT>
 
     /// Return the goto state for `state_idx` and `nonterm_idx`, or `None` if there isn't any.
     pub fn goto(&self, state_idx: StIdx, nonterm_idx: RIdx<StorageT>) -> Option<StIdx> {
-        let off = (u32::from(state_idx) * self.nonterms_len) + u32::from(nonterm_idx);
+        let off = (u32::from(state_idx) * self.rules_len) + u32::from(nonterm_idx);
         self.gotos.get(&off).and_then(|x| Some(*x))
     }
 }

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -393,7 +393,7 @@ fn resolve_shift_reduce<StorageT: 'static + Hash + PrimInt + Unsigned>
 where usize: AsPrimitive<StorageT>
 {
     let mut shift_reduce = 0;
-    let term_k_prec = grm.term_precedence(term_k);
+    let term_k_prec = grm.token_precedence(term_k);
     let prod_k_prec = grm.prod_precedence(prod_k);
     match (term_k_prec, prod_k_prec) {
         (_, None) | (None, _) => {

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -234,7 +234,7 @@ where usize: AsPrimitive<StorageT>
                 match actions.get(&off) {
                     Some(&Action::Reduce(p_idx)) => {
                         let prod_len = grm.prod(p_idx).len();
-                        let nt_idx = grm.prod_to_nonterm(p_idx);
+                        let nt_idx = grm.prod_to_rule(p_idx);
                         nt_depth.insert((nt_idx, prod_len), p_idx);
                     },
                     Some(&Action::Shift(_)) => {


### PR DESCRIPTION
The names we used in grmtools were previously very inconsistent. For example, we sometimes called things tokens, sometimes terminals; sometimes rules, sometimes nonterminals, sometimes non-terminals; and so on. In other words, we were not consistent with concepts. To add insult to injury, we were then horribly inconsistent with variable names (and, to a lesser extent, with parameters and function names). For example, there was `ntidx`, `nt_idx`, `rule_i`, `r_idx` and (my personal favourite) `nidx` (a clear typo, but it happened in two functions!).

This PR first attempts to settle on simple terminology in https://github.com/softdevteam/grmtools/commit/4c36cdacf76f20e5b18456226df8986e435b6656 -- here's the important bits:

```
//! A library for manipulating Context Free Grammars (CFG). It is impractical to fully homogenise
//! all the types of grammars out there, so the aim is for different grammar types
//! to have completely separate implementations. Code that wants to be generic over more than one
//! grammar type can then use an "adapter" to homogenise the particular grammar types of interest.
//! Currently this is a little academic, since only Yacc-style grammars are supported (albeit
//! several variants of Yacc grammars).
//!
//! Unfortunately, CFG terminology is something of a mess. Some people use different terms for the
//! same concept interchangeably; some use different terms to convey subtle differences of meaning
//! (but without complete uniformity). "Token", "terminal", and "lexeme" are examples of this: they
//! are synonyms in some tools and papers, but not in others.
//!
//! In order to make this library somewhat coherent, we therefore use some basic terminology
//! guidelines for major concepts (acknowledging that this will cause clashes with some grammar
//! types).
//!
//!   * A *grammar* is an ordered sequence of *productions*.
//!   * A *production* is an ordered sequence of *symbols*.
//!   * A *rule* maps a name to one or more productions.
//!   * A *token* is the name of a syntactic element.
//!
//! For example, in the following Yacc grammar:
//!
//!   R1: "a" "b" | R2;
//!   R2: "c";
//!
//! the following statements are true:
//!
//!   * There are 3 productions. 1: ["a", "b"] 2: ["R2"] 3: ["c"]`
//!   * There are two rules: R1 and R2. The mapping to productions is {R1: {1, 2}, R2: {3}}
//!   * There are three tokens: a, b, and c.
```

The aim here isn't to pick "perfect" terminology: I doubt such a thing exists, and if it does, it's beyond me. But it's hopefully simple enough that it won't complete confuse people.

The commits after that then try to change the entire code base to respect the above terminology. Each commit aims to be a sort-of atomic unit which shifts things in that direction; to that end, I can confirm that each commit passes all tests. Despite the scary number of commits, most are trivial: those of the form "mechanically rename X to Y with [srep](https://tratt.net/laurie/src/srep/)" are mechanical search-and-replace, so it's going to be hard to spot problems (e.g. if I got the search and replace wrong, we might have variab;e shadowing): thus, a brief flick at each is probably enough. The commits "homogenise variable names in X" are all done by hand, and might be worth some checking for typos if nothing else.

This wasn't the most fun PR to do; and definitely won't be the most fun PR to review; but it starts shifting the code in a direction that will hopefully make future maintenance more palatable.