### PR TITLE
Remove traits

### DIFF
--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -81,8 +81,6 @@ extern crate num_traits;
 #[cfg(feature="serde")] #[macro_use] extern crate serde;
 extern crate vob;
 
-use num_traits::{AsPrimitive, PrimInt, Unsigned};
-
 mod idxnewtype;
 pub mod yacc;
 
@@ -96,41 +94,3 @@ pub enum Symbol<StorageT> {
     Token(TIdx<StorageT>)
 }
 
-pub trait Grammar<StorageT: 'static + PrimInt + Unsigned> where usize: AsPrimitive<StorageT> {
-    /// How many productions does this grammar have?
-    fn prods_len(&self) -> PIdx<StorageT>;
-    /// How many rules does this grammar have?
-    fn rules_len(&self) -> RIdx<StorageT>;
-    /// What is the index of the start rule?
-    fn start_rule_idx(&self) -> RIdx<StorageT>;
-    /// How many tokens does this grammar have?
-    fn tokens_len(&self) -> TIdx<StorageT>;
-
-    /// Return an iterator which produces (in order from `0..self.rules_len()`) all this
-    /// grammar's valid `RIdx`s.
-    fn iter_rules(&self) -> Box<dyn Iterator<Item=RIdx<StorageT>>>
-    {
-        // We can use as_ safely, because we know that we're only generating integers from
-        // 0..self.rules_len() and, since rules_len() returns an RIdx<StorageT>, then by
-        // definition the integers we're creating fit within StorageT.
-        Box::new((0..usize::from(self.rules_len())).map(|x| RIdx(x.as_())))
-    }
-
-    /// Return an iterator which produces (in order from `0..self.prods_len()`) all this
-    /// grammar's valid `PIdx`s.
-    fn iter_pidxs(&self) -> Box<dyn Iterator<Item=PIdx<StorageT>>>
-    {
-        // We can use as_ safely, because we know that we're only generating integers from
-        // 0..self.rules_len() and, since rules_len() returns an RIdx<StorageT>, then by
-        // definition the integers we're creating fit within StorageT.
-        Box::new((0..usize::from(self.prods_len())).map(|x| PIdx(x.as_())))
-    }
-
-    fn iter_tidxs(&self) -> Box<dyn Iterator<Item=TIdx<StorageT>>>
-    {
-        // We can use as_ safely, because we know that we're only generating integers from
-        // 0..self.rules_len() and, since rules_len() returns an TIdx<StorageT>, then by
-        // definition the integers we're creating fit within StorageT.
-        Box::new((0..usize::from(self.tokens_len())).map(|x| TIdx(x.as_())))
-    }
-}

--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -82,7 +82,6 @@ extern crate num_traits;
 extern crate vob;
 
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
-use vob::Vob;
 
 mod idxnewtype;
 pub mod yacc;
@@ -134,21 +133,4 @@ pub trait Grammar<StorageT: 'static + PrimInt + Unsigned> where usize: AsPrimiti
         // definition the integers we're creating fit within StorageT.
         Box::new((0..usize::from(self.tokens_len())).map(|x| TIdx(x.as_())))
     }
-
-    fn firsts(&self) -> Box<dyn Firsts<StorageT>>;
-}
-
-pub trait Firsts<StorageT: 'static + PrimInt + Unsigned> where usize: AsPrimitive<StorageT> {
-    /// Return all the firsts for rule `ridx`.
-    fn firsts(&self, ridx: RIdx<StorageT>) -> &Vob;
-
-    /// Returns true if the token `tidx` is in the first set for rule `ridx`.
-    fn is_set(&self, ridx: RIdx<StorageT>, tidx: TIdx<StorageT>) -> bool;
-
-    /// Returns true if the rule `ridx` has epsilon in its first set.
-    fn is_epsilon_set(&self, ridx: RIdx<StorageT>) -> bool;
-
-    /// Ensures that the firsts bit for token `tidx` rule `ridx` is set. Returns true if
-    /// it was already set, or false otherwise.
-    fn set(&mut self, ridx: RIdx<StorageT>, tidx: TIdx<StorageT>) -> bool;
 }

