### PR TITLE
Cherry pick output from rustfmt.

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,6 @@
+indent_style="Block"
+imports_indent="Block"
+trailing_comma="Never"
+use_try_shorthand=true
+use_field_init_shorthand=true
+merge_imports=true

--- a/cfgrammar/src/lib/idxnewtype.rs
+++ b/cfgrammar/src/lib/idxnewtype.rs
@@ -72,7 +72,8 @@ IdxNewtype!(
     /// It is guaranteed that `RIdx` can be converted, without loss of precision, to `usize` with
     /// the idiom `RIdx::from(x_usize)`. `usize` values can be converted to `RIdx`, causing a
     /// panic if this would lead to a loss of precision with `usize::from(y_ridx)`.
-    RIdx);
+    RIdx
+);
 IdxNewtype!(
     /// A type specifically for production indices (e.g. a rule `E::=A|B` would
     /// have two productions for the single rule `E`).
@@ -80,18 +81,21 @@ IdxNewtype!(
     /// It is guaranteed that `PIdx` can be converted, without loss of precision, to `usize` with
     /// the idiom `PIdx::from(x_usize)`. `usize` values can be converted to `PTIdx`, causing a
     /// panic if this would lead to a loss of precision with `usize::from(y_pidx)`.
-    PIdx);
+    PIdx
+);
 IdxNewtype!(
     /// A type specifically for symbol indices (within a production).
     ///
     /// It is guaranteed that `SIdx` can be converted, without loss of precision, to `usize` with
     /// the idiom `SIdx::from(x_usize)`. `usize` values can be converted to `RIdx`, causing a
     /// panic if this would lead to a loss of precision with `usize::from(y_sidx)`.
-    SIdx);
+    SIdx
+);
 IdxNewtype!(
     /// A type specifically for token indices.
     ///
     /// It is guaranteed that `TIdx` can be converted, without loss of precision, to `usize` with
     /// the idiom `TIdx::from(x_usize)`. `usize` values can be converted to `TIdx`, causing a
     /// panic if this would lead to a loss of precision with `usize::from(y_tidx)`.
-    TIdx);
+    TIdx
+);

--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -85,7 +85,7 @@ mod idxnewtype;
 pub mod yacc;
 
 /// A type specifically for rule indices.
-pub use idxnewtype::{RIdx, PIdx, SIdx, TIdx};
+pub use idxnewtype::{PIdx, RIdx, SIdx, TIdx};
 
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/cfgrammar/src/lib/yacc/firsts.rs
+++ b/cfgrammar/src/lib/yacc/firsts.rs
@@ -63,7 +63,8 @@ pub struct YaccFirsts<StorageT> {
 }
 
 impl<StorageT: 'static + PrimInt + Unsigned> YaccFirsts<StorageT>
