### PR TITLE
tool_attributes has stabilised.

### DIFF
--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -75,8 +75,6 @@
 //! [`YaccGrammar::new_with_storaget()`](yacc/grammar/struct.YaccGrammar.html#method.new_with_storaget)
 //! which take as input a Yacc grammar.
 
-#![feature(tool_attributes)]
-
 #[macro_use]
 extern crate lazy_static;
 extern crate indexmap;


### PR DESCRIPTION
After upgrading Rust nightly, I was greeted by this:

```
  warning: the feature `tool_attributes` has been stable since 1.30.0 and no
  longer requires an attribute to enable
    --> cfgrammar/src/lib/mod.rs:78:12
     |
  78 | #![feature(tool_attributes)]
     |            ^^^^^^^^^^^^^^^
     |
     = note: #[warn(stable_features)] on by default
```

That means that we don't need this #![feature] on for nightly and, in Rust 1.30 onwards, won't need it for stable either.