--- a/cfgrammar/src/lib/yacc/firsts.rs
+++ b/cfgrammar/src/lib/yacc/firsts.rs
@@ -35,7 +35,7 @@ use std::marker::PhantomData;
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 use vob::Vob;
 
-use {Firsts, Grammar, RIdx, Symbol, TIdx};
+use {Grammar, RIdx, Symbol, TIdx};
 use yacc::YaccGrammar;
 
 /// `Firsts` stores all the first sets for a given grammar. For example, given this code and
@@ -143,25 +143,25 @@ where usize: AsPrimitive<StorageT>
             }
         }
     }
-}
 
-impl<StorageT: 'static + PrimInt + Unsigned>
-Firsts<StorageT> for YaccFirsts<StorageT>
-where usize: AsPrimitive<StorageT>
-{
-    fn firsts(&self, ridx: RIdx<StorageT>) -> &Vob {
+    /// Return all the firsts for rule `ridx`.
+    pub fn firsts(&self, ridx: RIdx<StorageT>) -> &Vob {
         &self.firsts[usize::from(ridx)]
     }
 
-    fn is_set(&self, ridx: RIdx<StorageT>, tidx: TIdx<StorageT>) -> bool {
+    /// Returns true if the token `tidx` is in the first set for rule `ridx`.
+    pub fn is_set(&self, ridx: RIdx<StorageT>, tidx: TIdx<StorageT>) -> bool {
         self.firsts[usize::from(ridx)][usize::from(tidx)]
     }
 
-    fn is_epsilon_set(&self, ridx: RIdx<StorageT>) -> bool {
+    /// Returns true if the rule `ridx` has epsilon in its first set.
+    pub fn is_epsilon_set(&self, ridx: RIdx<StorageT>) -> bool {
         self.epsilons[usize::from(ridx)]
     }
 
-    fn set(&mut self, ridx: RIdx<StorageT>, tidx: TIdx<StorageT>) -> bool {
+    /// Ensures that the firsts bit for token `tidx` rule `ridx` is set. Returns true if
+    /// it was already set, or false otherwise.
+    pub fn set(&mut self, ridx: RIdx<StorageT>, tidx: TIdx<StorageT>) -> bool {
         let r = &mut self.firsts[usize::from(ridx)];
         if r[usize::from(tidx)] {
             true
@@ -175,12 +175,13 @@ where usize: AsPrimitive<StorageT>
 
 #[cfg(test)]
 mod test {
-    use {Firsts, Grammar};
+    use Grammar;
     use yacc::{YaccGrammar, YaccKind};
     use num_traits::{AsPrimitive, PrimInt, Unsigned};
+    use super::YaccFirsts;
 
     fn has<StorageT: 'static + PrimInt + Unsigned>
-          (grm: &YaccGrammar<StorageT>, firsts: &Box<Firsts<StorageT>>, rn: &str, should_be: Vec<&str>)
+          (grm: &YaccGrammar<StorageT>, firsts: &YaccFirsts<StorageT>, rn: &str, should_be: Vec<&str>)
      where usize: AsPrimitive<StorageT>
     {
         let ridx = grm.rule_idx(rn).unwrap();

--- a/cfgrammar/src/lib/yacc/firsts.rs
+++ b/cfgrammar/src/lib/yacc/firsts.rs
@@ -35,7 +35,7 @@ use std::marker::PhantomData;
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 use vob::Vob;
 
-use {Grammar, RIdx, Symbol, TIdx};
+use {RIdx, Symbol, TIdx};
 use yacc::YaccGrammar;
 
 /// `Firsts` stores all the first sets for a given grammar. For example, given this code and
@@ -175,7 +175,6 @@ where usize: AsPrimitive<StorageT>
 
 #[cfg(test)]
 mod test {
-    use Grammar;
     use yacc::{YaccGrammar, YaccKind};
     use num_traits::{AsPrimitive, PrimInt, Unsigned};
     use super::YaccFirsts;

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -332,14 +332,9 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
         })
     }
 
-    /// Return an iterator which produces (in order from `0..self.rules_len()`) all this
-    /// grammar's valid `RIdx`s.
-    pub fn iter_rules(&self) -> impl Iterator<Item=RIdx<StorageT>>
-    {
-        // We can use as_ safely, because we know that we're only generating integers from
-        // 0..self.rules_len() and, since rules_len() returns an RIdx<StorageT>, then by
-        // definition the integers we're creating fit within StorageT.
-        Box::new((0..usize::from(self.rules_len())).map(|x| RIdx(x.as_())))
+    /// How many productions does this grammar have?
+    pub fn prods_len(&self) -> PIdx<StorageT> {
+        self.prods_len
     }
 
     /// Return an iterator which produces (in order from `0..self.prods_len()`) all this
@@ -350,29 +345,6 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
         // 0..self.rules_len() and, since rules_len() returns an RIdx<StorageT>, then by
         // definition the integers we're creating fit within StorageT.
         Box::new((0..usize::from(self.prods_len())).map(|x| PIdx(x.as_())))
-    }
-
-    pub fn iter_tidxs(&self) -> impl Iterator<Item=TIdx<StorageT>>
-    {
-        // We can use as_ safely, because we know that we're only generating integers from
-        // 0..self.rules_len() and, since rules_len() returns an TIdx<StorageT>, then by
-        // definition the integers we're creating fit within StorageT.
-        Box::new((0..usize::from(self.tokens_len())).map(|x| TIdx(x.as_())))
-    }
-
-    /// Return the index of the end token.
-    pub fn eof_token_idx(&self) -> TIdx<StorageT> {
-        self.eof_token_idx
-    }
-
-    /// Return the productions for rule `ridx`. Panics if `ridx` doesn't exist.
-    pub fn rule_to_prods(&self, ridx: RIdx<StorageT>) -> &[PIdx<StorageT>] {
-        &self.rules_prods[usize::from(ridx)]
-    }
-
-    /// Return the name of rule `ridx`. Panics if `ridx` doesn't exist.
-    pub fn rule_name(&self, ridx: RIdx<StorageT>) -> &str {
-        &self.rule_names[usize::from(ridx)]
     }
 
     /// Get the sequence of symbols for production `pidx`. Panics if `pidx` doesn't exist.
@@ -399,6 +371,77 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
         self.prod_precs[usize::from(pidx)]
     }
 
+    /// Return the production index of the start rule's sole production (for Yacc grammars the
+    /// start rule is defined to have precisely one production).
+    pub fn start_prod(&self) -> PIdx<StorageT> {
+        self.start_prod
+    }
+
+    /// How many rules does this grammar have?
+    pub fn rules_len(&self) -> RIdx<StorageT> {
+        self.rules_len
+    }
+
+    /// Return an iterator which produces (in order from `0..self.rules_len()`) all this
+    /// grammar's valid `RIdx`s.
+    pub fn iter_rules(&self) -> impl Iterator<Item=RIdx<StorageT>>
+    {
+        // We can use as_ safely, because we know that we're only generating integers from
+        // 0..self.rules_len() and, since rules_len() returns an RIdx<StorageT>, then by
+        // definition the integers we're creating fit within StorageT.
+        Box::new((0..usize::from(self.rules_len())).map(|x| RIdx(x.as_())))
+    }
+
+    /// Return the productions for rule `ridx`. Panics if `ridx` doesn't exist.
+    pub fn rule_to_prods(&self, ridx: RIdx<StorageT>) -> &[PIdx<StorageT>] {
+        &self.rules_prods[usize::from(ridx)]
+    }
+
+    /// Return the name of rule `ridx`. Panics if `ridx` doesn't exist.
+    pub fn rule_name(&self, ridx: RIdx<StorageT>) -> &str {
+        &self.rule_names[usize::from(ridx)]
+    }
+
+    /// Return the `RIdx` of the implict rule if it exists, or `None` otherwise.
+    pub fn implicit_rule(&self) -> Option<RIdx<StorageT>> {
+        self.implicit_rule
+    }
+
+    /// Return the index of the rule named `n` or `None` if it doesn't exist.
+    pub fn rule_idx(&self, n: &str) -> Option<RIdx<StorageT>> {
+        self.rule_names.iter()
+                          .position(|x| x == n)
+                          // The call to as_() is safe because rule_names is guaranteed to be
+                          // small enough to fit into StorageT
+                          .map(|x| RIdx(x.as_()))
+    }
+
+    /// What is the index of the start rule?
+    pub fn start_rule_idx(&self) -> RIdx<StorageT>
+    {
+        self.prod_to_rule(self.start_prod)
+    }
+
+    /// How many tokens does this grammar have?
+    pub fn tokens_len(&self) -> TIdx<StorageT> {
+        self.tokens_len
+    }
+
+    /// Return an iterator which produces (in order from `0..self.tokens_len()`) all this
+    /// grammar's valid `TIdx`s.
+    pub fn iter_tidxs(&self) -> impl Iterator<Item=TIdx<StorageT>>
+    {
+        // We can use as_ safely, because we know that we're only generating integers from
+        // 0..self.rules_len() and, since rules_len() returns an TIdx<StorageT>, then by
+        // definition the integers we're creating fit within StorageT.
+        Box::new((0..usize::from(self.tokens_len())).map(|x| TIdx(x.as_())))
+    }
+
+    /// Return the index of the end token.
+    pub fn eof_token_idx(&self) -> TIdx<StorageT> {
+        self.eof_token_idx
+    }
+
     /// Return the name of token `tidx` (where `None` indicates "the rule has no name"). Panics if
     /// `tidx` doesn't exist.
     pub fn token_name(&self, tidx: TIdx<StorageT>) -> Option<&str> {
@@ -421,26 +464,6 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
             }
         }
         m
-    }
-
-    /// Return the production index of the start rule's sole production (for Yacc grammars the
-    /// start rule is defined to have precisely one production).
-    pub fn start_prod(&self) -> PIdx<StorageT> {
-        self.start_prod
-    }
-
-    /// Return the `RIdx` of the implict rule if it exists, or `None` otherwise.
-    pub fn implicit_rule(&self) -> Option<RIdx<StorageT>> {
-        self.implicit_rule
-    }
-
-    /// Return the index of the rule named `n` or `None` if it doesn't exist.
-    pub fn rule_idx(&self, n: &str) -> Option<RIdx<StorageT>> {
-        self.rule_names.iter()
-                          .position(|x| x == n)
-                          // The call to as_() is safe because rule_names is guaranteed to be
-                          // small enough to fit into StorageT
-                          .map(|x| RIdx(x.as_()))
     }
 
     /// Return the index of the token named `n` or `None` if it doesn't exist.
@@ -501,27 +524,6 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
     /// Return a `YaccFirsts` struct for this grammar.
     pub fn firsts(&self) -> YaccFirsts<StorageT> {
         YaccFirsts::new(self)
-    }
-
-    /// How many productions does this grammar have?
-    pub fn prods_len(&self) -> PIdx<StorageT> {
-        self.prods_len
-    }
-
-    /// How many rules does this grammar have?
-    pub fn rules_len(&self) -> RIdx<StorageT> {
-        self.rules_len
-    }
-
-    /// What is the index of the start rule?
-    pub fn start_rule_idx(&self) -> RIdx<StorageT>
-    {
-        self.prod_to_rule(self.start_prod)
-    }
-
-    /// How many tokens does this grammar have?
-    pub fn tokens_len(&self) -> TIdx<StorageT> {
-        self.tokens_len
     }
 }
 

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -37,7 +37,7 @@ use std::fmt;
 
 use num_traits::{self, AsPrimitive, PrimInt, Unsigned};
 
-use {Firsts, Grammar, RIdx, PIdx, SIdx, Symbol, TIdx};
+use {Grammar, RIdx, PIdx, SIdx, Symbol, TIdx};
 use super::YaccKind;
 use yacc::firsts::YaccFirsts;
 use yacc::parser::YaccParser;
@@ -470,9 +470,8 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
         SentenceGenerator::new(self, token_cost)
     }
 
-    /// Return a `YaccFirsts` struct, allowing static dispatch (rather than the `firsts()` method,
-    /// which returns `Box<Firsts>`).
-    pub fn yacc_firsts(&self) -> YaccFirsts<StorageT> {
+    /// Return a `YaccFirsts` struct for this grammar.
+    pub fn firsts(&self) -> YaccFirsts<StorageT> {
         YaccFirsts::new(self)
     }
 }
@@ -497,10 +496,6 @@ where usize: AsPrimitive<StorageT>
 
     fn tokens_len(&self) -> TIdx<StorageT> {
         self.tokens_len
-    }
-
-    fn firsts(&self) -> Box<dyn Firsts<StorageT>> {
-        Box::new(YaccFirsts::new(self))
     }
 }
 

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -37,7 +37,7 @@ use std::fmt;
 
 use num_traits::{self, AsPrimitive, PrimInt, Unsigned};
 
-use {Grammar, RIdx, PIdx, SIdx, Symbol, TIdx};
+use {RIdx, PIdx, SIdx, Symbol, TIdx};
 use super::YaccKind;
 use yacc::firsts::YaccFirsts;
 use yacc::parser::YaccParser;
@@ -332,6 +332,34 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
         })
     }
 
