### PR TITLE
Force lrpar dependencies to be rebuilt if lrpar is recompiled.

### DIFF
--- a/lrpar/Cargo.toml
+++ b/lrpar/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lrpar"
 version = "0.1.0"
 authors = ["Lukas Diekmann <http://lukasdiekmann.com/>", "Laurence Tratt <http://tratt.net/laurie/>"]
+build = "build.rs"
 
 [[bin]]
 doc = false
@@ -10,6 +11,9 @@ name = "lrpar"
 [lib]
 name = "lrpar"
 path = "src/lib/mod.rs"
+
+[build-dependencies]
+vergen = "2"
 
 [dependencies]
 bincode = "1.0"

--- a/lrpar/build.rs
+++ b/lrpar/build.rs
@@ -1,0 +1,43 @@
+// Copyright (c) 2018 King's College London
+// created by the Software Development Team <http://soft-dev.org/>
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
+// copy of this software, associated documentation and/or data (collectively the "Software"), free
+// of charge and under any and all copyright rights in the Software, and any and all patent rights
+// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
+// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
+// below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
+// if one is included with the Software (each a "Larger Work" to which the Software is contributed
+// by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create derivative works
+// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
+// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
+// foregoing rights on either these or other terms.
+//
+// This license is subject to the following condition: The above copyright notice and either this
+// complete permission notice or at a minimum a reference to the UPL must be included in all copies
+// or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+extern crate vergen;
+
+use vergen::{ConstantsFlags, Vergen};
+
+fn main() {
+    let mut vgfl = ConstantsFlags::empty();
+    vgfl.insert(ConstantsFlags::BUILD_TIMESTAMP);
+    for (k, v) in Vergen::new(vgfl).unwrap().build_info() {
+        println!("cargo:rustc-env={}={}", k.name(), v);
+    }
+}

--- a/lrpar/src/lib/builder.rs
+++ b/lrpar/src/lib/builder.rs
@@ -274,6 +274,11 @@ pub fn parse(lexemes: &[Lexeme<{storaget}>])
         let mut cache = String::new();
         cache.push_str(" \n/* CACHE INFORMATION\n");
 
+        // Record the time that this version of lrpar was built. If the source code changes and
+        // rustc forces a recompile, this will change this value, causing anything which depends on
+        // this build of lrpar to be recompiled too.
+        cache.push_str(&format!("   Build time: {:?}", env!("VERGEN_BUILD_TIMESTAMP")));
+
         // Record the recoverer
         cache.push_str(&format!("   Recoverer: {:?}\n", self.recoverer));
 


### PR DESCRIPTION
Previously, if you changed the source code of lrpar, then libraries depending on it wouldn't be recompiled. This caused me some surprise and pain recently when I changed lrpar and couldn't work out why other libraries were not doing the right thing.

This commit uses vergen to embed the timestamp of the build into the lrpar cache; if lrpar is recompiled (e.g. as a result of someone changing the source code), then the cached timestamp will change, and libraries depending on lrpar will be recompiled.