### PR TITLE
Control rustfmt further

### DIFF
--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -77,10 +77,13 @@
 
 #![feature(tool_attributes)]
 
-#[macro_use] extern crate lazy_static;
+#[macro_use]
+extern crate lazy_static;
 extern crate indexmap;
 extern crate num_traits;
-#[cfg(feature="serde")] #[macro_use] extern crate serde;
+#[cfg(feature = "serde")]
+#[macro_use]
+extern crate serde;
 extern crate vob;
 
 mod idxnewtype;
@@ -95,4 +98,3 @@ pub enum Symbol<StorageT> {
     Rule(RIdx<StorageT>),
     Token(TIdx<StorageT>)
 }
-

--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -75,6 +75,8 @@
 //! [`YaccGrammar::new_with_storaget()`](yacc/grammar/struct.YaccGrammar.html#method.new_with_storaget)
 //! which take as input a Yacc grammar.
 
+#![feature(tool_attributes)]
+
 #[macro_use] extern crate lazy_static;
 extern crate indexmap;
 extern crate num_traits;

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -94,18 +94,24 @@ impl fmt::Display for GrammarValidationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.kind {
             GrammarValidationErrorKind::NoStartRule => write!(f, "No start rule specified"),
-            GrammarValidationErrorKind::InvalidStartRule => {
-                write!(f, "Start rule '{}' does not appear in grammar", self.sym.as_ref().unwrap())
-            },
-            GrammarValidationErrorKind::UnknownRuleRef => {
-                write!(f, "Unknown reference to rule '{}'", self.sym.as_ref().unwrap())
-            },
+            GrammarValidationErrorKind::InvalidStartRule => write!(
+                f,
+                "Start rule '{}' does not appear in grammar",
+                self.sym.as_ref().unwrap()
+            ),
+            GrammarValidationErrorKind::UnknownRuleRef => write!(
+                f,
+                "Unknown reference to rule '{}'",
+                self.sym.as_ref().unwrap()
+            ),
             GrammarValidationErrorKind::UnknownToken => {
                 write!(f, "Unknown token '{}'", self.sym.as_ref().unwrap())
-            },
-            GrammarValidationErrorKind::NoPrecForToken => {
-                write!(f, "Token '{}' used in %prec has no precedence attached", self.sym.as_ref().unwrap())
             }
+            GrammarValidationErrorKind::NoPrecForToken => write!(
+                f,
+                "Token '{}' used in %prec has no precedence attached",
+                self.sym.as_ref().unwrap()
+            )
         }
     }
 }

--- a/cfgrammar/src/lib/yacc/firsts.rs
+++ b/cfgrammar/src/lib/yacc/firsts.rs
@@ -105,7 +105,7 @@ where
                                     changed = true;
                                 }
                                 break;