-where usize: AsPrimitive<StorageT>
+where
+    usize: AsPrimitive<StorageT>
 {
     /// Generates and returns the firsts set for the given grammar.
     pub fn new(grm: &YaccGrammar<StorageT>) -> Self {
@@ -74,7 +75,7 @@ where usize: AsPrimitive<StorageT>
         let mut firsts = YaccFirsts {
             firsts,
             epsilons: Vob::from_elem(usize::from(grm.rules_len()), false),
-            phantom      : PhantomData
+            phantom: PhantomData
         };
 
         // Loop looking for changes to the firsts set, until we reach a fixed point. In essence, we
@@ -165,8 +166,7 @@ where usize: AsPrimitive<StorageT>
         let r = &mut self.firsts[usize::from(ridx)];
         if r[usize::from(tidx)] {
             true
-        }
-        else {
+        } else {
             r.set(usize::from(tidx), true);
             false
         }
@@ -175,13 +175,17 @@ where usize: AsPrimitive<StorageT>
 
 #[cfg(test)]
 mod test {
-    use yacc::{YaccGrammar, YaccKind};
-    use num_traits::{AsPrimitive, PrimInt, Unsigned};
     use super::YaccFirsts;
+    use num_traits::{AsPrimitive, PrimInt, Unsigned};
+    use yacc::{YaccGrammar, YaccKind};
 
-    fn has<StorageT: 'static + PrimInt + Unsigned>
-          (grm: &YaccGrammar<StorageT>, firsts: &YaccFirsts<StorageT>, rn: &str, should_be: Vec<&str>)
-     where usize: AsPrimitive<StorageT>
+    fn has<StorageT: 'static + PrimInt + Unsigned>(
+        grm: &YaccGrammar<StorageT>,
+        firsts: &YaccFirsts<StorageT>,
+        rn: &str,
+        should_be: Vec<&str>
+    ) where
+        usize: AsPrimitive<StorageT>
     {
         let ridx = grm.rule_idx(rn).unwrap();
         for tidx in grm.iter_tidxs() {
@@ -195,7 +199,7 @@ mod test {
                         panic!("{} is not set in {}", n, rn);
                     }
                 }
-                None    => {
+                None => {
                     if firsts.is_set(ridx, tidx) {
                         panic!("{} is incorrectly set in {}", n, rn);
                     }
@@ -208,8 +212,10 @@ mod test {
     }
 
     #[test]
-    fn test_first(){
-        let grm = YaccGrammar::new(YaccKind::Original, &"
+    fn test_first() {
+        let grm = YaccGrammar::new(
+            YaccKind::Original,
+            &"
           %start C
           %token c d
           %%
@@ -217,7 +223,8 @@ mod test {
           D: 'd';
           E: D | C;
           F: E;
-          ").unwrap();
+          "
+        ).unwrap();
         let firsts = grm.firsts();
         has(&grm, &firsts, "^", vec!["c"]);
         has(&grm, &firsts, "D", vec!["d"]);
@@ -227,21 +234,26 @@ mod test {
 
     #[test]
     fn test_first_no_subsequent_rules() {
-        let grm = YaccGrammar::new(YaccKind::Original, &"
+        let grm = YaccGrammar::new(
+            YaccKind::Original,
+            &"
           %start C
           %token c d
           %%
           C: 'c';
           D: 'd';
           E: D C;
-          ").unwrap();
+          "
+        ).unwrap();
         let firsts = grm.firsts();
         has(&grm, &firsts, "E", vec!["d"]);
     }
 
     #[test]
     fn test_first_epsilon() {
-        let grm = YaccGrammar::new(YaccKind::Original, &"
+        let grm = YaccGrammar::new(
+            YaccKind::Original,
+            &"
           %start A
           %token a b c
           %%
@@ -249,7 +261,8 @@ mod test {
           B: 'b' | ;
           C: 'c' | ;
           D: C;
-          ").unwrap();
+          "
+        ).unwrap();
         let firsts = grm.firsts();
         has(&grm, &firsts, "A", vec!["b", "a"]);
         has(&grm, &firsts, "C", vec!["c", ""]);
@@ -258,14 +271,17 @@ mod test {
 
     #[test]
     fn test_last_epsilon() {
-        let grm = YaccGrammar::new(YaccKind::Original, &"
+        let grm = YaccGrammar::new(
+            YaccKind::Original,
+            &"
           %start A
           %token b c
           %%
           A: B C;
           B: 'b' | ;
           C: B 'c' B;
-          ").unwrap();
+          "
+        ).unwrap();
         let firsts = grm.firsts();
         has(&grm, &firsts, "A", vec!["b", "c"]);
         has(&grm, &firsts, "B", vec!["b", ""]);
@@ -274,19 +290,24 @@ mod test {
 
     #[test]
     fn test_first_no_multiples() {
-        let grm = YaccGrammar::new(YaccKind::Original, &"
+        let grm = YaccGrammar::new(
+            YaccKind::Original,
+            &"
           %start A
           %token b c
           %%
           A: B 'b';
           B: 'b' | ;
-          ").unwrap();
+          "
+        ).unwrap();
         let firsts = grm.firsts();
         has(&grm, &firsts, "A", vec!["b"]);
     }
 
     fn eco_grammar() -> YaccGrammar {
-        YaccGrammar::new(YaccKind::Original, &"
+        YaccGrammar::new(
+            YaccKind::Original,
+            &"
           %start S
           %token a b c d f
           %%
@@ -296,7 +317,8 @@ mod test {
           C: D A;
           D: 'd' | ;
           F: C D 'f';
-          ").unwrap()
+          "
+        ).unwrap()
     }
 
     #[test]
@@ -313,7 +335,9 @@ mod test {
 
     #[test]
     fn test_first_from_eco_bug() {
-        let grm = YaccGrammar::new(YaccKind::Original, &"
+        let grm = YaccGrammar::new(
+            YaccKind::Original,
+            &"
           %start E
           %token a b c d e f
           %%
@@ -324,7 +348,8 @@ mod test {
           D: D 'd' | F;
           F: 'f' | ;
           G: C D;
-          ").unwrap();
+          "
+        ).unwrap();
         let firsts = grm.firsts();
         has(&grm, &firsts, "E", vec!["a"]);
         has(&grm, &firsts, "T", vec!["a"]);

--- a/cfgrammar/src/lib/yacc/mod.rs
+++ b/cfgrammar/src/lib/yacc/mod.rs
@@ -35,9 +35,11 @@ pub mod firsts;
 pub mod grammar;
 pub mod parser;
 
-pub use self::ast::{GrammarValidationError, GrammarValidationErrorKind};
-pub use self::parser::{YaccParserError, YaccParserErrorKind};
-pub use self::grammar::{AssocKind, Precedence, SentenceGenerator, YaccGrammar, YaccGrammarError};
+pub use self::{
+    ast::{GrammarValidationError, GrammarValidationErrorKind},
+    grammar::{AssocKind, Precedence, SentenceGenerator, YaccGrammar, YaccGrammarError},
+    parser::{YaccParserError, YaccParserErrorKind}
+};
 
 /// The particular Yacc variant this grammar makes use of.
 #[derive(Clone, Copy)]

--- a/lrlex/examples/calclex/build.rs
+++ b/lrlex/examples/calclex/build.rs
@@ -6,6 +6,6 @@ fn main() {
     // Note that we specify the integer type (u8) we'll use for token IDs (this type *must* be big
     // enough to fit all IDs in) as well as the input file (which must end in ".l").
     LexerBuilder::<u8>::new()
-                       .process_file_in_src("calc.l")
-                       .unwrap();
+        .process_file_in_src("calc.l")
+        .unwrap();
 }

--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -35,16 +35,14 @@
 extern crate regex;
 extern crate typename;
 
-use std::convert::TryFrom;
-use std::error::Error;
-use std::fmt;
+use std::{convert::TryFrom, error::Error, fmt};
 
 mod builder;
 mod lexer;
 mod parser;
 
 pub use builder::LexerBuilder;
-pub use lexer::{Lexeme, LexerDef, Lexer, Rule};
+pub use lexer::{Lexeme, Lexer, LexerDef, Rule};
 use parser::parse_lex;
 
 pub type LexBuildResult<T> = Result<T, LexBuildError>;
@@ -53,8 +51,8 @@ pub type LexBuildResult<T> = Result<T, LexBuildError>;
 #[derive(Debug)]
 pub struct LexBuildError {
     pub kind: LexErrorKind,
-    line: usize,
-    col: usize
+    line:     usize,
+    col:      usize
 }
 
 impl Error for LexBuildError {}
@@ -75,19 +73,21 @@ impl fmt::Display for LexBuildError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let s;
         match self.kind {
-            LexErrorKind::PrematureEnd         => s = "File ends prematurely",
+            LexErrorKind::PrematureEnd => s = "File ends prematurely",
             LexErrorKind::RoutinesNotSupported => s = "Routines not currently supported",
-            LexErrorKind::UnknownDeclaration   => s = "Unknown declaration",
-            LexErrorKind::MissingSpace         => s = "Rule is missing a space",
-            LexErrorKind::InvalidName          => s = "Invalid rule name",
-            LexErrorKind::DuplicateName        => s = "Rule name already exists",
-            LexErrorKind::RegexError           => s = "Invalid regular expression"
+            LexErrorKind::UnknownDeclaration => s = "Unknown declaration",
+            LexErrorKind::MissingSpace => s = "Rule is missing a space",
+            LexErrorKind::InvalidName => s = "Invalid rule name",
+            LexErrorKind::DuplicateName => s = "Rule name already exists",
+            LexErrorKind::RegexError => s = "Invalid regular expression"
         }
         write!(f, "{} at line {} column {}", s, self.line, self.col)
     }
 }
 
-pub fn build_lex<StorageT: Copy + Eq + TryFrom<usize>>(s: &str) -> Result<LexerDef<StorageT>, LexBuildError> {
+pub fn build_lex<StorageT: Copy + Eq + TryFrom<usize>>(
+    s: &str
+) -> Result<LexerDef<StorageT>, LexBuildError> {
     parse_lex(s)
 }
 
@@ -95,5 +95,7 @@ pub fn build_lex<StorageT: Copy + Eq + TryFrom<usize>>(s: &str) -> Result<LexerD
 /// statically compiled by lrlex can then be used in a crate with `lrlex_mod!(x)`.
 #[macro_export]
 macro_rules! lrlex_mod {
-    ($n:ident) => { include!(concat!(env!("OUT_DIR"), "/", stringify!($n), ".rs")); };
+    ($n:ident) => {
+        include!(concat!(env!("OUT_DIR"), "/", stringify!($n), ".rs"));
+    };
 }

--- a/lrlex/src/main.rs
+++ b/lrlex/src/main.rs
@@ -34,10 +34,13 @@ extern crate getopts;
 extern crate lrlex;
 
 use getopts::Options;
-use std::{env, process};
-use std::fs::File;
-use std::io::{Read, stderr, Write};
-use std::path::Path;
+use std::{
+    env,
+    fs::File,
+    io::{stderr, Read, Write},
+    path::Path,
+    process
+};
 
 use lrlex::{build_lex, LexerDef};
 
@@ -70,9 +73,7 @@ fn read_file(path: &str) -> String {
 fn main() {
     let args: Vec<String> = env::args().collect();
     let prog = args[0].clone();
-    let matches = match Options::new()
-                                .optflag("h", "help", "")
-                                .parse(&args[1..]) {
+    let matches = match Options::new().optflag("h", "help", "").parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => {
             usage(&prog, f.to_string().as_str());
@@ -86,12 +87,16 @@ fn main() {
 
     let lex_l_path = &matches.free[0];
     let lexerdef: LexerDef<usize> = build_lex(&read_file(lex_l_path)).unwrap_or_else(|s| {
-            writeln!(&mut stderr(), "{}: {}", &lex_l_path, &s).ok();
-            process::exit(1);
-        });
+        writeln!(&mut stderr(), "{}: {}", &lex_l_path, &s).ok();
+        process::exit(1);
+    });
     let input = &read_file(&matches.free[1]);
     let lexemes = lexerdef.lexer(input).lexemes().unwrap();
     for l in &lexemes {
-        println!("{} {}", lexerdef.get_rule_by_id(l.tok_id()).name.as_ref().unwrap(), &input[l.start()..l.start() + l.len()]);
+        println!(
+            "{} {}",
+            lexerdef.get_rule_by_id(l.tok_id()).name.as_ref().unwrap(),
+            &input[l.start()..l.start() + l.len()]
+        );
     }
 }

--- a/lrpar/examples/calcparse/build.rs
+++ b/lrpar/examples/calcparse/build.rs
@@ -43,10 +43,9 @@ fn main() -> Result<(), Box<std::error::Error>> {
     // Note that we specify the integer type (u8) we'll use for token IDs (this type *must* be big
     // enough to fit all IDs in) as well as the input file (which must end in ".y" for lrpar, and
     // ".l" for lrlex).
-    let lex_rule_ids_map = ParserBuilder::<u8>::new()
-                                               .process_file_in_src("calc.y")?;
+    let lex_rule_ids_map = ParserBuilder::<u8>::new().process_file_in_src("calc.y")?;
     LexerBuilder::new()
-                 .rule_ids_map(lex_rule_ids_map)
-                 .process_file_in_src("calc.l")?;
+        .rule_ids_map(lex_rule_ids_map)
+        .process_file_in_src("calc.l")?;
     Ok(())
 }

--- a/lrpar/examples/calcparse/src/main.rs
+++ b/lrpar/examples/calcparse/src/main.rs
@@ -41,10 +41,10 @@ fn main() {
                                 }
                             }
                         }
-                    },
+                    }
                     Err(e) => println!("Lexing error {:?}", e)
                 }
-            },
+            }
             _ => break
         }
     }
@@ -56,7 +56,7 @@ struct Eval<'a> {
 
 impl<'a> Eval<'a> {
     fn new(s: &'a str) -> Self {
-        Eval{s}
+        Eval { s }
     }
 
     fn eval(&self, n: &Node<u8>) -> i64 {

--- a/lrpar/src/lib/astar.rs
+++ b/lrpar/src/lib/astar.rs
@@ -30,8 +30,7 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-use std::hash::Hash;
-use std::fmt::Debug;
+use std::{fmt::Debug, hash::Hash};
 
 use indexmap::map::{Entry, IndexMap};
 
@@ -45,15 +44,17 @@ use indexmap::map::{Entry, IndexMap};
 /// [`astar_bag_collect`](https://docs.rs/pathfinding/0.6.8/pathfinding/fn.astar_bag.html)
 /// in the `pathfinding` crate. Unlike `astar_bag_collect`, this `astar_all` does not record the
 /// path taken to reach a success node: this allows it to be substantially faster.
-pub(crate) fn astar_all<N, FN, FM, FS>(start_node: N,
-                                       neighbours: FN,
-                                       merge: FM,
-                                       success: FS)
-                                    -> Vec<N>
-                                 where N: Debug + Clone + Hash + Eq + PartialEq,
-                                       FN: Fn(bool, &N, &mut Vec<(u16, u16, N)>) -> bool,
-                                       FM: Fn(&mut N, N),
-                                       FS: Fn(&N) -> bool,
+pub(crate) fn astar_all<N, FN, FM, FS>(
+    start_node: N,
+    neighbours: FN,
+    merge: FM,
+    success: FS
+) -> Vec<N>
+where
+    N: Debug + Clone + Hash + Eq + PartialEq,
+    FN: Fn(bool, &N, &mut Vec<(u16, u16, N)>) -> bool,
+    FM: Fn(&mut N, N),
+    FS: Fn(&N) -> bool
 {
     // We tackle the problem in two phases. In the first phase we search for a success node, with
     // the cost monotonically increasing. All neighbouring nodes are stored for future inspection,
@@ -99,8 +100,12 @@ pub(crate) fn astar_all<N, FN, FM, FS>(start_node: N,
                 todo.push(IndexMap::new());
             }
             match todo[off].entry(nbr.clone()) {
-                Entry::Vacant(e) => { e.insert(nbr); },
-                Entry::Occupied(mut e) => { merge(&mut e.get_mut(), nbr); }
+                Entry::Vacant(e) => {
+                    e.insert(nbr);
+                }
+                Entry::Occupied(mut e) => {
+                    merge(&mut e.get_mut(), nbr);
+                }
             }
         }
     }
@@ -112,7 +117,10 @@ pub(crate) fn astar_all<N, FN, FM, FS>(start_node: N,
     // That never leads to more interesting repairs from our perspective.
 
     // Free up all memory except for the cost todo that contains the first success node.
-    let mut scs_todo = todo.drain(usize::from(c)..usize::from(c) + 1).nth(0).unwrap();
+    let mut scs_todo = todo
+        .drain(usize::from(c)..usize::from(c) + 1)
+        .nth(0)
+        .unwrap();
     while !scs_todo.is_empty() {
         let n = scs_todo.pop().unwrap().1;
         if success(&n) {
@@ -128,8 +136,12 @@ pub(crate) fn astar_all<N, FN, FM, FS>(start_node: N,
             // existing success nodes and an empty heuristic.
             if nbr_cost + nbr_hrstc == c {
                 match scs_todo.entry(nbr.clone()) {
-                    Entry::Vacant(e) => { e.insert(nbr); },
-                    Entry::Occupied(mut e) => { merge(&mut e.get_mut(), nbr); }
+                    Entry::Vacant(e) => {
+                        e.insert(nbr);
+                    }
+                    Entry::Occupied(mut e) => {
+                        merge(&mut e.get_mut(), nbr);
+                    }
                 }
             }
         }
@@ -147,15 +159,17 @@ pub(crate) fn astar_all<N, FN, FM, FS>(start_node: N,
 /// The name of this function isn't entirely accurate: this isn't Dijkstra's original algorithm or
 /// one of its well-known variants. However, unlike the astar_all function it doesn't expect a
 /// heuristic and it also filters out some duplicates.
-pub(crate) fn dijkstra<N, FM, FN, FS>(start_node: N,
-                                      neighbours: FN,
-                                      merge: FM,
-                                      success: FS)
-                                   -> Vec<N>
-                                where N: Debug + Clone + Hash + Eq + PartialEq,
-                                      FN: Fn(bool, &N, &mut Vec<(u16, N)>) -> bool,
-                                      FM: Fn(&mut N, N),
-                                      FS: Fn(&N) -> bool,
+pub(crate) fn dijkstra<N, FM, FN, FS>(
+    start_node: N,
+    neighbours: FN,
+    merge: FM,
+    success: FS
+) -> Vec<N>
+where
+    N: Debug + Clone + Hash + Eq + PartialEq,
+    FN: Fn(bool, &N, &mut Vec<(u16, N)>) -> bool,
+    FM: Fn(&mut N, N),
+    FS: Fn(&N) -> bool
 {
     let mut scs_nodes = Vec::new();
     let mut todo: Vec<IndexMap<N, N>> = vec![indexmap![start_node.clone() => start_node]];
@@ -185,13 +199,20 @@ pub(crate) fn dijkstra<N, FM, FN, FS>(start_node: N,
                 todo.push(IndexMap::new());
             }
             match todo[off].entry(nbr.clone()) {
-                Entry::Vacant(e) => { e.insert(nbr); },
-                Entry::Occupied(mut e) => { merge(&mut e.get_mut(), nbr); }
+                Entry::Vacant(e) => {
+                    e.insert(nbr);
+                }
+                Entry::Occupied(mut e) => {
+                    merge(&mut e.get_mut(), nbr);
+                }
             }
         }
     }
 
-    let mut scs_todo = todo.drain(usize::from(c)..usize::from(c) + 1).nth(0).unwrap();
+    let mut scs_todo = todo
+        .drain(usize::from(c)..usize::from(c) + 1)
+        .nth(0)
+        .unwrap();
     while !scs_todo.is_empty() {
         let n = scs_todo.pop().unwrap().1;
         if success(&n) {
@@ -204,8 +225,12 @@ pub(crate) fn dijkstra<N, FM, FN, FS>(start_node: N,
         for (nbr_cost, nbr) in next.drain(..) {
             if nbr_cost == c {
                 match scs_todo.entry(nbr.clone()) {
-                    Entry::Vacant(e) => { e.insert(nbr); },
-                    Entry::Occupied(mut e) => { merge(&mut e.get_mut(), nbr); }
+                    Entry::Vacant(e) => {
+                        e.insert(nbr);
+                    }
+                    Entry::Occupied(mut e) => {
+                        merge(&mut e.get_mut(), nbr);
+                    }
                 }
             }
         }

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -51,16 +51,18 @@ mod builder;
 mod cpctplus;
 mod panic;
 pub mod parser;
-pub use parser::{Node, parse_rcvry, ParseError, ParseRepair, RecoveryKind};
+pub use parser::{parse_rcvry, Node, ParseError, ParseRepair, RecoveryKind};
 mod mf;
 
-pub use builder::{ParserBuilder, reconstitute};
+pub use builder::{reconstitute, ParserBuilder};
 
 /// A convenience macro for including statically compiled `.y` files. A file `src/x.y` which is
 /// statically compiled by lrpar can then be used in a crate with `lrpar_mod!(x)`.
 #[macro_export]
 macro_rules! lrpar_mod {
-    ($n:ident) => { include!(concat!(env!("OUT_DIR"), "/", stringify!($n), ".rs")); };
+    ($n:ident) => {
+        include!(concat!(env!("OUT_DIR"), "/", stringify!($n), ".rs"));
+    };
 }
 
 #[doc(hidden)]

--- a/lrpar/src/lib/panic.rs
+++ b/lrpar/src/lib/panic.rs
@@ -30,36 +30,36 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-use std::fmt::Debug;
-use std::hash::Hash;
-use std::time::Instant;
+use std::{fmt::Debug, hash::Hash, time::Instant};
 
 use lrtable::StIdx;
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 
-use parser::{Node, Parser, ParseRepair, Recoverer};
+use parser::{Node, ParseRepair, Parser, Recoverer};
 
 struct Panic;
 
-pub(crate) fn recoverer<'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned>
-                       (_: &'a Parser<StorageT>)
-                     -> Box<Recoverer<StorageT> + 'a>
-                  where usize: AsPrimitive<StorageT>
+pub(crate) fn recoverer<'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned>(
+    _: &'a Parser<StorageT>
+) -> Box<Recoverer<StorageT> + 'a>
+where
+    usize: AsPrimitive<StorageT>
 {
     Box::new(Panic)
 }
 
 impl<StorageT: 'static + Debug + Hash + PrimInt + Unsigned> Recoverer<StorageT> for Panic
-where usize: AsPrimitive<StorageT>
+where
+    usize: AsPrimitive<StorageT>
 {
-    fn recover(&self,
-               finish_by: Instant,
-               parser: &Parser<StorageT>,
-               in_laidx: usize,
-               in_pstack: &mut Vec<StIdx>,
-               _: &mut Vec<Node<StorageT>>)
-           -> (usize, Vec<Vec<ParseRepair<StorageT>>>)
-    {
+    fn recover(
+        &self,
+        finish_by: Instant,
+        parser: &Parser<StorageT>,
+        in_laidx: usize,
+        in_pstack: &mut Vec<StIdx>,
+        _: &mut Vec<Node<StorageT>>
+    ) -> (usize, Vec<Vec<ParseRepair<StorageT>>>) {
         // This recoverer is based on that in Compiler Design in C by Allen I. Holub p.348.
         //
         // It doesn't really fit into our recoverer mould very well: it can't always flesh out a

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -30,32 +30,39 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-use std::fmt::{self, Debug, Display};
-use std::error::Error;
-use std::hash::Hash;
-use std::time::{Duration, Instant};
+use std::{
+    error::Error,
+    fmt::{self, Debug, Display},
+    hash::Hash,
+    time::{Duration, Instant}
+};
 
 use cactus::Cactus;
-use cfgrammar::{RIdx, TIdx};
-use cfgrammar::yacc::YaccGrammar;
+use cfgrammar::{yacc::YaccGrammar, RIdx, TIdx};
 use lrlex::Lexeme;
-use lrtable::{Action, StateGraph, StateTable, StIdx};
+use lrtable::{Action, StIdx, StateGraph, StateTable};
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 
-use mf;
 use cpctplus;
+use mf;
 use panic;
 
 const RECOVERY_TIME_BUDGET: u64 = 500; // milliseconds
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Node<StorageT> {
-    Term{lexeme: Lexeme<StorageT>},
-    Nonterm{ridx: RIdx<StorageT>, nodes: Vec<Node<StorageT>>}
+    Term {
+        lexeme: Lexeme<StorageT>
+    },
+    Nonterm {
+        ridx: RIdx<StorageT>,
+        nodes: Vec<Node<StorageT>>
+    }
 }
 
 impl<StorageT: 'static + PrimInt + Unsigned> Node<StorageT>
-where usize: AsPrimitive<StorageT>
+where
+    usize: AsPrimitive<StorageT>
 {
     /// Return a pretty-printed version of this node.
     pub fn pp(&self, grm: &YaccGrammar<StorageT>, input: &str) -> String {
@@ -67,13 +74,13 @@ where usize: AsPrimitive<StorageT>
                 s.push_str(" ");
             }
             match *e {
-                Node::Term{lexeme} => {
+                Node::Term { lexeme } => {
                     let tidx = TIdx(lexeme.tok_id());
                     let tn = grm.token_name(tidx).unwrap();
                     let lt = &input[lexeme.start()..lexeme.start() + lexeme.len()];
                     s.push_str(&format!("{} {}\n", tn, lt));
                 }
-                Node::Nonterm{ridx, ref nodes} => {
+                Node::Nonterm { ridx, ref nodes } => {
                     s.push_str(&format!("{}\n", grm.rule_name(ridx)));
                     for x in nodes.iter().rev() {
                         st.push((indent + 1, x));
@@ -99,33 +106,41 @@ pub struct Parser<'a, StorageT: 'a + Eq + Hash> {
     pub lexemes: &'a [Lexeme<StorageT>]
 }
 
-impl<'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned>
-Parser<'a, StorageT>
-where usize: AsPrimitive<StorageT>
+impl<'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned> Parser<'a, StorageT>
+where
+    usize: AsPrimitive<StorageT>
 {
-    fn parse<F>(rcvry_kind: RecoveryKind,
-                grm: &YaccGrammar<StorageT>,
-                token_cost: F,
-                sgraph: &StateGraph<StorageT>,
-                stable: &StateTable<StorageT>,
-                lexemes: &[Lexeme<StorageT>])
-             -> Result<Node<StorageT>,
-                      (Option<Node<StorageT>>, Vec<ParseError<StorageT>>)>
-          where F: Fn(TIdx<StorageT>) -> u8
+    fn parse<F>(
+        rcvry_kind: RecoveryKind,
+        grm: &YaccGrammar<StorageT>,
+        token_cost: F,
+        sgraph: &StateGraph<StorageT>,
+        stable: &StateTable<StorageT>,
+        lexemes: &[Lexeme<StorageT>]
+    ) -> Result<Node<StorageT>, (Option<Node<StorageT>>, Vec<ParseError<StorageT>>)>
+    where
+        F: Fn(TIdx<StorageT>) -> u8
     {
         for tidx in grm.iter_tidxs() {
             assert!(token_cost(tidx) > 0);
         }
-        let psr = Parser{rcvry_kind, grm, token_cost: &token_cost, sgraph, stable, lexemes};
+        let psr = Parser {
+            rcvry_kind,
+            grm,
+            token_cost: &token_cost,
+            sgraph,
+            stable,
+            lexemes
+        };
         let mut pstack = vec![StIdx::from(0u32)];
         let mut tstack: Vec<Node<StorageT>> = Vec::new();
         let mut errors: Vec<ParseError<StorageT>> = Vec::new();
         let accpt = psr.lr(0, &mut pstack, &mut tstack, &mut errors);
         match (accpt, errors.is_empty()) {
-            (true, true)   => Ok(tstack.drain(..).nth(0).unwrap()),
-            (true, false)  => Err((Some(tstack.drain(..).nth(0).unwrap()), errors)),
+            (true, true) => Ok(tstack.drain(..).nth(0).unwrap()),
+            (true, false) => Err((Some(tstack.drain(..).nth(0).unwrap()), errors)),
             (false, false) => Err((None, errors)),
-            (false, true)  => panic!("Internal error")
+            (false, true) => panic!("Internal error")
         }
     }
 
@@ -142,13 +157,13 @@ where usize: AsPrimitive<StorageT>
     /// Return `true` if the parse reached an accept state (i.e. all the input was consumed,
     /// possibly after making repairs) or `false` (i.e. some of the input was not consumed, even
     /// after possibly making repairs) otherwise.
-    pub fn lr(&self,
-              mut laidx: usize,
-              pstack: &mut PStack,
-              tstack: &mut TStack<StorageT>,
-              errors: &mut Errors<StorageT>)
-           -> bool
-    {
+    pub fn lr(
+        &self,
+        mut laidx: usize,
+        pstack: &mut PStack,
+        tstack: &mut TStack<StorageT>,
+        errors: &mut Errors<StorageT>
+    ) -> bool {
         let mut recoverer = None;
         let mut recovery_budget = Duration::from_millis(RECOVERY_TIME_BUDGET);
         loop {
@@ -160,57 +175,61 @@ where usize: AsPrimitive<StorageT>
                     let ridx = self.grm.prod_to_rule(pidx);
                     let pop_idx = pstack.len() - self.grm.prod(pidx).len();
                     let nodes = tstack.drain(pop_idx - 1..).collect::<Vec<Node<StorageT>>>();
-                    tstack.push(Node::Nonterm{ridx, nodes});
+                    tstack.push(Node::Nonterm { ridx, nodes });
 
                     pstack.drain(pop_idx..);
                     let prior = *pstack.last().unwrap();
                     pstack.push(self.stable.goto(prior, ridx).unwrap());
-                },
+                }
                 Some(Action::Shift(state_id)) => {
                     let la_lexeme = self.next_lexeme(laidx);
-                    tstack.push(Node::Term{lexeme: la_lexeme});
+                    tstack.push(Node::Term { lexeme: la_lexeme });
                     pstack.push(state_id);
                     laidx += 1;
-                },
+                }
                 Some(Action::Accept) => {
                     debug_assert_eq!(la_tidx, self.grm.eof_token_idx());
                     debug_assert_eq!(tstack.len(), 1);
                     return true;
-                },
+                }
                 None => {
                     if recoverer.is_none() {
                         recoverer = Some(match self.rcvry_kind {
-                                             RecoveryKind::CPCTPlus => cpctplus::recoverer(self),
-                                             RecoveryKind::MF => mf::recoverer(self),
-                                             RecoveryKind::Panic => panic::recoverer(self),
-                                             RecoveryKind::None => {
-                                                let la_lexeme = self.next_lexeme(laidx);
-                                                errors.push(ParseError{stidx,
-                                                                       lexeme_idx: laidx,
-                                                                       lexeme: la_lexeme,
-                                                                       repairs: vec![]});
-                                                return false;
-                                             }
-                                         });
+                            RecoveryKind::CPCTPlus => cpctplus::recoverer(self),
+                            RecoveryKind::MF => mf::recoverer(self),
+                            RecoveryKind::Panic => panic::recoverer(self),
+                            RecoveryKind::None => {
+                                let la_lexeme = self.next_lexeme(laidx);
+                                errors.push(ParseError {
+                                    stidx,
+                                    lexeme_idx: laidx,
+                                    lexeme: la_lexeme,
+                                    repairs: vec![]
+                                });
+                                return false;
+                            }
+                        });
                     }
 
                     let before = Instant::now();
                     let finish_by = before + recovery_budget;
-                    let (new_laidx, repairs) = recoverer.as_ref()
-                                                         .unwrap()
-                                                         .as_ref()
-                                                         .recover(finish_by,
-                                                                  self,
-                                                                  laidx,
-                                                                  pstack,
-                                                                  tstack);
+                    let (new_laidx, repairs) = recoverer
+                        .as_ref()
+                        .unwrap()
+                        .as_ref()
+                        .recover(finish_by, self, laidx, pstack, tstack);
                     let after = Instant::now();
-                    recovery_budget = recovery_budget.checked_sub(after - before)
-                                                     .unwrap_or_else(|| Duration::new(0, 0));
+                    recovery_budget = recovery_budget
+                        .checked_sub(after - before)
+                        .unwrap_or_else(|| Duration::new(0, 0));
                     let keep_going = !repairs.is_empty();
                     let la_lexeme = self.next_lexeme(laidx);
-                    errors.push(ParseError{stidx, lexeme_idx: laidx,
-                                           lexeme: la_lexeme, repairs});
+                    errors.push(ParseError {
+                        stidx,
+                        lexeme_idx: laidx,
+                        lexeme: la_lexeme,
+                        repairs
+                    });
                     if !keep_going {
                         return false;
                     }
@@ -224,51 +243,53 @@ where usize: AsPrimitive<StorageT>
     /// Returns the index of the token it parsed up to (by definition <= end_laidx: can be less if
     /// the input is < end_laidx, or if an error is encountered). Does not do any form of error
     /// recovery.
-    pub fn lr_upto(&self,
-                   lexeme_prefix: Option<Lexeme<StorageT>>,
-                   mut laidx: usize,
-                   end_laidx: usize,
-                   pstack: &mut PStack,
-                   tstack: &mut Option<&mut Vec<Node<StorageT>>>)
-           -> usize
-    {
+    pub fn lr_upto(
+        &self,
+        lexeme_prefix: Option<Lexeme<StorageT>>,
+        mut laidx: usize,
+        end_laidx: usize,
+        pstack: &mut PStack,
+        tstack: &mut Option<&mut Vec<Node<StorageT>>>
+    ) -> usize {
         assert!(lexeme_prefix.is_none() || end_laidx == laidx + 1);
         while laidx != end_laidx && laidx <= self.lexemes.len() {
             let stidx = *pstack.last().unwrap();
             let la_tidx = if let Some(l) = lexeme_prefix {
-                              TIdx(l.tok_id())
-                          } else {
-                              self.next_tidx(laidx)
-                          };
+                TIdx(l.tok_id())
+            } else {
+                self.next_tidx(laidx)
+            };
 
             match self.stable.action(stidx, la_tidx) {
                 Some(Action::Reduce(pidx)) => {
                     let ridx = self.grm.prod_to_rule(pidx);
                     let pop_idx = pstack.len() - self.grm.prod(pidx).len();
                     if let Some(ref mut tstack_uw) = *tstack {
-                        let nodes = tstack_uw.drain(pop_idx - 1..).collect::<Vec<Node<StorageT>>>();
-                        tstack_uw.push(Node::Nonterm{ridx, nodes});
+                        let nodes = tstack_uw
+                            .drain(pop_idx - 1..)
+                            .collect::<Vec<Node<StorageT>>>();
+                        tstack_uw.push(Node::Nonterm { ridx, nodes });
                     }
 
                     pstack.drain(pop_idx..);
                     let prior = *pstack.last().unwrap();
                     pstack.push(self.stable.goto(prior, ridx).unwrap());
-                },
+                }
                 Some(Action::Shift(state_id)) => {
                     if let Some(ref mut tstack_uw) = *tstack {
                         let la_lexeme = if let Some(l) = lexeme_prefix {
-                                            l
-                                        } else {
-                                            self.next_lexeme(laidx)
-                                        };
-                        tstack_uw.push(Node::Term{lexeme: la_lexeme});
+                            l
+                        } else {
+                            self.next_lexeme(laidx)
+                        };
+                        tstack_uw.push(Node::Term { lexeme: la_lexeme });
                     }
                     pstack.push(state_id);
                     laidx += 1;
-                },
+                }
                 Some(Action::Accept) => {
                     break;
-                },
+                }
                 None => {
                     break;
                 }
@@ -279,8 +300,7 @@ where usize: AsPrimitive<StorageT>
 
     /// Return a `Lexeme` for the next lemexe (if `laidx` == `self.lexemes.len()` this will be
     /// a lexeme constructed to look as if contains the EOF token).
-    pub(crate) fn next_lexeme(&self, laidx: usize) -> Lexeme<StorageT>
-    {
+    pub(crate) fn next_lexeme(&self, laidx: usize) -> Lexeme<StorageT> {
         let llen = self.lexemes.len();
         debug_assert!(laidx <= llen);
         if laidx < llen {
@@ -288,14 +308,18 @@ where usize: AsPrimitive<StorageT>
         } else {
             // We have to artificially construct a Lexeme for the EOF lexeme.
             let last_la_end = if llen == 0 {
-                    0
-                } else {
-                    debug_assert!(laidx > 0);
-                    let last_la = self.lexemes[laidx - 1];
-                    last_la.start() + last_la.len()
-                };
+                0
+            } else {
+                debug_assert!(laidx > 0);
+                let last_la = self.lexemes[laidx - 1];
+                last_la.start() + last_la.len()
+            };
 
-            Lexeme::new(StorageT::from(u32::from(self.grm.eof_token_idx())).unwrap(), last_la_end, 0)
+            Lexeme::new(
+                StorageT::from(u32::from(self.grm.eof_token_idx())).unwrap(),
+                last_la_end,
+                0
+            )
         }
     }
 
@@ -318,31 +342,32 @@ where usize: AsPrimitive<StorageT>
     /// Note that if `lexeme_prefix` is specified, `laidx` will still be incremented, and thus
     /// `end_laidx` *must* be set to `laidx + 1` in order that the parser doesn't skip the real
     /// lexeme at position `laidx`.
-    pub(crate) fn lr_cactus(&self,
-                            lexeme_prefix: Option<Lexeme<StorageT>>,
-                            mut laidx: usize,
-                            end_laidx: usize,
-                            mut pstack: Cactus<StIdx>,
-                            tstack: &mut Option<&mut Vec<Node<StorageT>>>)
-      -> (usize, Cactus<StIdx>)
-    {
+    pub(crate) fn lr_cactus(
+        &self,
+        lexeme_prefix: Option<Lexeme<StorageT>>,
+        mut laidx: usize,
+        end_laidx: usize,
+        mut pstack: Cactus<StIdx>,
+        tstack: &mut Option<&mut Vec<Node<StorageT>>>
+    ) -> (usize, Cactus<StIdx>) {
         assert!(lexeme_prefix.is_none() || end_laidx == laidx + 1);
         while laidx != end_laidx {
             let stidx = *pstack.val().unwrap();
             let la_tidx = if let Some(l) = lexeme_prefix {
-                              TIdx(l.tok_id())
-                          } else {
-                              self.next_tidx(laidx)
-                          };
+                TIdx(l.tok_id())
+            } else {
+                self.next_tidx(laidx)
+            };
 
             match self.stable.action(stidx, la_tidx) {
                 Some(Action::Reduce(pidx)) => {
                     let ridx = self.grm.prod_to_rule(pidx);
                     let pop_num = self.grm.prod(pidx).len();
                     if let Some(ref mut tstack_uw) = *tstack {
-                        let nodes = tstack_uw.drain(pstack.len() - pop_num - 1..)
-                                             .collect::<Vec<Node<StorageT>>>();
-                        tstack_uw.push(Node::Nonterm{ridx, nodes});
+                        let nodes = tstack_uw
+                            .drain(pstack.len() - pop_num - 1..)
+                            .collect::<Vec<Node<StorageT>>>();
+                        tstack_uw.push(Node::Nonterm { ridx, nodes });
                     }
 
                     for _ in 0..pop_num {
@@ -350,26 +375,26 @@ where usize: AsPrimitive<StorageT>
                     }
                     let prior = *pstack.val().unwrap();
                     pstack = pstack.child(self.stable.goto(prior, ridx).unwrap());
-                },
+                }
                 Some(Action::Shift(state_id)) => {
                     if let Some(ref mut tstack_uw) = *tstack {
                         let la_lexeme = if let Some(l) = lexeme_prefix {
-                                            l
-                                        } else {
-                                            self.next_lexeme(laidx)
-                                        };
-                        tstack_uw.push(Node::Term{lexeme: la_lexeme});
+                            l
+                        } else {
+                            self.next_lexeme(laidx)
+                        };
+                        tstack_uw.push(Node::Term { lexeme: la_lexeme });
                     }
                     pstack = pstack.child(state_id);
                     laidx += 1;
-                },
+                }
                 Some(Action::Accept) => {
                     debug_assert_eq!(la_tidx, self.grm.eof_token_idx());
                     if let Some(ref mut tstack_uw) = *tstack {
                         debug_assert_eq!(tstack_uw.len(), 1);
                     }
                     break;
-                },
+                }
                 None => {
                     break;
                 }
@@ -379,10 +404,15 @@ where usize: AsPrimitive<StorageT>
     }
 }
 
-pub trait Recoverer<StorageT: Hash + PrimInt + Unsigned>
-{
-    fn recover(&self, Instant, &Parser<StorageT>, usize, &mut PStack, &mut TStack<StorageT>)
-           -> (usize, Vec<Vec<ParseRepair<StorageT>>>);
+pub trait Recoverer<StorageT: Hash + PrimInt + Unsigned> {
+    fn recover(
+        &self,
+        Instant,
+        &Parser<StorageT>,
+        usize,
+        &mut PStack,
+        &mut TStack<StorageT>
+    ) -> (usize, Vec<Vec<ParseRepair<StorageT>>>);
 }
 
 #[derive(Debug)]
@@ -395,14 +425,14 @@ pub enum RecoveryKind {
 
 /// Parse the lexemes. On success return a parse tree. On failure, return a parse tree (if all the
 /// input was consumed) or `None` otherwise, and a vector of `ParseError`s.
-pub fn parse<StorageT: 'static + Debug + Hash + PrimInt + Unsigned>
-           (grm: &YaccGrammar<StorageT>,
-            sgraph: &StateGraph<StorageT>,
-            stable: &StateTable<StorageT>,
-            lexemes: &Lexemes<StorageT>)
-         -> Result<Node<StorageT>,
-                  (Option<Node<StorageT>>, Vec<ParseError<StorageT>>)>
-      where usize: AsPrimitive<StorageT>
+pub fn parse<StorageT: 'static + Debug + Hash + PrimInt + Unsigned>(
+    grm: &YaccGrammar<StorageT>,
+    sgraph: &StateGraph<StorageT>,
+    stable: &StateTable<StorageT>,
+    lexemes: &Lexemes<StorageT>
+) -> Result<Node<StorageT>, (Option<Node<StorageT>>, Vec<ParseError<StorageT>>)>
+where
+    usize: AsPrimitive<StorageT>
 {
     parse_rcvry(RecoveryKind::MF, grm, |_| 1, sgraph, stable, lexemes)
 }
@@ -410,17 +440,17 @@ pub fn parse<StorageT: 'static + Debug + Hash + PrimInt + Unsigned>
 /// Parse the lexemes, specifying a particularly type of error recovery. On success return a parse
 /// tree. On failure, return a parse tree (if all the input was consumed) or `None` otherwise, and
 /// a vector of `ParseError`s.
-pub fn parse_rcvry
-       <StorageT: 'static + Debug + Hash + PrimInt + Unsigned, F>
-       (rcvry_kind: RecoveryKind,
-        grm: &YaccGrammar<StorageT>,
-        token_cost: F,
-        sgraph: &StateGraph<StorageT>,
-        stable: &StateTable<StorageT>,
-        lexemes: &[Lexeme<StorageT>])
-    -> Result<Node<StorageT>, (Option<Node<StorageT>>, Vec<ParseError<StorageT>>)>
-    where F: Fn(TIdx<StorageT>) -> u8,
-          usize: AsPrimitive<StorageT>
+pub fn parse_rcvry<StorageT: 'static + Debug + Hash + PrimInt + Unsigned, F>(
+    rcvry_kind: RecoveryKind,
+    grm: &YaccGrammar<StorageT>,
+    token_cost: F,
+    sgraph: &StateGraph<StorageT>,
+    stable: &StateTable<StorageT>,
+    lexemes: &[Lexeme<StorageT>]
+) -> Result<Node<StorageT>, (Option<Node<StorageT>>, Vec<ParseError<StorageT>>)>
+where
+    F: Fn(TIdx<StorageT>) -> u8,
+    usize: AsPrimitive<StorageT>
 {
     Parser::parse(rcvry_kind, grm, token_cost, sgraph, stable, lexemes)
 }
@@ -483,51 +513,58 @@ impl<StorageT: PrimInt + Unsigned> ParseError<StorageT> {
 pub(crate) mod test {
     use std::collections::HashMap;
 
+    use super::*;
     use cfgrammar::yacc::{YaccGrammar, YaccKind};
     use lrlex::{build_lex, Lexeme};
-    use lrtable::{Minimiser, from_yacc};
+    use lrtable::{from_yacc, Minimiser};
     use num_traits::ToPrimitive;
-    use super::*;
 
-    pub(crate) fn do_parse(rcvry_kind: RecoveryKind,
-                           lexs: &str,
-                           grms: &str,
-                           input: &str)
-                       -> (YaccGrammar<u16>,
-                           Result<Node<u16>, (Option<Node<u16>>,
-                                              Vec<ParseError<u16>>)>)
-    {
+    pub(crate) fn do_parse(
+        rcvry_kind: RecoveryKind,
+        lexs: &str,
+        grms: &str,
+        input: &str
+    ) -> (
+        YaccGrammar<u16>,
+        Result<Node<u16>, (Option<Node<u16>>, Vec<ParseError<u16>>)>
+    ) {
         do_parse_with_costs(rcvry_kind, lexs, grms, input, &HashMap::new())
     }
 
-    pub(crate) fn do_parse_with_costs(rcvry_kind: RecoveryKind,
-                                      lexs: &str,
-                                      grms: &str,
-                                      input: &str,
-                                      costs: &HashMap<&str, u8>)
-                                  -> (YaccGrammar<u16>,
-                                      Result<Node<u16>, (Option<Node<u16>>,
-                                                         Vec<ParseError<u16>>)>)
-    {
+    pub(crate) fn do_parse_with_costs(
+        rcvry_kind: RecoveryKind,
+        lexs: &str,
+        grms: &str,
+        input: &str,
+        costs: &HashMap<&str, u8>
+    ) -> (
+        YaccGrammar<u16>,
+        Result<Node<u16>, (Option<Node<u16>>, Vec<ParseError<u16>>)>
+    ) {
         let mut lexerdef = build_lex(lexs).unwrap();
         let grm = YaccGrammar::<u16>::new_with_storaget(YaccKind::Original, grms).unwrap();
         let (sgraph, stable) = from_yacc(&grm, Minimiser::Pager).unwrap();
         {
-            let rule_ids = grm.tokens_map().iter()
-                                          .map(|(&n, &i)| (n, u32::from(i).to_u16().unwrap()))
-                                          .collect();
+            let rule_ids = grm
+                .tokens_map()
+                .iter()
+                .map(|(&n, &i)| (n, u32::from(i).to_u16().unwrap()))
+                .collect();
             lexerdef.set_rule_ids(&rule_ids);
         }
         let lexemes = lexerdef.lexer(&input).lexemes().unwrap();
-        let costs_tidx = costs.iter()
-                              .map(|(k, v)| (grm.token_idx(k).unwrap(), v))
-                              .collect::<HashMap<_, _>>();
-        let pr = parse_rcvry(rcvry_kind,
-                             &grm,
-                             move |tidx| **costs_tidx.get(&tidx).unwrap_or(&&1),
-                             &sgraph,
-                             &stable,
-                             &lexemes);
+        let costs_tidx = costs
+            .iter()
+            .map(|(k, v)| (grm.token_idx(k).unwrap(), v))
+            .collect::<HashMap<_, _>>();
+        let pr = parse_rcvry(
+            rcvry_kind,
+            &grm,
+            move |tidx| **costs_tidx.get(&tidx).unwrap_or(&&1),
+            &sgraph,
+            &stable,
+            &lexemes
+        );
         (grm, pr)
     }
 
@@ -656,5 +693,5 @@ Call: 'ID' '(' ')';";
         assert_eq!(errs.len(), 1);
         let err_tok_id = usize::from(grm.token_idx("ID").unwrap()).to_u16().unwrap();
         assert_eq!(errs[0].lexeme(), &Lexeme::new(err_tok_id, 2, 1));
-     }
+    }
 }

--- a/lrtable/src/lib/mod.rs
+++ b/lrtable/src/lib/mod.rs
@@ -35,13 +35,12 @@
 extern crate cfgrammar;
 extern crate fnv;
 extern crate num_traits;
-#[cfg(feature="serde")]
+#[cfg(feature = "serde")]
 #[macro_use]
 extern crate serde;
 extern crate vob;
 
-use std::hash::Hash;
-use std::mem::size_of;
+use std::{hash::Hash, mem::size_of};
 
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 
@@ -103,15 +102,17 @@ pub enum Minimiser {
     Pager
 }
 
-pub fn from_yacc<StorageT: 'static + Hash + PrimInt + Unsigned>
-                (grm: &YaccGrammar<StorageT>, m: Minimiser)
-              -> Result<(StateGraph<StorageT>, StateTable<StorageT>), StateTableError<StorageT>>
-           where usize: AsPrimitive<StorageT>
+pub fn from_yacc<StorageT: 'static + Hash + PrimInt + Unsigned>(
+    grm: &YaccGrammar<StorageT>,
+    m: Minimiser
+) -> Result<(StateGraph<StorageT>, StateTable<StorageT>), StateTableError<StorageT>>
+where
+    usize: AsPrimitive<StorageT>
 {
     match m {
         Minimiser::Pager => {
             let sg = pager::pager_stategraph(grm);
-            let st = try!(StateTable::new(grm, &sg));
+            let st = StateTable::new(grm, &sg)?;
             Ok((sg, st))
         }
     }


### PR DESCRIPTION
The formatting of various parts of grmtools has become quite poor, mostly because of very recent changes. Manually reformatting it is unappealing, so I hoped that [rustfmt](https://github.com/rust-lang-nursery/rustfmt) could do the job. It almost can. However, it has a bug or two which makes it generate incorrect output in a couple of cases; it struggles to format a handful of inline comments correctly (which is a bit weird); and it makes some of the tests much, much harder to read (which isn't really its fault: it just can't know that formatting things in a different way is the right thing to do).

What I've done is manually select as much of the formatting it's done as possible. I've probably selected about 95% of the non-test changes; but quite a lot of the tests I've left as-is, because they're easier to read as they are (splitting them over multiple lines, as is rustfmt's wont, makes comparing multiple `assert`s harder).

It might, in the future, be possible to let rustfmt loose over the whole codebase. Until then, this is, I think, better than nothing.