+    /// Return an iterator which produces (in order from `0..self.rules_len()`) all this
+    /// grammar's valid `RIdx`s.
+    pub fn iter_rules(&self) -> impl Iterator<Item=RIdx<StorageT>>
+    {
+        // We can use as_ safely, because we know that we're only generating integers from
+        // 0..self.rules_len() and, since rules_len() returns an RIdx<StorageT>, then by
+        // definition the integers we're creating fit within StorageT.
+        Box::new((0..usize::from(self.rules_len())).map(|x| RIdx(x.as_())))
+    }
+
+    /// Return an iterator which produces (in order from `0..self.prods_len()`) all this
+    /// grammar's valid `PIdx`s.
+    pub fn iter_pidxs(&self) -> impl Iterator<Item=PIdx<StorageT>>
+    {
+        // We can use as_ safely, because we know that we're only generating integers from
+        // 0..self.rules_len() and, since rules_len() returns an RIdx<StorageT>, then by
+        // definition the integers we're creating fit within StorageT.
+        Box::new((0..usize::from(self.prods_len())).map(|x| PIdx(x.as_())))
+    }
+
+    pub fn iter_tidxs(&self) -> impl Iterator<Item=TIdx<StorageT>>
+    {
+        // We can use as_ safely, because we know that we're only generating integers from
+        // 0..self.rules_len() and, since rules_len() returns an TIdx<StorageT>, then by
+        // definition the integers we're creating fit within StorageT.
+        Box::new((0..usize::from(self.tokens_len())).map(|x| TIdx(x.as_())))
+    }
+
     /// Return the index of the end token.
     pub fn eof_token_idx(&self) -> TIdx<StorageT> {
         self.eof_token_idx
@@ -474,27 +502,25 @@ impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT> where usize: 
     pub fn firsts(&self) -> YaccFirsts<StorageT> {
         YaccFirsts::new(self)
     }
-}
 