-                            },
+                            }
                             Symbol::Rule(s_ridx) => {
                                 // if we're dealing with another rule, union its FIRSTs
                                 // together with the current rules FIRSTs. Note this is
@@ -134,7 +134,7 @@ where
                                 if !firsts.is_epsilon_set(s_ridx) {
                                     break;
                                 }
-                            },
+                            }
                         }
                     }
                 }

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -168,7 +168,7 @@ where
             YaccKind::Original => {
                 implicit_rule = None;
                 implicit_start_rule = None;
-            },
+            }
             YaccKind::Eco => {
                 if ast.implicit_tokens.is_some() {
                     let mut n1 = IMPLICIT_RULE.to_string();
@@ -285,7 +285,7 @@ where
                     match *astsym {
                         ast::Symbol::Rule(ref n) => {
                             prod.push(Symbol::Rule(rule_map[n]));
-                        },
+                        }
                         ast::Symbol::Token(ref n) => {
                             prod.push(Symbol::Token(token_map[n]));
                             if implicit_rule.is_some() {
@@ -629,7 +629,7 @@ where
                     Symbol::Rule(s_ridx) => {
                         st.push((pidx, sidx + 1));
                         st.push((cheapest_prod(*s_ridx), 0));
-                    },
+                    }
                     Symbol::Token(s_tidx) => {
                         s.push(*s_tidx);
                     }
@@ -964,18 +964,20 @@ mod test {
         assert_eq!(*r_prod, [Symbol::Token(grm.token_idx("T").unwrap())]);
         assert_eq!(grm.prods_rules, vec![RIdx(1), RIdx(0)]);
 
-        assert_eq!(grm.tokens_map(),
-                   [("T", TIdx(0))].iter()
-                                                .cloned()
-                                                .collect::<HashMap<&str, TIdx<_>>>());
-        assert_eq!(grm.iter_rules().collect::<Vec<_>>(),
-                   vec![RIdx(0), RIdx(1)]);
+        assert_eq!(
+            grm.tokens_map(),
+            [("T", TIdx(0))]
+                .iter()
+                .cloned()
+                .collect::<HashMap<&str, TIdx<_>>>()
+        );
+        assert_eq!(grm.iter_rules().collect::<Vec<_>>(), vec![RIdx(0), RIdx(1)]);
     }
 
     #[test]
     fn test_rule_ref() {
-        let grm = YaccGrammar::new(YaccKind::Original,
-                           "%start R %token T %% R : S; S: 'T';").unwrap();
+        let grm =
+            YaccGrammar::new(YaccKind::Original, "%start R %token T %% R : S; S: 'T';").unwrap();
 
         grm.rule_idx("^").unwrap();
         grm.rule_idx("R").unwrap();
@@ -983,9 +985,10 @@ mod test {
         grm.token_idx("T").unwrap();
         assert!(grm.token_name(grm.eof_token_idx()).is_none());
 
-        assert_eq!(grm.rules_prods, vec![vec![PIdx(2)],
-                                         vec![PIdx(0)],
-                                         vec![PIdx(1)]]);
+        assert_eq!(
+            grm.rules_prods,
+            vec![vec![PIdx(2)], vec![PIdx(0)], vec![PIdx(1)]]
+        );
         let start_prod = grm.prod(grm.rules_prods[usize::from(grm.rule_idx("^").unwrap())][0]);
         assert_eq!(*start_prod, [Symbol::Rule(grm.rule_idx("R").unwrap())]);
         let r_prod = grm.prod(grm.rules_prods[usize::from(grm.rule_idx("R").unwrap())][0]);

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -997,6 +997,7 @@ mod test {
     }
 
     #[test]
+    #[rustfmt::skip]
     fn test_long_prod() {
         let grm = YaccGrammar::new(
             YaccKind::Original,
@@ -1049,6 +1050,7 @@ mod test {
     }
 
     #[test]
+    #[rustfmt::skip]
     fn test_left_right_nonassoc_precs() {
         let grm = YaccGrammar::new(
             YaccKind::Original,
@@ -1081,6 +1083,7 @@ mod test {
     }
 
     #[test]
+    #[rustfmt::skip]
     fn test_prec_override() {
         let grm = YaccGrammar::new(
             YaccKind::Original,
@@ -1108,6 +1111,7 @@ mod test {
     }
 
     #[test]
+    #[rustfmt::skip]
     fn test_implicit_tokens_rewrite() {
         let grm = YaccGrammar::new(
             YaccKind::Eco,
@@ -1183,6 +1187,7 @@ mod test {
     }
 
     #[test]
+    #[rustfmt::skip]
     fn test_has_path() {
         let grm = YaccGrammar::new(
             YaccKind::Original,
@@ -1209,6 +1214,7 @@ mod test {
     }
 
     #[test]
+    #[rustfmt::skip]
     fn test_rule_min_costs() {
         let grm = YaccGrammar::new(
             YaccKind::Original,
@@ -1277,6 +1283,7 @@ mod test {
     }
 
     #[test]
+    #[rustfmt::skip]
     fn test_rule_max_costs1() {
         let grm = YaccGrammar::new(
             YaccKind::Original,
@@ -1300,6 +1307,7 @@ mod test {
     }
 
     #[test]
+    #[rustfmt::skip]
     fn test_rule_max_costs2() {
         let grm = YaccGrammar::new(
             YaccKind::Original,

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -788,6 +788,7 @@ x".to_string();
     }
 
     #[test]
+    #[rustfmt::skip]
     fn test_unknown_declaration() {
         let src = "%woo".to_string();
         match parse(YaccKind::Original, &src) {
@@ -802,6 +803,7 @@ x".to_string();
     }
 
     #[test]
+    #[rustfmt::skip]
     fn test_precs() {
         let src = "
           %left '+' '-'
@@ -865,6 +867,7 @@ x".to_string();
     }
 
     #[test]
+    #[rustfmt::skip]
     fn test_prec_override() {
         // Taken from the Yacc manual
         let src = "

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -826,41 +826,45 @@ x".to_string();
     #[test]
     fn test_dup_precs() {
         let srcs = vec![
-          "
+            "
           %left 'x'
           %left 'x'
           %%
           ",
-          "
+            "
           %left 'x'
           %right 'x'
           %%
           ",
-          "
+            "
           %right 'x'
           %right 'x'
           %%
           ",
-          "
+            "
           %nonassoc 'x'
           %nonassoc 'x'
           %%
           ",
-          "
+            "
           %left 'x'
           %nonassoc 'x'
           %%
           ",
-          "
+            "
           %right 'x'
           %nonassoc 'x'
           %%
-          "
-          ];
+          ",
+        ];
         for src in srcs.iter() {
             match parse(YaccKind::Original, &src.to_string()) {
                 Ok(_) => panic!("Duplicate precedence parsed"),
-                Err(YaccParserError{kind: YaccParserErrorKind::DuplicatePrecedence, line: 3, ..}) => (),
+                Err(YaccParserError {
+                    kind: YaccParserErrorKind::DuplicatePrecedence,
+                    line: 3,
+                    ..
+                }) => (),
                 Err(e) => panic!("Incorrect error returned {}", e)
             }
         }
@@ -891,85 +895,134 @@ x".to_string();
 
     #[test]
     fn test_bad_prec_overrides() {
-        match parse(YaccKind::Original, &"
+        match parse(
+            YaccKind::Original,
+            &"
           %%
           S: 'A' %prec ;
-          ") {
-                Ok(_) => panic!("Incorrect %prec parsed"),
-                Err(YaccParserError{kind: YaccParserErrorKind::IllegalString, line: 3, ..}) => (),
-                Err(e) => panic!("Incorrect error returned {}", e)
+          "
+        ) {
+            Ok(_) => panic!("Incorrect %prec parsed"),
+            Err(YaccParserError {
+                kind: YaccParserErrorKind::IllegalString,
+                line: 3,
+                ..
+            }) => (),
+            Err(e) => panic!("Incorrect error returned {}", e)
         }
 
-        match parse(YaccKind::Original, &"
+        match parse(
+            YaccKind::Original,
+            &"
           %%
           S: 'A' %prec B;
           B: ;
-          ") {
-                Ok(_) => panic!("Incorrect %prec parsed"),
-                Err(YaccParserError{kind: YaccParserErrorKind::PrecNotFollowedByToken, line: 3, ..}) => (),
-                Err(e) => panic!("Incorrect error returned {}", e)
+          "
+        ) {
+            Ok(_) => panic!("Incorrect %prec parsed"),
+            Err(YaccParserError {
+                kind: YaccParserErrorKind::PrecNotFollowedByToken,
+                line: 3,
+                ..
+            }) => (),
+            Err(e) => panic!("Incorrect error returned {}", e)
         }
     }
 
     #[test]
     fn test_no_implicit_tokens_in_original_yacc() {
-        match parse(YaccKind::Original, &"
+        match parse(
+            YaccKind::Original,
+            &"
           %implicit_tokens X
           %%
-          ") {
+          "
+        ) {
             Ok(_) => panic!(),
-            Err(YaccParserError{kind: YaccParserErrorKind::UnknownDeclaration, line: 2, ..}) => (),
+            Err(YaccParserError {
+                kind: YaccParserErrorKind::UnknownDeclaration,
+                line: 2,
+                ..
+            }) => (),
             Err(e) => panic!("Incorrect error returned {}", e)
         }
     }
 
     #[test]
     fn test_parse_implicit_tokens() {
-        let ast = parse(YaccKind::Eco, &"
+        let ast = parse(
+            YaccKind::Eco,
+            &"
           %implicit_tokens ws1 ws2
           %start R
           %%
           R: 'a';
-          ").unwrap();
-        assert_eq!(ast.implicit_tokens, Some(["ws1".to_string(), "ws2".to_string()].iter().cloned().collect()));
+          "
+        ).unwrap();
+        assert_eq!(
+            ast.implicit_tokens,
+            Some(
+                ["ws1".to_string(), "ws2".to_string()]
+                    .iter()
+                    .cloned()
+                    .collect()
+            )
+        );
         assert!(ast.tokens.get("ws1").is_some());
         assert!(ast.tokens.get("ws2").is_some());
     }
 
     #[test]
     fn test_duplicate_implicit_tokens() {
-        match parse(YaccKind::Eco, &"
+        match parse(
+            YaccKind::Eco,
+            &"
           %implicit_tokens X
           %implicit_tokens Y
           %%
-          ") {
+          "
+        ) {
             Ok(_) => panic!(),
-            Err(YaccParserError{kind: YaccParserErrorKind::DuplicateImplicitTokensDeclaration, line: 3, ..}) => (),
+            Err(YaccParserError {
+                kind: YaccParserErrorKind::DuplicateImplicitTokensDeclaration,
+                line: 3,
+                ..
+            }) => (),
             Err(e) => panic!("Incorrect error returned {}", e)
         }
     }
 
     #[test]
     fn test_duplicate_start() {
-        match parse(YaccKind::Eco, &"
+        match parse(
+            YaccKind::Eco,
+            &"
           %start X
           %start X
           %%
-          ") {
+          "
+        ) {
             Ok(_) => panic!(),
-            Err(YaccParserError{kind: YaccParserErrorKind::DuplicateStartDeclaration, line: 3, ..}) => (),
+            Err(YaccParserError {
+                kind: YaccParserErrorKind::DuplicateStartDeclaration,
+                line: 3,
+                ..
+            }) => (),
             Err(e) => panic!("Incorrect error returned {}", e)
         }
     }
 
     #[test]
     fn test_implicit_start() {
-        let ast = parse(YaccKind::Eco, &"
+        let ast = parse(
+            YaccKind::Eco,
+            &"
           %%
           R: ;
           R2: ;
           R3: ;
-          ").unwrap();
+          "
+        ).unwrap();
         assert_eq!(ast.start, Some("R".to_string()));
     }
 
@@ -984,39 +1037,57 @@ x".to_string();
         let grm = parse(YaccKind::Original, src).unwrap();
         assert!(grm.has_token("a"));
 
-        match parse(YaccKind::Original, &"
+        match parse(
+            YaccKind::Original,
+            &"
             /* An invalid comment * /
             %token   a
             %%\n
-            A : a;")
-        {
+            A : a;"
+        ) {
             Ok(_) => panic!(),
-            Err(YaccParserError{kind: YaccParserErrorKind::IncompleteComment, line: 2, ..}) => (),
+            Err(YaccParserError {
+                kind: YaccParserErrorKind::IncompleteComment,
+                line: 2,
+                ..
+            }) => (),
             Err(e) => panic!("Incorrect error returned {}", e)
         }
 
-        match parse(YaccKind::Original, &"
+        match parse(
+            YaccKind::Original,
+            &"
             %token   a
             %%
             /* A valid
              * multi-line comment
              */
             /* An invalid comment * /
-            A : a;")
-        {
+            A : a;"
+        ) {
             Ok(_) => panic!(),
-            Err(YaccParserError{kind: YaccParserErrorKind::IncompleteComment, line: 7, ..}) => (),
+            Err(YaccParserError {
+                kind: YaccParserErrorKind::IncompleteComment,
+                line: 7,
+                ..
+            }) => (),
             Err(e) => panic!("Incorrect error returned {}", e)
         }
 
-        match parse(YaccKind::Original, &"
+        match parse(
+            YaccKind::Original,
+            &"
             %token   a
             %%
             // Valid comment
-            A : a")
-        {
+            A : a"
+        ) {
             Ok(_) => panic!(),
-            Err(YaccParserError{kind: YaccParserErrorKind::IncompleteRule, line: 5, ..}) => (),
+            Err(YaccParserError {
+                kind: YaccParserErrorKind::IncompleteRule,
+                line: 5,
+                ..
+            }) => (),
             Err(e) => panic!("Incorrect error returned {}", e)
         }
     }

--- a/lrlex/examples/calclex/src/main.rs
+++ b/lrlex/examples/calclex/src/main.rs
@@ -1,6 +1,7 @@
 use std::io::{self, BufRead, Write};
 
-#[macro_use] extern crate lrlex;
+#[macro_use]
+extern crate lrlex;
 
 // Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
 lrlex_mod!(calc_l);
@@ -21,7 +22,7 @@ fn main() {
                     Ok(lexemes) => println!("{:?}", lexemes),
                     Err(e) => println!("{:?}", e)
                 }
-            },
+            }
             _ => break
         }
     }

--- a/lrlex/src/lib/builder.rs
+++ b/lrlex/src/lib/builder.rs
@@ -233,10 +233,13 @@ where
 impl<StorageT: Copy + Debug + Eq + TypeName> LexerDef<StorageT> {
     pub(crate) fn rust_pp(&self, outs: &mut String) {
         // Header
-        outs.push_str(&format!("use lrlex::{{LexerDef, Rule}};
+        outs.push_str(&format!(
+            "use lrlex::{{LexerDef, Rule}};
 
 pub fn lexerdef() -> LexerDef<{}> {{
-    let rules = vec![", StorageT::type_name()));
+    let rules = vec![",
+            StorageT::type_name()
+        ));
 
         // Individual rules
         for r in &self.rules {
@@ -248,16 +251,22 @@ pub fn lexerdef() -> LexerDef<{}> {{
                 Some(ref n) => format!("Some({:?}.to_string())", n),
                 None => "None".to_owned()
             };
-            outs.push_str(&format!("
+            outs.push_str(&format!(
+                "
 Rule::new({}, {}, \"{}\".to_string()).unwrap(),",
-                tok_id, n, r.re_str.replace("\\", "\\\\").replace("\"", "\\\"")));
+                tok_id,
+                n,
+                r.re_str.replace("\\", "\\\\").replace("\"", "\\\"")
+            ));
         }
 
         // Footer
-        outs.push_str("
+        outs.push_str(
+            "
 ];
     LexerDef::new(rules)
 }
-");
+"
+        );
     }
 }

--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -51,8 +51,8 @@ pub type LexBuildResult<T> = Result<T, LexBuildError>;
 #[derive(Debug)]
 pub struct LexBuildError {
     pub kind: LexErrorKind,
-    line:     usize,
-    col:      usize
+    line: usize,
+    col: usize
 }
 
 impl Error for LexBuildError {}

--- a/lrlex/src/lib/parser.rs
+++ b/lrlex/src/lib/parser.rs
@@ -247,11 +247,16 @@ mod test {
     fn test_broken_rule() {
         let src = "%%
 [0-9]
-'int'".to_string();
+'int'"
+            .to_string();
         assert!(parse_lex::<u8>(&src).is_err());
         match parse_lex::<u8>(&src) {
-            Ok(_)  => panic!("Broken rule parsed"),
-            Err(LexBuildError{kind: LexErrorKind::MissingSpace, line: 2, col: 1}) => (),
+            Ok(_) => panic!("Broken rule parsed"),
+            Err(LexBuildError {
+                kind: LexErrorKind::MissingSpace,
+                line: 2,
+                col: 1
+            }) => (),
             Err(e) => panic!("Incorrect error returned {}", e)
         }
     }
@@ -259,11 +264,16 @@ mod test {
     #[test]
     fn test_broken_rule2() {
         let src = "%%
-[0-9] ".to_string();
+[0-9] "
+            .to_string();
         assert!(parse_lex::<u8>(&src).is_err());
         match parse_lex::<u8>(&src) {
-            Ok(_)  => panic!("Broken rule parsed"),
-            Err(LexBuildError{kind: LexErrorKind::MissingSpace, line: 2, col: 1}) => (),
+            Ok(_) => panic!("Broken rule parsed"),
+            Err(LexBuildError {
+                kind: LexErrorKind::MissingSpace,
+                line: 2,
+                col: 1
+            }) => (),
             Err(e) => panic!("Incorrect error returned {}", e)
         }
     }
@@ -271,11 +281,16 @@ mod test {
     #[test]
     fn test_broken_rule3() {
         let src = "%%
-[0-9] int".to_string();
+[0-9] int"
+            .to_string();
         assert!(parse_lex::<u8>(&src).is_err());
         match parse_lex::<u8>(&src) {
-            Ok(_)  => panic!("Broken rule parsed"),
-            Err(LexBuildError{kind: LexErrorKind::InvalidName, line: 2, col: 7}) => (),
+            Ok(_) => panic!("Broken rule parsed"),
+            Err(LexBuildError {
+                kind: LexErrorKind::InvalidName,
+                line: 2,
+                col: 7
+            }) => (),
             Err(e) => panic!("Incorrect error returned {}", e)
         }
     }
@@ -283,11 +298,16 @@ mod test {
     #[test]
     fn test_broken_rule4() {
         let src = "%%
-[0-9] 'int".to_string();
+[0-9] 'int"
+            .to_string();
         assert!(parse_lex::<u8>(&src).is_err());
         match parse_lex::<u8>(&src) {
-            Ok(_)  => panic!("Broken rule parsed"),
-            Err(LexBuildError{kind: LexErrorKind::InvalidName, line: 2, col: 7}) => (),
+            Ok(_) => panic!("Broken rule parsed"),
+            Err(LexBuildError {
+                kind: LexErrorKind::InvalidName,
+                line: 2,
+                col: 7
+            }) => (),
             Err(e) => panic!("Incorrect error returned {}", e)
         }
     }
@@ -296,10 +316,15 @@ mod test {
     fn test_duplicate_rule() {
         let src = "%%
 [0-9] 'int'
-[0-9] 'int'".to_string();
+[0-9] 'int'"
+            .to_string();
         match parse_lex::<u8>(&src) {
-            Ok(_)  => panic!("Duplicate rule parsed"),
-            Err(LexBuildError{kind: LexErrorKind::DuplicateName, line: 3, col: 7}) => (),
+            Ok(_) => panic!("Duplicate rule parsed"),
+            Err(LexBuildError {
+                kind: LexErrorKind::DuplicateName,
+                line: 3,
+                col: 7
+            }) => (),
             Err(e) => panic!("Incorrect error returned {}", e)
         }
     }

--- a/lrpar/src/lib/builder.rs
+++ b/lrpar/src/lib/builder.rs
@@ -217,12 +217,15 @@ where
         // Header
         let mod_name = inp.as_ref().file_stem().unwrap().to_str().unwrap();
         outs.push_str(&format!("mod {}_y {{", mod_name));
-        outs.push_str(&format!("use lrpar::{{Node, parse_rcvry, ParseError, reconstitute, RecoveryKind}};
+        outs.push_str(&format!(
+            "use lrpar::{{Node, parse_rcvry, ParseError, reconstitute, RecoveryKind}};
 use lrlex::Lexeme;
 
 pub fn parse(lexemes: &[Lexeme<{storaget}>])
           -> Result<Node<{storaget}>, (Option<Node<{storaget}>>, Vec<ParseError<{storaget}>>)>
-{{", storaget=StorageT::type_name()));
+{{",
+            storaget = StorageT::type_name()
+        ));
 
         // grm, sgraph, stable
         let recoverer = match self.recoverer {
@@ -231,7 +234,8 @@ pub fn parse(lexemes: &[Lexeme<{storaget}>])
             RecoveryKind::Panic => "Panic",
             RecoveryKind::None => "None"
         };
-        outs.push_str(&format!("
+        outs.push_str(&format!(
+            "
     let (grm, sgraph, stable) = reconstitute(include_bytes!(\"{}\"),
                                              include_bytes!(\"{}\"),
                                              include_bytes!(\"{}\"));
@@ -277,7 +281,10 @@ pub fn parse(lexemes: &[Lexeme<{storaget}>])
         // Record the time that this version of lrpar was built. If the source code changes and
         // rustc forces a recompile, this will change this value, causing anything which depends on
         // this build of lrpar to be recompiled too.
-        cache.push_str(&format!("   Build time: {:?}", env!("VERGEN_BUILD_TIMESTAMP")));
+        cache.push_str(&format!(
+            "   Build time: {:?}",
+            env!("VERGEN_BUILD_TIMESTAMP")
+        ));
 
         // Record the recoverer
         cache.push_str(&format!("   Recoverer: {:?}\n", self.recoverer));

--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -529,19 +529,19 @@ E : 'N'
         //    E
         //     E
         //      N n
-        //     + 
+        //     +
         //     N n
         //    )
         // is also the result of a valid minimal-cost repair, but, since the repair involves a
         // Shift, rank_cnds will always put this too low down the list for us to ever see it.
         if !vec![
-"E
+            "E
  ( (
  E
   N n
  ) 
 ",
-"E
+            "E
  E
   ( (
   E
@@ -549,9 +549,10 @@ E : 'N'
   ) 
  + 
  N n
-"]
-            .iter()
-            .any(|x| *x == pp) {
+",
+        ].iter()
+        .any(|x| *x == pp)
+        {
             panic!("Can't find a match for {}", pp);
         }
 

--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -1261,7 +1261,7 @@ E: '(' E ')'
         let (pt, errs) = pr.unwrap_err();
         let pp = pt.unwrap().pp(&grm, &us);
         if !vec![
-"E
+            "E
  ( (
  E
   ( (
@@ -1270,7 +1270,7 @@ E: '(' E ')'
   ) 
  ) 
 ",
-"E
+            "E
  ( (
  E
   ( (
@@ -1278,9 +1278,10 @@ E: '(' E ')'
    B 
   ) 
  ) 
-"]
-            .iter()
-            .any(|x| *x == pp) {
+",
+        ].iter()
+        .any(|x| *x == pp)
+        {
             panic!("Can't find a match for {}", pp);
         }
         assert_eq!(errs.len(), 1);

--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -851,6 +851,7 @@ mod test {
     }
 
     #[test]
+    #[rustfmt::skip]
     fn dist_kimyi() {
         let grms = "%start A
 %%
@@ -914,6 +915,7 @@ A: '(' A ')'
     }
 
     #[test]
+    #[rustfmt::skip]
     fn dist_short() {
         let grms = "%start S
 %%
@@ -966,6 +968,7 @@ U: 'B';
     }
 
     #[test]
+    #[rustfmt::skip]
     fn dist_large() {
         let grms = "%start Expr
 %%
@@ -1016,6 +1019,7 @@ Factor: '(' Expr ')'
     }
 
     #[test]
+    #[rustfmt::skip]
     fn dist_nested() {
         let grms = "%start S
 %%
@@ -1150,6 +1154,7 @@ A: '(' A ')'
     }
 
     #[test]
+    #[rustfmt::skip]
     fn corchuelo_example() {
         // The example from the Corchuelo paper
         let lexs = "%%

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -36,7 +36,8 @@ extern crate bincode;
 extern crate cactus;
 extern crate cfgrammar;
 extern crate filetime;
-#[macro_use] extern crate indexmap;
+#[macro_use]
+extern crate indexmap;
 extern crate lrlex;
 extern crate lrtable;
 extern crate num_traits;

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -576,25 +576,27 @@ pub(crate) mod test {
     #[test]
     fn simple_parse() {
         // From p4 of https://www.cs.umd.edu/class/spring2014/cmsc430/lectures/lec07.pdf
-        check_parse_output("%%
+        check_parse_output(
+            "%%
 [a-zA-Z_] 'ID'
 \\+ '+'",
-"
+            "
 %start E
 %%
 E: T '+' E
  | T;
 T: 'ID';
 ",
-"a+b",
-"E
+            "a+b",
+            "E
  T
   ID a
  + +
  E
   T
    ID b
-");
+"
+        );
     }
 
     #[test]
@@ -607,16 +609,21 @@ S: L;
 L: 'ID'
  | ;
 ";
-        check_parse_output(&lexs, &grms, "",
-"S
+        check_parse_output(
+            &lexs, &grms, "", "S
  L
-");
+",
+        );
 
-        check_parse_output(&lexs, &grms, "x",
-"S
+        check_parse_output(
+            &lexs,
+            &grms,
+            "x",
+            "S
  L
   ID x
-");
+"
+        );
     }
 
     #[test]
@@ -632,8 +639,11 @@ Expr : Term '+' Expr | Term;
 Term : Factor '*' Term | Factor;
 Factor : 'INT';";
 
-        check_parse_output(&lexs, &grms, "2+3*4",
-"Expr
+        check_parse_output(
+            &lexs,
+            &grms,
+            "2+3*4",
+            "Expr
  Term
   Factor
    INT 2
@@ -646,9 +656,13 @@ Factor : 'INT';";
    Term
     Factor
      INT 4
-");
-        check_parse_output(&lexs, &grms, "2*3+4",
-"Expr
+"
+        );
+        check_parse_output(
+            &lexs,
+            &grms,
+            "2*3+4",
+            "Expr
  Term
   Factor
    INT 2
@@ -661,7 +675,8 @@ Factor : 'INT';";
   Term
    Factor
     INT 4
-");
+"
+        );
     }
 
     #[test]
@@ -675,12 +690,16 @@ Factor : 'INT';";
 %%
 Call: 'ID' '(' ')';";
 
-        check_parse_output(&lexs, &grms, "f()",
-"Call
+        check_parse_output(
+            &lexs,
+            &grms,
+            "f()",
+            "Call
  ID f
  ( (
  ) )
-");
+"
+        );
 
         let (grm, pr) = do_parse(RecoveryKind::MF, &lexs, &grms, "f(");
         let (_, errs) = pr.unwrap_err();

--- a/lrtable/src/lib/itemset.rs
+++ b/lrtable/src/lib/itemset.rs
@@ -227,7 +227,9 @@ mod test {
     }
 
     fn eco_grammar() -> YaccGrammar {
-        YaccGrammar::new(YaccKind::Original, &"
+        YaccGrammar::new(
+            YaccKind::Original,
+            &"
           %start S
           %token a b c d f
           %%
@@ -237,7 +239,8 @@ mod test {
           C: D A;
           D: 'd' | ;
           F: C D 'f';
-          ").unwrap()
+          "
+        ).unwrap()
     }
 
     #[test]
@@ -274,13 +277,16 @@ mod test {
     //     a
     //     aSb
     fn grammar3() -> YaccGrammar {
-        YaccGrammar::new(YaccKind::Original, &"
+        YaccGrammar::new(
+            YaccKind::Original,
+            &"
           %start S
           %token a b c d
           %%
           S: S 'b' | 'b' A 'a';
           A: 'a' S 'c' | 'a' | 'a' S 'b';
-          ").unwrap()
+          "
+        ).unwrap()
     }
 
     #[test]

--- a/lrtable/src/lib/itemset.rs
+++ b/lrtable/src/lib/itemset.rs
@@ -196,6 +196,7 @@ mod test {
     use vob::Vob;
 
     #[test]
+    #[rustfmt::skip]
     fn test_dragon_grammar() {
         // From http://binarysculpting.com/2012/02/04/computing-lr1-closure/
         let grm = &YaccGrammar::new(
@@ -240,6 +241,7 @@ mod test {
     }
 
     #[test]
+    #[rustfmt::skip]
     fn test_closure1_ecogrm() {
         let grm = eco_grammar();
         let firsts = grm.firsts();
@@ -282,6 +284,7 @@ mod test {
     }
 
     #[test]
+    #[rustfmt::skip]
     fn test_closure1_grm3() {
         let grm = grammar3();
         let firsts = grm.firsts();
@@ -316,6 +319,7 @@ mod test {
     }
 
     #[test]
+    #[rustfmt::skip]
     fn test_goto1() {
         let grm = grammar3();
         let firsts = grm.firsts();

--- a/lrtable/src/lib/pager.rs
+++ b/lrtable/src/lib/pager.rs
@@ -466,6 +466,7 @@ mod test {
     }
 
     #[test]
+    #[rustfmt::skip]
     fn test_stategraph() {
         let grm = grammar3();
         let sg = pager_stategraph(&grm);
@@ -545,6 +546,7 @@ mod test {
         ).unwrap()
     }
 
+    #[rustfmt::skip]
     fn test_pager_graph(grm: &YaccGrammar) {
         let sg = pager_stategraph(&grm);
 
@@ -695,6 +697,7 @@ mod test {
     }
 
     #[test]
+    #[rustfmt::skip]
     fn test_pager_graph_core_states() {
         let grm = grammar_pager();
         let sg = pager_stategraph(&grm);

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -269,6 +269,7 @@ mod test {
     use StIdx;
 
     #[test]
+    #[rustfmt::skip]
     fn test_statetable_core() {
         // Taken from p13 of https://link.springer.com/article/10.1007/s00236-010-0115-6
         let grm = YaccGrammar::new(

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -807,16 +807,25 @@ mod test {
 
     #[test]
     fn accept_reduce_conflict() {
-        let grm = YaccGrammar::new(YaccKind::Original, &"
+        let grm = YaccGrammar::new(
+            YaccKind::Original,
+            &"
 %start D
 %%
 D : D;
-          ").unwrap();
+          "
+        ).unwrap();
         let sg = pager_stategraph(&grm);
         match StateTable::new(&grm, &sg) {
             Ok(_) => panic!("Infinitely recursive rule let through"),
-            Err(StateTableError{kind: StateTableErrorKind::AcceptReduceConflict, pidx})
-                if pidx == PIdx(1) => (),
+            Err(StateTableError {
+                kind: StateTableErrorKind::AcceptReduceConflict,
+                pidx
+            })
+                if pidx == PIdx(1) =>
+            {
+                ()
+            }
             Err(e) => panic!("Incorrect error returned {:?}", e)
         }
     }

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -480,6 +480,7 @@ mod test {
     use StIdx;
 
     #[test]
+    #[rustfmt::skip]
     fn test_statetable() {
         // Taken from p19 of www.cs.umd.edu/~mvz/cmsc430-s07/M10lr.pdf
         let grm = YaccGrammar::new(
@@ -562,6 +563,7 @@ mod test {
     }
 
     #[test]
+    #[rustfmt::skip]
     fn test_default_reduce_reduce() {
         let grm = YaccGrammar::new(YaccKind::Original, &"
             %start A
@@ -583,6 +585,7 @@ mod test {
     }
 
     #[test]
+    #[rustfmt::skip]
     fn test_default_shift_reduce() {
         let grm = YaccGrammar::new(YaccKind::Original, &"
             %start Expr
@@ -610,6 +613,7 @@ mod test {
     }
 
     #[test]
+    #[rustfmt::skip]
     fn test_conflict_resolution() {
         // Example taken from p54 of Locally least-cost error repair in LR parsers, Carl Cerecke
         let grm = YaccGrammar::new(YaccKind::Original, &"
@@ -635,6 +639,7 @@ mod test {
     }
 
     #[test]
+    #[rustfmt::skip]
     fn test_left_associativity() {
         let grm = YaccGrammar::new(YaccKind::Original, &"
             %start Expr
@@ -672,6 +677,7 @@ mod test {
     }
 
     #[test]
+    #[rustfmt::skip]
     fn test_left_right_associativity() {
         let grm = &YaccGrammar::new(YaccKind::Original, &"
             %start Expr
@@ -726,6 +732,7 @@ mod test {
     }
 
     #[test]
+    #[rustfmt::skip]
     fn test_left_right_nonassoc_associativity() {
         let grm = YaccGrammar::new(YaccKind::Original, &"
             %start Expr


### PR DESCRIPTION
The basic aim of this PR is to ttop rustfmt formatting some things that it can't do a good job of, allowing us to reduce the diff between `cargo fmt --all` and the repo. In fact, we reduce that diff by 15x with this PR (from ~1500 lines to ~100).

The basic problem is that some of the tests in this repository are formatted to make reading them (and spotting problems) much easier (generally by following vertical information). rustfmt doesn't (and can't) know about it. Although this commit makes all of grmtools nightly only (at least until [tool_attributes stabilises](https://github.com/rust-lang/rust/issues/44690), it gets us much closer to "run rustfmt all the time."

https://github.com/softdevteam/grmtools/commit/686059e6f7852aef7fc379a2becbe60308a65615 is the important commit: it uses `#[rustfmt::skip]` to turn rustfmt off on functions where it can't do a job. https://github.com/softdevteam/grmtools/commit/695a65b7dd0e0884d7034ee4c7cbe3d3a418a29e then simply applies many of the remaining diffs that rustfmt produces to our repository.