### PR TITLE
Use packed vectors to store state tables

### DIFF
--- a/lrpar/src/lib/builder.rs
+++ b/lrpar/src/lib/builder.rs
@@ -72,7 +72,8 @@ pub struct ParserBuilder<StorageT = u32> {
 impl<StorageT> ParserBuilder<StorageT>
 where
     StorageT: 'static + Debug + Hash + PrimInt + Serialize + TypeName + Unsigned,
-    usize: AsPrimitive<StorageT>
+    usize: AsPrimitive<StorageT>,
+    u32: AsPrimitive<StorageT>
 {
     /// Create a new `ParserBuilder`.
     ///

--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -135,7 +135,8 @@ pub(crate) fn recoverer<'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigne
     parser: &'a Parser<StorageT>
 ) -> Box<Recoverer<StorageT> + 'a>
 where
-    usize: AsPrimitive<StorageT>
+    usize: AsPrimitive<StorageT>,
+    u32: AsPrimitive<StorageT>
 {
     Box::new(CPCTPlus { parser })
 }
@@ -143,7 +144,8 @@ where
 impl<'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned> Recoverer<StorageT>
     for CPCTPlus<'a, StorageT>
 where
-    usize: AsPrimitive<StorageT>
+    usize: AsPrimitive<StorageT>,
+    u32: AsPrimitive<StorageT>
 {
     fn recover(
         &self,
@@ -268,7 +270,8 @@ where
 
 impl<'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned> CPCTPlus<'a, StorageT>
 where
-    usize: AsPrimitive<StorageT>
+    usize: AsPrimitive<StorageT>,
+    u32: AsPrimitive<StorageT>
 {
     fn insert(&self, n: &PathFNode<StorageT>, nbrs: &mut Vec<(u16, PathFNode<StorageT>)>) {
         let laidx = n.laidx;

--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -140,7 +140,8 @@ pub(crate) fn recoverer<'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigne
     parser: &'a Parser<StorageT>
 ) -> Box<Recoverer<StorageT> + 'a>
 where
-    usize: AsPrimitive<StorageT>
+    usize: AsPrimitive<StorageT>,
+    u32: AsPrimitive<StorageT>
 {
     let dist = Dist::new(parser.grm, parser.sgraph, parser.stable, parser.token_cost);
     Box::new(MF { dist, parser })
@@ -149,7 +150,8 @@ where
 impl<'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned> Recoverer<StorageT>
     for MF<'a, StorageT>
 where
-    usize: AsPrimitive<StorageT>
+    usize: AsPrimitive<StorageT>,
+    u32: AsPrimitive<StorageT>
 {
     fn recover(
         &self,
@@ -261,7 +263,8 @@ where
 
 impl<'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned> MF<'a, StorageT>
 where
-    usize: AsPrimitive<StorageT>
+    usize: AsPrimitive<StorageT>,
+    u32: AsPrimitive<StorageT>
 {
     fn insert(&self, n: &PathFNode<StorageT>, nbrs: &mut Vec<(u16, u16, PathFNode<StorageT>)>) {
         let top_pstack = *n.pstack.val().unwrap();
@@ -538,7 +541,8 @@ pub(crate) fn rank_cnds<StorageT: 'static + Debug + Hash + PrimInt + Unsigned>(
     in_cnds: Vec<Vec<Vec<ParseRepair<StorageT>>>>
 ) -> Vec<Vec<ParseRepair<StorageT>>>
 where
-    usize: AsPrimitive<StorageT>
+    usize: AsPrimitive<StorageT>,
+    u32: AsPrimitive<StorageT>
 {
     let mut cnds = Vec::new();
     let mut furthest = 0;
@@ -580,7 +584,8 @@ pub(crate) fn apply_repairs<StorageT: 'static + Debug + Hash + PrimInt + Unsigne
     repairs: &[ParseRepair<StorageT>]
 ) -> usize
 where
-    usize: AsPrimitive<StorageT>
+    usize: AsPrimitive<StorageT>,
+    u32: AsPrimitive<StorageT>
 {
     for r in repairs.iter() {
         match *r {
@@ -632,7 +637,8 @@ pub(crate) struct Dist<StorageT> {
 
 impl<StorageT: 'static + Hash + PrimInt + Unsigned> Dist<StorageT>
 where
-    usize: AsPrimitive<StorageT>
+    usize: AsPrimitive<StorageT>,
+    u32: AsPrimitive<StorageT>
 {
     pub(crate) fn new<F>(
         grm: &YaccGrammar<StorageT>,

--- a/lrpar/src/lib/panic.rs
+++ b/lrpar/src/lib/panic.rs
@@ -43,14 +43,16 @@ pub(crate) fn recoverer<'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigne
     _: &'a Parser<StorageT>
 ) -> Box<Recoverer<StorageT> + 'a>
 where
-    usize: AsPrimitive<StorageT>
+    usize: AsPrimitive<StorageT>,
+    u32: AsPrimitive<StorageT>
 {
     Box::new(Panic)
 }
 
 impl<StorageT: 'static + Debug + Hash + PrimInt + Unsigned> Recoverer<StorageT> for Panic
 where
-    usize: AsPrimitive<StorageT>
+    usize: AsPrimitive<StorageT>,
+    u32: AsPrimitive<StorageT>
 {
     fn recover(
         &self,

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -108,7 +108,8 @@ pub struct Parser<'a, StorageT: 'a + Eq + Hash> {
 
 impl<'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned> Parser<'a, StorageT>
 where
-    usize: AsPrimitive<StorageT>
+    usize: AsPrimitive<StorageT>,
+    u32: AsPrimitive<StorageT>
 {
     fn parse<F>(
         rcvry_kind: RecoveryKind,
@@ -439,7 +440,8 @@ pub fn parse<StorageT: 'static + Debug + Hash + PrimInt + Unsigned>(
     lexemes: &Lexemes<StorageT>
 ) -> Result<Node<StorageT>, (Option<Node<StorageT>>, Vec<ParseError<StorageT>>)>
 where
-    usize: AsPrimitive<StorageT>
+    usize: AsPrimitive<StorageT>,
+    u32: AsPrimitive<StorageT>
 {
     parse_rcvry(RecoveryKind::MF, grm, |_| 1, sgraph, stable, lexemes)
 }
@@ -457,7 +459,8 @@ pub fn parse_rcvry<StorageT: 'static + Debug + Hash + PrimInt + Unsigned, F>(
 ) -> Result<Node<StorageT>, (Option<Node<StorageT>>, Vec<ParseError<StorageT>>)>
 where
     F: Fn(TIdx<StorageT>) -> u8,
-    usize: AsPrimitive<StorageT>
+    usize: AsPrimitive<StorageT>,
+    u32: AsPrimitive<StorageT>
 {
     Parser::parse(rcvry_kind, grm, token_cost, sgraph, stable, lexemes)
 }

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -192,7 +192,7 @@ where
                     debug_assert_eq!(tstack.len(), 1);
                     return true;
                 }
-                None => {
+                Some(Action::Error) => {
                     if recoverer.is_none() {
                         recoverer = Some(match self.rcvry_kind {
                             RecoveryKind::CPCTPlus => cpctplus::recoverer(self),
@@ -234,7 +234,8 @@ where
                         return false;
                     }
                     laidx = new_laidx;
-                }
+                },
+                None => ()
             }
         }
     }
@@ -288,6 +289,9 @@ where
                     laidx += 1;
                 }
                 Some(Action::Accept) => {
+                    break;
+                }
+                Some(Action::Error) => {
                     break;
                 }
                 None => {
@@ -395,6 +399,9 @@ where
                     }
                     break;
                 }
+                Some(Action::Error) => {
+                    break;
+                },
                 None => {
                     break;
                 }

--- a/lrtable/Cargo.toml
+++ b/lrtable/Cargo.toml
@@ -16,3 +16,4 @@ num-traits = "0.2"
 cfgrammar = { path="../cfgrammar", features=["serde"] }
 serde = { version="1.0", features=["derive"], optional=true }
 vob = { version="1.3", features=["serde"] }
+packed_vec = { git = "https://github.com/gabi-250/packed-vec", features=["serde"] }

--- a/lrtable/src/lib/mod.rs
+++ b/lrtable/src/lib/mod.rs
@@ -66,6 +66,12 @@ type StIdxStorageT = u32;
 // we can change our storage to u32 later transparently.
 pub struct StIdx(u16);
 
+impl StIdx {
+    fn max_value() -> StIdx {
+        StIdx(u16::max_value())
+    }
+}
+
 impl From<StIdxStorageT> for StIdx {
     fn from(v: StIdxStorageT) -> Self {
         if v > StIdxStorageT::from(u16::max_value()) {

--- a/lrtable/src/lib/mod.rs
+++ b/lrtable/src/lib/mod.rs
@@ -113,7 +113,8 @@ pub fn from_yacc<StorageT: 'static + Hash + PrimInt + Unsigned>(
     m: Minimiser
 ) -> Result<(StateGraph<StorageT>, StateTable<StorageT>), StateTableError<StorageT>>
 where
-    usize: AsPrimitive<StorageT>
+    usize: AsPrimitive<StorageT>,
+    u32: AsPrimitive<StorageT>
 {
     match m {
         Minimiser::Pager => {

--- a/lrtable/src/lib/mod.rs
+++ b/lrtable/src/lib/mod.rs
@@ -39,6 +39,7 @@ extern crate num_traits;
 #[macro_use]
 extern crate serde;
 extern crate vob;
+extern crate packed_vec;
 
 use std::{hash::Hash, mem::size_of};
 

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -31,10 +31,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 use std::{
-    collections::hash_map::{Entry, HashMap, OccupiedEntry},
+    collections::hash_map::{HashMap},
     error::Error,
     fmt::{self, Debug},
-    hash::{BuildHasherDefault, Hash},
+    hash::{Hash},
     marker::PhantomData
 };
 
@@ -42,7 +42,6 @@ use cfgrammar::{
     yacc::{AssocKind, YaccGrammar},
     PIdx, RIdx, Symbol, TIdx
 };
-use fnv::FnvHasher;
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 use vob::{IterSetBits, Vob};
 
@@ -85,7 +84,7 @@ pub struct StateTable<StorageT> {
     //   0  shift 1
     //   1  shift 0  reduce B
     // is represented as a hashtable {0: shift 1, 2: shift 0, 3: reduce 4}.
-    actions: HashMap<u32, Action<StorageT>, BuildHasherDefault<FnvHasher>>,
+    actions: Vec<u32>,
     state_actions: Vob,
     gotos: Vec<StIdx>,
     core_reduces: Vob,
@@ -109,8 +108,14 @@ pub enum Action<StorageT> {
     /// Reduce production X in the grammar.
     Reduce(PIdx<StorageT>),
     /// Accept this input.
-    Accept
+    Accept,
+    Error
 }
+
+const SHIFT: u8 = 1;
+const REDUCE: u8 = 2;
+const ACCEPT: u8 = 3;
+const ERROR: u8 = 0;
 
 impl<StorageT: 'static + Hash + PrimInt + Unsigned> StateTable<StorageT>
 where
@@ -120,17 +125,20 @@ where
         grm: &YaccGrammar<StorageT>,
         sg: &StateGraph<StorageT>
     ) -> Result<Self, StateTableError<StorageT>> {
-        let mut actions = HashMap::with_hasher(BuildHasherDefault::<FnvHasher>::default());
         let mut state_actions = Vob::from_elem(
             usize::from(sg.all_states_len())
                 .checked_mul(usize::from(grm.tokens_len()))
                 .unwrap(),
             false
         );
-        let max = usize::from(grm.rules_len()) * usize::from(sg.all_states_len());
-        assert!(usize::from(sg.all_states_len()) < usize::from(StIdx::max_value()));
-        let mut gotos: Vec<StIdx> = Vec::with_capacity(max);
-        gotos.resize(max, StIdx::max_value());
+        let maxa = usize::from(grm.tokens_len()) * usize::from(sg.all_states_len());
+        let maxg = usize::from(grm.rules_len()) * usize::from(sg.all_states_len());
+        // We only have 30 bits to store state IDs
+        assert!(usize::from(sg.all_states_len()) < (u32::max_value() - 4) as usize);
+        let mut actions: Vec<u32> = Vec::with_capacity(maxa);
+        actions.resize(maxa, 0);
+        let mut gotos: Vec<StIdx> = Vec::with_capacity(maxg);
+        gotos.resize(maxg, StIdx::max_value());
 
         let mut reduce_reduce = 0; // How many automatically resolved reduce/reduces were made?
         let mut shift_reduce = 0; // How many automatically resolved shift/reduces were made?
@@ -155,9 +163,7 @@ where
                         TIdx(tidx.as_())
                     );
                     state_actions.set(off as usize, true);
-                    match actions.entry(off) {
-                        Entry::Occupied(mut e) => {
-                            match *e.get_mut() {
+                    match StateTable::decode(actions[off as usize]) {
                                 Action::Reduce(r_pidx) => {
                                     if pidx == grm.start_prod()
                                         && tidx == usize::from(grm.eof_token_idx())
@@ -171,7 +177,7 @@ where
                                     // of the earlier production in the grammar.
                                     if pidx < r_pidx {
                                         reduce_reduce += 1;
-                                        e.insert(Action::Reduce(pidx));
+                                        actions[off as usize] = StateTable::encode(Action::Reduce(pidx));
                                     } else if pidx > r_pidx {
                                         reduce_reduce += 1;
                                     }
@@ -182,19 +188,17 @@ where
                                         pidx
                                     })
                                 }
+                                Action::Error => {
+                                    if pidx == grm.start_prod() && tidx == usize::from(grm.eof_token_idx())
+                                    {
+                                        assert!(final_state.is_none());
+                                        final_state = Some(stidx);
+                                        actions[off as usize] = StateTable::encode(Action::Accept);
+                                    } else {
+                                        actions[off as usize] = StateTable::encode(Action::Reduce(pidx));
+                                    }
+                                }
                                 _ => panic!("Internal error")
-                            }
-                        }
-                        Entry::Vacant(e) => {
-                            if pidx == grm.start_prod() && tidx == usize::from(grm.eof_token_idx())
-                            {
-                                assert!(final_state.is_none());
-                                final_state = Some(stidx);
-                                e.insert(Action::Accept);
-                            } else {
-                                e.insert(Action::Reduce(pidx));
-                            }
-                        }
                     }
                 }
             }
@@ -218,17 +222,15 @@ where
                         // Populate shifts
                         let off = actions_offset(grm.tokens_len(), stidx, s_tidx);
                         state_actions.set(off as usize, true);
-                        match actions.entry(off) {
-                            Entry::Occupied(mut e) => match *e.get_mut() {
-                                Action::Shift(x) => assert_eq!(*ref_stidx, x),
-                                Action::Reduce(r_pidx) => {
-                                    shift_reduce +=
-                                        resolve_shift_reduce(grm, e, s_tidx, r_pidx, *ref_stidx);
-                                }
-                                Action::Accept => panic!("Internal error")
-                            },
-                            Entry::Vacant(e) => {
-                                e.insert(Action::Shift(*ref_stidx));
+                        match StateTable::decode(actions[off as usize]) {
+                            Action::Shift(x) => assert_eq!(*ref_stidx, x),
+                            Action::Reduce(r_pidx) => {
+                                shift_reduce +=
+                                    resolve_shift_reduce(grm, &mut actions, off as usize, s_tidx, r_pidx, *ref_stidx);
+                            }
+                            Action::Accept => panic!("Internal error"),
+                            Action::Error => {
+                                actions[off as usize] = StateTable::encode(Action::Shift(*ref_stidx));
                             }
                         }
                     }
@@ -256,20 +258,20 @@ where
             let mut only_reduces = true;
             for tidx in grm.iter_tidxs() {
                 let off = actions_offset(grm.tokens_len(), stidx, tidx);
-                match actions.get(&off) {
-                    Some(&Action::Reduce(pidx)) => {
+                match StateTable::decode(actions[off as usize]) {
+                    Action::Reduce(pidx) => {
                         let prod_len = grm.prod(pidx).len();
                         let ridx = grm.prod_to_rule(pidx);
                         nt_depth.insert((ridx, prod_len), pidx);
                     }
-                    Some(&Action::Shift(_)) => {
+                    Action::Shift(_) => {
                         only_reduces = false;
                         state_shifts.set(off as usize, true);
                     }
-                    Some(&Action::Accept) => {
+                    Action::Accept => {
                         only_reduces = false;
                     }
-                    None => ()
+                    Action::Error => ()
                 }
             }
 
@@ -306,10 +308,35 @@ where
         })
     }
 
+    fn decode(bits: u32) -> Action<StorageT> {
+        let action = (bits & 0b11) as u8;
+        let val: u32 = bits >> 2;
+
+        match action {
+            SHIFT => Action::Shift(StIdx::from(val)),
+            REDUCE => Action::Reduce(PIdx(StorageT::from(val).unwrap())),
+            ACCEPT => Action::Accept,
+            ERROR => Action::Error,
+            _ => unreachable!()
+        }
+    }
+
+    fn encode(action: Action<StorageT>) -> u32 {
+        let enc:u32;
+        match action {
+            Action::Shift(stidx) => { enc = SHIFT as u32 | (u32::from(stidx) << 2); },
+            Action::Reduce(r_pidx) => { enc = REDUCE as u32 | (u32::from(r_pidx) << 2); },
+            Action::Accept => { enc = ACCEPT as u32; },
+            Action::Error => { enc = ERROR as u32; }
+        }
+        enc
+    }
+
     /// Return the action for `stidx` and `sym`, or `None` if there isn't any.
     pub fn action(&self, stidx: StIdx, tidx: TIdx<StorageT>) -> Option<Action<StorageT>> {
         let off = actions_offset(self.tokens_len, stidx, tidx);
-        self.actions.get(&off).and_then(|x| Some(*x))
+        // For now leave this as an option so we don't need to touch all the other libraries
+        Some(StateTable::decode(self.actions[off as usize]))
     }
 
     /// Return an iterator over the indexes of all non-empty actions of `stidx`.
@@ -386,6 +413,8 @@ fn actions_offset<StorageT: PrimInt + Unsigned>(
     StIdxStorageT::from(stidx) * StIdxStorageT::from(tokens_len) + StIdxStorageT::from(tidx)
 }
 
+
+
 pub struct StateActionsIterator<'a, StorageT> {
     iter: IterSetBits<'a, usize>,
     start: usize,
@@ -426,7 +455,8 @@ where
 
 fn resolve_shift_reduce<StorageT: 'static + Hash + PrimInt + Unsigned>(
     grm: &YaccGrammar<StorageT>,
-    mut e: OccupiedEntry<u32, Action<StorageT>>,
+    actions: &mut Vec<u32>,
+    off: usize,
     tidx: TIdx<StorageT>,
     pidx: PIdx<StorageT>,
     stidx: StIdx
@@ -441,7 +471,7 @@ where
         (_, None) | (None, _) => {
             // If the token and production don't both have precedences, we use Yacc's default
             // resolution, which is in favour of the shift.
-            e.insert(Action::Shift(stidx));
+            actions[off] = StateTable::encode(Action::Shift(stidx));
             shift_reduce += 1;
         }
         (Some(token_prec), Some(prod_prec)) => {
@@ -455,12 +485,12 @@ where
                     }
                     (AssocKind::Right, AssocKind::Right) => {
                         // Right associativity is resolved in favour of the shift.
-                        e.insert(Action::Shift(stidx));
+                        actions[off] = StateTable::encode(Action::Shift(stidx));
                     }
                     (AssocKind::Nonassoc, AssocKind::Nonassoc) => {
                         // Nonassociativity leads to a run-time parsing error, so we need to remove
                         // the action entirely.
-                        e.remove();
+                        actions[off] = StateTable::encode(Action::Error);
                     }
                     (_, _) => {
                         panic!("Not supported.");
@@ -468,7 +498,7 @@ where
                 }
             } else if token_prec.level > prod_prec.level {
                 // The token has higher level precedence, so resolve in favour of shift.
-                e.insert(Action::Shift(stidx));
+                actions[off] = StateTable::encode(Action::Shift(stidx));
             }
             // If token_lev < prod_lev, then the production has higher level precedence and we keep
             // the reduce as-is.
@@ -518,7 +548,7 @@ mod test {
         let st = StateTable::new(&grm, &sg).unwrap();
 
         // Actions
-        assert_eq!(st.actions.len(), 15);
+        assert_eq!(st.actions.len(), 9*4);
         let assert_reduce = |stidx: StIdx, tidx: TIdx<_>, rule: &str, prod_off: usize| {
             let pidx = grm.rule_to_prods(grm.rule_idx(rule).unwrap())[prod_off];
             assert_eq!(st.action(stidx, tidx).unwrap(), Action::Reduce(pidx.into()));
@@ -583,7 +613,9 @@ mod test {
           ").unwrap();
         let sg = pager_stategraph(&grm);
         let st = StateTable::new(&grm, &sg).unwrap();
-        assert_eq!(st.actions.len(), 8);
+
+        let len = usize::from(grm.tokens_len()) * usize::from(sg.all_states_len());
+        assert_eq!(st.actions.len(), len);
 
         // We only extract the states necessary to test those rules affected by the reduce/reduce.
         let s0 = StIdx(0);
@@ -605,7 +637,8 @@ mod test {
           ").unwrap();
         let sg = pager_stategraph(&grm);
         let st = StateTable::new(&grm, &sg).unwrap();
-        assert_eq!(st.actions.len(), 15);
+        let len = usize::from(grm.tokens_len()) * usize::from(sg.all_states_len());
+        assert_eq!(st.actions.len(), len);
 
         let s0 = StIdx(0);
         let s1 = sg.edge(s0, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
@@ -661,7 +694,8 @@ mod test {
           ").unwrap();
         let sg = pager_stategraph(&grm);
         let st = StateTable::new(&grm, &sg).unwrap();
-        assert_eq!(st.actions.len(), 15);
+        let len = usize::from(grm.tokens_len()) * usize::from(sg.all_states_len());
+        assert_eq!(st.actions.len(), len);
 
         let s0 = StIdx(0);
         let s1 = sg.edge(s0, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
@@ -701,7 +735,8 @@ mod test {
           ").unwrap();
         let sg = pager_stategraph(&grm);
         let st = StateTable::new(&grm, &sg).unwrap();
-        assert_eq!(st.actions.len(), 24);
+        let len = usize::from(grm.tokens_len()) * usize::from(sg.all_states_len());
+        assert_eq!(st.actions.len(), len);
 
         let s0 = StIdx(0);
         let s1 = sg.edge(s0, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
@@ -758,7 +793,8 @@ mod test {
           ").unwrap();
         let sg = pager_stategraph(&grm);
         let st = StateTable::new(&grm, &sg).unwrap();
-        assert_eq!(st.actions.len(), 34);
+        let len = usize::from(grm.tokens_len()) * usize::from(sg.all_states_len());
+        assert_eq!(st.actions.len(), len);
 
         let s0 = StIdx(0);
         let s1 = sg.edge(s0, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -45,6 +45,7 @@ use cfgrammar::{
 };
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 use vob::{IterSetBits, Vob};
+use packed_vec::PackedVec;
 
 use {StIdx, StIdxStorageT};
 use stategraph::StateGraph;
@@ -85,7 +86,7 @@ pub struct StateTable<StorageT> {
     //   0  shift 1
     //   1  shift 0  reduce B
     // is represented as a hashtable {0: shift 1, 2: shift 0, 3: reduce 4}.
-    actions: Vec<u32>,
+    actions: PackedVec<u32>,
     state_actions: Vob,
     gotos: Vec<StIdx>,
     core_reduces: Vob,
@@ -294,6 +295,8 @@ where
             }
         }
 
+        let actions = PackedVec::new(actions);
+
         Ok(StateTable {
             actions,
             state_actions,
@@ -338,7 +341,7 @@ where
     pub fn action(&self, stidx: StIdx, tidx: TIdx<StorageT>) -> Option<Action<StorageT>> {
         let off = actions_offset(self.tokens_len, stidx, tidx);
         // For now leave this as an option so we don't need to touch all the other libraries
-        Some(StateTable::decode(self.actions[off as usize]))
+        Some(StateTable::decode(self.actions.get(off as usize).unwrap()))
     }
 
     /// Return an iterator over the indexes of all non-empty actions of `stidx`.


### PR DESCRIPTION
This PR replaces the state table HashMaps (`goto` and `actions`) with packed vectors. This sacrifices memory usage for performance, as it makes table lookups O(1).

Previously, states were stored as `(stIdx, ridx) => stidx`, where `stidx` is a state id, and ridx is a rule id. Now, lookups are done by calculating an index into the vector from `stidx` and `ridx` which reveals the state, e.g. `goto[stidx * nt_len + ridx]`, where `nt_len` is the amount of nonterminals in the grammar.

We then use https://github.com/gabi-250/packed-vec to pack the vectors to reduce memory usage.