-impl<StorageT: 'static + PrimInt + Unsigned> Grammar<StorageT>
-for YaccGrammar<StorageT>
-where usize: AsPrimitive<StorageT>
-{
-    fn prods_len(&self) -> PIdx<StorageT> {
+    /// How many productions does this grammar have?
+    pub fn prods_len(&self) -> PIdx<StorageT> {
         self.prods_len
     }
 
-    fn rules_len(&self) -> RIdx<StorageT> {
+    /// How many rules does this grammar have?
+    pub fn rules_len(&self) -> RIdx<StorageT> {
         self.rules_len
     }
 
-    /// Return the index of the start rule.
-    fn start_rule_idx(&self) -> RIdx<StorageT>
+    /// What is the index of the start rule?
+    pub fn start_rule_idx(&self) -> RIdx<StorageT>
     {
         self.prod_to_rule(self.start_prod)
     }
 
-    fn tokens_len(&self) -> TIdx<StorageT> {
+    /// How many tokens does this grammar have?
+    pub fn tokens_len(&self) -> TIdx<StorageT> {
         self.tokens_len
     }
 }
@@ -909,7 +935,7 @@ impl fmt::Display for YaccGrammarError {
 mod test {
     use std::collections::HashMap;
     use super::{IMPLICIT_RULE, IMPLICIT_START_RULE, rule_max_costs, rule_min_costs};
-    use {Grammar, RIdx, PIdx, Symbol, TIdx};
+    use {RIdx, PIdx, Symbol, TIdx};
     use yacc::{AssocKind, Precedence, YaccGrammar, YaccKind};
 
     #[test]

--- a/lrpar/src/lib/builder.rs
+++ b/lrpar/src/lib/builder.rs
@@ -42,7 +42,6 @@ use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
 
 use bincode::{deserialize, serialize_into};
-use cfgrammar::Grammar;
 use cfgrammar::yacc::{YaccGrammar, YaccKind};
 use filetime::FileTime;
 use lrtable::{Minimiser, from_yacc, StateGraph, StateTable};

--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -37,7 +37,7 @@ use std::mem;
 use std::time::Instant;
 
 use cactus::Cactus;
-use cfgrammar::{Grammar, Symbol, TIdx};
+use cfgrammar::{Symbol, TIdx};
 use cfgrammar::yacc::YaccGrammar;
 use lrlex::Lexeme;
 use lrtable::{Action, StateGraph, StateTable, StIdx};

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -36,7 +36,7 @@ use std::hash::Hash;
 use std::time::{Duration, Instant};
 
 use cactus::Cactus;
-use cfgrammar::{Grammar, RIdx, TIdx};
+use cfgrammar::{RIdx, TIdx};
 use cfgrammar::yacc::YaccGrammar;
 use lrlex::Lexeme;
 use lrtable::{Action, StateGraph, StateTable, StIdx};

--- a/lrtable/src/lib/itemset.rs
+++ b/lrtable/src/lib/itemset.rs
@@ -39,7 +39,6 @@ use fnv::FnvHasher;
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 use vob::Vob;
 
-use cfgrammar::Firsts;
 use cfgrammar::yacc::firsts::YaccFirsts;
 
 /// The type of "context" (also known as "lookaheads")
@@ -198,7 +197,7 @@ mod test {
           L: '*' R | 'id';
           R: L;
           ").unwrap();
-        let firsts = grm.yacc_firsts();
+        let firsts = grm.firsts();
 
         let mut is = Itemset::new(&grm);
         let mut la = Vob::from_elem(usize::from(grm.tokens_len()), false);
@@ -232,7 +231,7 @@ mod test {
     #[test]
     fn test_closure1_ecogrm() {
         let grm = eco_grammar();
-        let firsts = grm.yacc_firsts();
+        let firsts = grm.firsts();
 
         let mut is = Itemset::new(&grm);
         let mut la = Vob::from_elem(usize::from(grm.tokens_len()), false);
@@ -274,7 +273,7 @@ mod test {
     #[test]
     fn test_closure1_grm3() {
         let grm = grammar3();
-        let firsts = grm.yacc_firsts();
+        let firsts = grm.firsts();
 
         let mut is = Itemset::new(&grm);
         let mut la = Vob::from_elem(usize::from(grm.tokens_len()), false);
@@ -308,7 +307,7 @@ mod test {
     #[test]
     fn test_goto1() {
         let grm = grammar3();
-        let firsts = grm.yacc_firsts();
+        let firsts = grm.firsts();
 
         let mut is = Itemset::new(&grm);
         let mut la = Vob::from_elem(usize::from(grm.tokens_len()), false);

--- a/lrtable/src/lib/itemset.rs
+++ b/lrtable/src/lib/itemset.rs
@@ -33,7 +33,7 @@
 use std::collections::hash_map::{Entry, HashMap};
 use std::hash::{BuildHasherDefault, Hash};
 
-use cfgrammar::{Grammar, PIdx, Symbol, SIdx};
+use cfgrammar::{PIdx, Symbol, SIdx};
 use cfgrammar::yacc::YaccGrammar;
 use fnv::FnvHasher;
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
@@ -183,7 +183,7 @@ where usize: AsPrimitive<StorageT>
 mod test {
     use vob::Vob;
     use super::Itemset;
-    use cfgrammar::{Grammar, SIdx, Symbol};
+    use cfgrammar::{SIdx, Symbol};
     use cfgrammar::yacc::{YaccGrammar, YaccKind};
     use stategraph::state_exists;
 

--- a/lrtable/src/lib/pager.rs
+++ b/lrtable/src/lib/pager.rs
@@ -150,7 +150,7 @@ where usize: AsPrimitive<StorageT>
 {
     // This function can be seen as a modified version of items() from Chen's dissertation.
 
-    let firsts = grm.yacc_firsts();
+    let firsts = grm.firsts();
     // closed_states and core_states are both equally sized vectors of states. Core states are
     // smaller, and used for the weakly compatible checks, but we ultimately need to return
     // closed states. Closed states which are None are those which require processing; thus

--- a/lrtable/src/lib/pager.rs
+++ b/lrtable/src/lib/pager.rs
@@ -34,7 +34,7 @@ use std::collections::HashSet;
 use std::collections::hash_map::HashMap;
 use std::hash::Hash;
 
-use cfgrammar::{Grammar, Symbol, SIdx};
+use cfgrammar::{Symbol, SIdx};
 use cfgrammar::yacc::YaccGrammar;
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 use vob::Vob;

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -208,7 +208,7 @@ where usize: AsPrimitive<StorageT>
 }
 
 #[cfg(test)]
-use cfgrammar::{Grammar, SIdx};
+use cfgrammar::SIdx;
 
 #[cfg(test)]
 pub fn state_exists<StorageT: 'static + Hash + PrimInt + Unsigned>

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -36,7 +36,7 @@ use std::hash::{Hash, BuildHasherDefault};
 use std::fmt::{self, Debug};
 use std::marker::PhantomData;
 
-use cfgrammar::{Grammar, PIdx, RIdx, Symbol, TIdx};
+use cfgrammar::{PIdx, RIdx, Symbol, TIdx};
 use cfgrammar::yacc::{AssocKind, YaccGrammar};
 use fnv::FnvHasher;
 use num_traits::{AsPrimitive, PrimInt, Unsigned};


### PR DESCRIPTION
My original plan was to have a sort-of OO-ish superclass-ish trait called Grammar, which various grammar types (e.g. Yacc, ANTLR) could implement. This might have worked *but* the performance was going to be terrible. The basic problem is that dynamic dispatch in Rust can be horribly inefficient, and complex traits tend to hit those bad cases.

For example, at one point I had this:

```rust
trait Grammar {
  pub fn iter_pidxs<'a>(&'a self, ntidx: NTIdx<StorageT>)
                     -> Box<Iterator<Item=PIdx<StorageT>> + 'a>;
}

impl Grammar for YaccGrammar {
  pub fn iter_pidxs<'a>(&'a self, ntidx: NTIdx<StorageT>)
                     -> Box<impl Iterator<Item=PIdx<StorageT>> + 'a>
  {
      self.rules_prods[usize::from(ntidx)].iter().cloned()
  }
}
```

This looks innocuous, but it made compiling the Java grammar over 30% slower compared to:

```rust
impl YaccGrammar {
  pub fn iter_pidxs<'a>(&'a self, ntidx: NTIdx<StorageT>)
                     -> impl Iterator<Item=PIdx<StorageT>> + 'a
  {
      self.rules_prods[usize::from(ntidx)].iter().cloned()
  }
}
```

A 30% slowdown for something so simple is not exactly encouraging, and going further down this route seems only like to make the problem ever worse.

Therefore remove the Grammar trait entirely and (since it's currently our only grammar type) move stuff into YaccGrammar; do the same with the Firsts trait. In the future, my gut feeling is that the right way for an application to deal with multiple grammar types will be to have grammar "adapters" that can turn incompatible-underneath grammar types into seemingly compatible grammars. With luck, the generic guarantees that cfgrammar makes about grammars (in src/lib/mod.rs) will prove tenable for different grammar types going forward, but we can cross that bridge when we come to it.