### PR TITLE
Make the Lexer trait be a pseudo-iterator.

### DIFF
--- a/lrlex/examples/calclex/src/main.rs
+++ b/lrlex/examples/calclex/src/main.rs
@@ -21,7 +21,7 @@ fn main() {
                 // Now we create a lexer with the `lexer` method with which we can lex an input.
                 // Note that each lexer can only lex one input in its lifetime.
                 let mut lexer = lexerdef.lexer(l);
-                match lexer.lexemes() {
+                match lexer.all_lexemes() {
                     Ok(lexemes) => println!("{:?}", lexemes),
                     Err(e) => println!("{:?}", e)
                 }

--- a/lrlex/examples/calclex/src/main.rs
+++ b/lrlex/examples/calclex/src/main.rs
@@ -20,7 +20,7 @@ fn main() {
             Some(Ok(ref l)) => {
                 // Now we create a lexer with the `lexer` method with which we can lex an input.
                 // Note that each lexer can only lex one input in its lifetime.
-                let lexer = lexerdef.lexer(l);
+                let mut lexer = lexerdef.lexer(l);
                 match lexer.lexemes() {
                     Ok(lexemes) => println!("{:?}", lexemes),
                     Err(e) => println!("{:?}", e)

--- a/lrlex/src/main.rs
+++ b/lrlex/src/main.rs
@@ -93,7 +93,7 @@ fn main() {
         process::exit(1);
     });
     let input = &read_file(&matches.free[1]);
-    let lexemes = lexerdef.lexer(input).lexemes().unwrap();
+    let lexemes = lexerdef.lexer(input).all_lexemes().unwrap();
     for l in &lexemes {
         println!(
             "{} {}",

--- a/lrpar/examples/calcparse/build.rs
+++ b/lrpar/examples/calcparse/build.rs
@@ -34,7 +34,7 @@ extern crate lrlex;
 extern crate lrpar;
 
 use lrlex::LexerBuilder;
-use lrpar::ParserBuilder;
+use lrpar::CTParserBuilder;
 
 fn main() -> Result<(), Box<std::error::Error>> {
     // First we create the parser, which returns a HashMap of all the tokens used, then we pass
@@ -43,7 +43,7 @@ fn main() -> Result<(), Box<std::error::Error>> {
     // Note that we specify the integer type (u8) we'll use for token IDs (this type *must* be big
     // enough to fit all IDs in) as well as the input file (which must end in ".y" for lrpar, and
     // ".l" for lrlex).
-    let lex_rule_ids_map = ParserBuilder::<u8>::new().process_file_in_src("calc.y")?;
+    let lex_rule_ids_map = CTParserBuilder::<u8>::new().process_file_in_src("calc.y")?;
     LexerBuilder::new()
         .rule_ids_map(lex_rule_ids_map)
         .process_file_in_src("calc.l")?;

--- a/lrpar/examples/calcparse/src/main.rs
+++ b/lrpar/examples/calcparse/src/main.rs
@@ -29,7 +29,7 @@ fn main() {
                 // Now we create a lexer with the `lexer` method with which we can lex an input.
                 // Note that each lexer can only lex one input in its lifetime.
                 let mut lexer = lexerdef.lexer(l);
-                match lexer.lexemes() {
+                match lexer.all_lexemes() {
                     Ok(lexemes) => {
                         // Now parse the stream of lexemes into a tree
                         match calc_y::parse(&lexemes) {

--- a/lrpar/examples/calcparse/src/main.rs
+++ b/lrpar/examples/calcparse/src/main.rs
@@ -1,8 +1,10 @@
 use std::io::{self, BufRead, Write};
 
 extern crate cfgrammar;
-#[macro_use] extern crate lrlex;
-#[macro_use] extern crate lrpar;
+#[macro_use]
+extern crate lrlex;
+#[macro_use]
+extern crate lrpar;
 
 use cfgrammar::RIdx;
 use lrpar::{Lexer, Node};
@@ -26,7 +28,7 @@ fn main() {
                 }
                 // Now we create a lexer with the `lexer` method with which we can lex an input.
                 // Note that each lexer can only lex one input in its lifetime.
-                let lexer = lexerdef.lexer(l);
+                let mut lexer = lexerdef.lexer(l);
                 match lexer.lexemes() {
                     Ok(lexemes) => {
                         // Now parse the stream of lexemes into a tree

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -60,22 +60,22 @@ const RUST_FILE_EXT: &str = "rs";
 const SGRAPH_FILE_EXT: &str = "sgraph";
 const STABLE_FILE_EXT: &str = "stable";
 
-/// A `ParserBuilder` allows one to specify the criteria for building a statically generated
+/// A `CTParserBuilder` allows one to specify the criteria for building a statically generated
 /// parser.
-pub struct ParserBuilder<StorageT = u32> {
+pub struct CTParserBuilder<StorageT = u32> {
     // Anything stored in here almost certainly needs to be included as part of the rebuild_cache
     // function below so that, if it's changed, the grammar is rebuilt.
     recoverer: RecoveryKind,
     phantom: PhantomData<StorageT>
 }
 
-impl<StorageT> ParserBuilder<StorageT>
+impl<StorageT> CTParserBuilder<StorageT>
 where
     StorageT: 'static + Debug + Hash + PrimInt + Serialize + TypeName + Unsigned,
     usize: AsPrimitive<StorageT>,
     u32: AsPrimitive<StorageT>
 {
-    /// Create a new `ParserBuilder`.
+    /// Create a new `CTParserBuilder`.
     ///
     /// `StorageT` must be an unsigned integer type (e.g. `u8`, `u16`) which is big enough to index
     /// (separately) all the tokens, rules, and productions in the grammar and less than or
@@ -89,12 +89,12 @@ where
     /// # Examples
     ///
     /// ```rust,ignore
-    /// ParserBuilder::<u8>::new()
+    /// CTParserBuilder::<u8>::new()
     ///     .process_file_in_src("grm.y")
     ///     .unwrap();
     /// ```
     pub fn new() -> Self {
-        ParserBuilder {
+        CTParserBuilder {
             recoverer: RecoveryKind::MF,
             phantom: PhantomData
         }
@@ -108,7 +108,7 @@ where
 
     /// Given the filename `x/y.z` as input, statically compile the grammar `src/x/y.z` into a Rust
     /// module which can then be imported using `lrpar_mod!(x_y)`. This is a convenience function
-    /// around [`process_file`](struct.ParserBuilder.html#method.process_file) which makes it
+    /// around [`process_file`](struct.CTParserBuilder.html#method.process_file) which makes it
     /// easier to compile `.y` files stored in a project's `src/` directory. Note that leaf names
     /// must be unique within a single project, even if they are in different directories: in other
     /// words, `y.z` and `x/y.z` will both be mapped to the same module `y_z` (and it is undefined
@@ -219,7 +219,8 @@ where
         let mod_name = inp.as_ref().file_stem().unwrap().to_str().unwrap();
         outs.push_str(&format!("mod {}_y {{", mod_name));
         outs.push_str(&format!(
-            "use lrpar::{{Lexeme, Node, parse_rcvry, ParseError, reconstitute, RecoveryKind}};
+            "use lrpar::{{Lexeme, Node, parse_rcvry, ParseError, RecoveryKind}};
+use lrpar::ctbuilder::_reconstitute;
 
 pub fn parse(lexemes: &[Lexeme<{storaget}>])
           -> Result<Node<{storaget}>, (Option<Node<{storaget}>>, Vec<ParseError<{storaget}>>)>
@@ -236,9 +237,9 @@ pub fn parse(lexemes: &[Lexeme<{storaget}>])
         };
         outs.push_str(&format!(
             "
-    let (grm, sgraph, stable) = reconstitute(include_bytes!(\"{}\"),
-                                             include_bytes!(\"{}\"),
-                                             include_bytes!(\"{}\"));
+    let (grm, sgraph, stable) = _reconstitute(include_bytes!(\"{}\"),
+                                              include_bytes!(\"{}\"),
+                                              include_bytes!(\"{}\"));
     parse_rcvry(RecoveryKind::{}, &grm, |_| 1, &sgraph, &stable, lexemes)
 ",
             out_grm.to_str().unwrap(),
@@ -320,7 +321,7 @@ pub fn parse(lexemes: &[Lexeme<{storaget}>])
 /// This function is called by generated files; it exists so that generated files don't require a
 /// dependency on serde and rmps.
 #[doc(hidden)]
-pub fn reconstitute<'a, StorageT: Deserialize<'a> + Hash + PrimInt + Unsigned>(
+pub fn _reconstitute<'a, StorageT: Deserialize<'a> + Hash + PrimInt + Unsigned>(
     grm_buf: &'a [u8],
     sgraph_buf: &'a [u8],
     stable_buf: &'a [u8]

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -219,11 +219,11 @@ where
         let mod_name = inp.as_ref().file_stem().unwrap().to_str().unwrap();
         outs.push_str(&format!("mod {}_y {{", mod_name));
         outs.push_str(&format!(
-            "use lrpar::{{Lexeme, Node, parse_rcvry, ParseError, RecoveryKind}};
+            "use lrpar::{{Lexer, Node, LexParseError, RecoveryKind, RTParserBuilder}};
 use lrpar::ctbuilder::_reconstitute;
 
-pub fn parse(lexemes: &[Lexeme<{storaget}>])
-          -> Result<Node<{storaget}>, (Option<Node<{storaget}>>, Vec<ParseError<{storaget}>>)>
+pub fn parse(lexer: &mut Lexer<{storaget}>)
+          -> Result<Node<{storaget}>, LexParseError<{storaget}>>
 {{",
             storaget = StorageT::type_name()
         ));
@@ -240,7 +240,9 @@ pub fn parse(lexemes: &[Lexeme<{storaget}>])
     let (grm, sgraph, stable) = _reconstitute(include_bytes!(\"{}\"),
                                               include_bytes!(\"{}\"),
                                               include_bytes!(\"{}\"));
-    parse_rcvry(RecoveryKind::{}, &grm, |_| 1, &sgraph, &stable, lexemes)
+    RTParserBuilder::new(&grm, &sgraph, &stable)
+        .recoverer(RecoveryKind::{})
+        .parse(lexer)
 ",
             out_grm.to_str().unwrap(),
             out_sgraph.to_str().unwrap(),

--- a/lrpar/src/lib/lex.rs
+++ b/lrpar/src/lib/lex.rs
@@ -7,11 +7,7 @@ pub struct LexError {
     pub idx: usize
 }
 
-impl Error for LexError {
-    fn cause(&self) -> Option<&Error> {
-        None
-    }
-}
+impl Error for LexError {}
 
 impl fmt::Display for LexError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/lrpar/src/lib/lex.rs
+++ b/lrpar/src/lib/lex.rs
@@ -20,7 +20,7 @@ impl fmt::Display for LexError {
 }
 
 pub trait Lexer<StorageT: Hash + PrimInt + Unsigned> {
-    fn lexemes(&self) -> Result<Vec<Lexeme<StorageT>>, LexError>;
+    fn lexemes(&mut self) -> Result<Vec<Lexeme<StorageT>>, LexError>;
     fn line_and_col(&self, &Lexeme<StorageT>) -> Result<(usize, usize), ()>;
 }
 
@@ -67,4 +67,3 @@ impl<StorageT: Copy> Lexeme<StorageT> {
         self.len == 0
     }
 }
-

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -49,8 +49,8 @@ extern crate typename;
 extern crate vob;
 
 mod astar;
-mod builder;
 mod cpctplus;
+pub mod ctbuilder;
 pub mod lex;
 pub use lex::{LexError, Lexeme, Lexer};
 mod panic;
@@ -58,7 +58,7 @@ pub mod parser;
 pub use parser::{parse_rcvry, Node, ParseError, ParseRepair, RecoveryKind};
 mod mf;
 
-pub use builder::{reconstitute, ParserBuilder};
+pub use ctbuilder::CTParserBuilder;
 
 /// A convenience macro for including statically compiled `.y` files. A file `src/x.y` which is
 /// statically compiled by lrpar can then be used in a crate with `lrpar_mod!(x)`.

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -55,7 +55,7 @@ pub mod lex;
 pub use lex::{LexError, Lexeme, Lexer};
 mod panic;
 pub mod parser;
-pub use parser::{parse_rcvry, Node, ParseError, ParseRepair, RecoveryKind};
+pub use parser::{Node, RTParserBuilder, ParseError, ParseRepair, RecoveryKind};
 mod mf;
 
 pub use ctbuilder::CTParserBuilder;

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -55,7 +55,7 @@ pub mod lex;
 pub use lex::{LexError, Lexeme, Lexer};
 mod panic;
 pub mod parser;
-pub use parser::{Node, RTParserBuilder, ParseError, ParseRepair, RecoveryKind};
+pub use parser::{Node, LexParseError, RTParserBuilder, ParseError, ParseRepair, RecoveryKind};
 mod mf;
 
 pub use ctbuilder::CTParserBuilder;

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -52,7 +52,7 @@ mod astar;
 mod builder;
 mod cpctplus;
 pub mod lex;
-pub use lex::{Lexeme, Lexer, LexError};
+pub use lex::{LexError, Lexeme, Lexer};
 mod panic;
 pub mod parser;
 pub use parser::{parse_rcvry, Node, ParseError, ParseRepair, RecoveryKind};

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -528,8 +528,8 @@ pub(crate) mod test {
     use num_traits::ToPrimitive;
     use regex::Regex;
 
-    use ::lex::Lexeme;
     use super::*;
+    use lex::Lexeme;
 
     pub(crate) fn do_parse(
         rcvry_kind: RecoveryKind,
@@ -591,9 +591,12 @@ pub(crate) mod test {
         for l in lexs.split("\n").map(|x| x.trim()).filter(|x| !x.is_empty()) {
             assert!(l.rfind("'") == Some(l.len() - 1));
             let i = l[..l.len() - 1].rfind("'").unwrap();
-            let name = &l[i + 1 .. l.len() - 1];
+            let name = &l[i + 1..l.len() - 1];
             let re = &l[..i - 1].trim();
-            rules.push((ids_map[name], Regex::new(&format!("\\A(?:{})", re)).unwrap()));
+            rules.push((
+                ids_map[name],
+                Regex::new(&format!("\\A(?:{})", re)).unwrap()
+            ));
         }
         rules
     }

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -48,8 +48,10 @@ use std::{
 use cfgrammar::yacc::{YaccGrammar, YaccKind};
 use getopts::Options;
 use lrlex::build_lex;
-use lrpar::Lexer;
-use lrpar::parser::{parse_rcvry, ParseRepair, RecoveryKind};
+use lrpar::{
+    parser::{parse_rcvry, ParseRepair, RecoveryKind},
+    Lexer
+};
 use lrtable::{from_yacc, Minimiser};
 use num_traits::ToPrimitive;
 
@@ -185,7 +187,7 @@ fn main() {
     }
 
     let input = read_file(&matches.free[2]);
-    let lexer = lexerdef.lexer(&input);
+    let mut lexer = lexerdef.lexer(&input);
     let lexemes = lexer.lexemes().unwrap();
     let token_cost = |_| 1; // Cost of inserting/deleting a token
     match parse_rcvry::<u16, _>(recoverykind, &grm, &token_cost, &sgraph, &stable, &lexemes) {

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -188,7 +188,7 @@ fn main() {
 
     let input = read_file(&matches.free[2]);
     let mut lexer = lexerdef.lexer(&input);
-    let lexemes = lexer.lexemes().unwrap();
+    let lexemes = lexer.all_lexemes().unwrap();
     let token_cost = |_| 1; // Cost of inserting/deleting a token
     match parse_rcvry::<u16, _>(recoverykind, &grm, &token_cost, &sgraph, &stable, &lexemes) {
         Ok(pt) => println!("{}", pt.pp(&grm, &input)),


### PR DESCRIPTION
Traditional `lex` semi-lazy in the sense that it only produces tokens when Yacc asks it to (and Yacc can advance the input such that lex implicitly skips some parts of the input). One advantage to this approach is memory usage. If you tokenize a huge file into a Vec, it can take up more memory than one might like.

This commit enables lazy lexing through the Lexer trait: the next() method simply says "give me the next token". It's up to the individual lexer whether it's actually lazy or not, but this at least gives it the option to do so. Currently the lrpar parser isn't itself lazy, but making it lazy later should be an internal change without external impact.

As part of this, it's time to finally rethink the external parsing API that users use. We now have very similar compile-time (`CTParserBuilder`) and run-time (`RTParserBuilder`) interfaces. They will start to diverge a bit over time in terms of some of the options they offer, but for the time being they're very similar.
