### PR TITLE
Tidy up the StIdx type.

### DIFF
--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -801,7 +801,7 @@ where
 mod test {
     use std::{collections::HashMap, fmt::Debug};
 
-    use num_traits::{AsPrimitive, PrimInt, ToPrimitive, Unsigned};
+    use num_traits::{AsPrimitive, PrimInt, ToPrimitive, Unsigned, Zero};
     use test::{black_box, Bencher};
 
     use cactus::Cactus;
@@ -809,7 +809,7 @@ mod test {
         yacc::{YaccGrammar, YaccKind},
         Symbol
     };
-    use lrtable::{from_yacc, Minimiser, StIdx};
+    use lrtable::{from_yacc, Minimiser, StIdx, StIdxStorageT};
 
     use lex::Lexeme;
     use parser::{
@@ -870,7 +870,7 @@ A: '(' A ')'
         let grm = YaccGrammar::new(YaccKind::Original, grms).unwrap();
         let (sgraph, stable) = from_yacc(&grm, Minimiser::Pager).unwrap();
         let d = Dist::new(&grm, &sgraph, &stable, |_| 1);
-        let s0 = StIdx::from(0u32);
+        let s0 = StIdx::from(StIdxStorageT::zero());
         assert_eq!(d.dist(s0, grm.token_idx("(").unwrap()), 0);
         assert_eq!(d.dist(s0, grm.token_idx(")").unwrap()), 1);
         assert_eq!(d.dist(s0, grm.token_idx("a").unwrap()), 0);
@@ -937,7 +937,7 @@ U: 'B';
         // This only tests a subset of all the states and distances but, I believe, it tests all
         // more interesting edge cases that the example from the Kim/Yi paper.
 
-        let s0 = StIdx::from(0u32);
+        let s0 = StIdx::from(StIdxStorageT::zero());
         assert_eq!(d.dist(s0, grm.token_idx("A").unwrap()), 0);
         assert_eq!(d.dist(s0, grm.token_idx("B").unwrap()), 1);
         assert_eq!(d.dist(s0, grm.token_idx("C").unwrap()), 2);
@@ -995,7 +995,7 @@ Factor: '(' Expr ')'
         // This only tests a subset of all the states and distances but, I believe, it tests all
         // more interesting edge cases that the example from the Kim/Yi paper.
 
-        let s0 = StIdx::from(0u32);
+        let s0 = StIdx::from(StIdxStorageT::zero());
         assert_eq!(d.dist(s0, grm.token_idx("+").unwrap()), 1);
         assert_eq!(d.dist(s0, grm.token_idx("*").unwrap()), 1);
         assert_eq!(d.dist(s0, grm.token_idx("(").unwrap()), 0);
@@ -1057,7 +1057,7 @@ W: 'b' ;
         let (sgraph, stable) = from_yacc(&grm, Minimiser::Pager).unwrap();
         let d = Dist::new(&grm, &sgraph, &stable, |_| 1);
 
-        let s0 = StIdx::from(0u32);
+        let s0 = StIdx::from(StIdxStorageT::zero());
         assert_eq!(d.dist(s0, grm.token_idx("a").unwrap()), 0);
         assert_eq!(d.dist(s0, grm.token_idx("b").unwrap()), 1);
         assert_eq!(d.dist(s0, grm.eof_token_idx()), 0);

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -40,8 +40,8 @@ use std::{
 
 use cactus::Cactus;
 use cfgrammar::{yacc::YaccGrammar, RIdx, TIdx};
-use lrtable::{Action, StIdx, StateGraph, StateTable};
-use num_traits::{AsPrimitive, PrimInt, Unsigned};
+use lrtable::{Action, StIdx, StateGraph, StateTable, StIdxStorageT};
+use num_traits::{AsPrimitive, PrimInt, Unsigned, Zero};
 
 use cpctplus;
 use lex::{LexError, Lexeme, Lexer};
@@ -132,7 +132,7 @@ where
             stable,
             lexemes
         };
-        let mut pstack = vec![StIdx::from(0u32)];
+        let mut pstack = vec![StIdx::from(StIdxStorageT::zero())];
         let mut tstack: Vec<Node<StorageT>> = Vec::new();
         let mut errors: Vec<ParseError<StorageT>> = Vec::new();
         let accpt = psr.lr(0, &mut pstack, &mut tstack, &mut errors);

--- a/lrtable/src/lib/mod.rs
+++ b/lrtable/src/lib/mod.rs
@@ -54,40 +54,37 @@ use cfgrammar::yacc::YaccGrammar;
 pub use stategraph::StateGraph;
 pub use statetable::{Action, StateTable, StateTableError, StateTableErrorKind};
 
-type StIdxStorageT = u32;
+/// The type of the inner value of an StIdx.
+pub type StIdxStorageT = u16;
 
-/// StIdx is a wrapper for a 32-bit state index.
-///
-/// We guarantee that this value can be infallibly converted to usize.
+/// StIdx is a wrapper for a state index. Its internal type is `StIdxStorageT`. The only guarantee
+/// we make about `StIdx' is that it can be infallibly converted to usize.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-// The biggest grammars I'm currently aware of have just over 1000 states, so in practise it
-// looks like a u16 is always big enough to store state indexes. So, for as long as we can get
-// away with it, we only store u16. Nevertheless, we tell the world we only deal in u32 so that
-// we can change our storage to u32 later transparently.
-pub struct StIdx(u16);
+
+pub struct StIdx(StIdxStorageT);
 
 impl StIdx {
     fn max_value() -> StIdx {
-        StIdx(u16::max_value())
+        StIdx(StIdxStorageT::max_value())
     }
 }
 
 impl From<StIdxStorageT> for StIdx {
     fn from(v: StIdxStorageT) -> Self {
-        if v > StIdxStorageT::from(u16::max_value()) {
+        if v > StIdxStorageT::max_value() {
             panic!("Overflow");
         }
-        StIdx(v as u16)
+        StIdx(v as StIdxStorageT)
     }
 }
 
 impl From<usize> for StIdx {
     fn from(v: usize) -> Self {
-        if v > usize::from(u16::max_value()) {
+        if v > usize::from(StIdxStorageT::max_value()) {
             panic!("Overflow");
         }
-        StIdx(v as u16)
+        StIdx(v as StIdxStorageT)
     }
 }
 

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -327,14 +327,12 @@ where
     }
 
     fn encode(action: Action<StorageT>) -> u32 {
-        let enc:u32;
         match action {
-            Action::Shift(stidx) => { enc = SHIFT as u32 | (u32::from(stidx) << 2); },
-            Action::Reduce(r_pidx) => { enc = REDUCE as u32 | (u32::from(r_pidx) << 2); },
-            Action::Accept => { enc = ACCEPT as u32; },
-            Action::Error => { enc = ERROR as u32; }
+            Action::Shift(stidx) => SHIFT as u32 | (u32::from(stidx) << 2),
+            Action::Reduce(ridx) => REDUCE as u32 | (u32::from(ridx) << 2),
+            Action::Accept => ACCEPT as u32,
+            Action::Error => ERROR as u32
         }
-        enc
     }
 
     /// Return the action for `stidx` and `sym`, or `None` if there isn't any.

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -92,7 +92,7 @@ pub struct StateTable<StorageT> {
     core_reduces: Vob,
     state_shifts: Vob,
     reduce_states: Vob,
-    rules_len: u32,
+    rules_len: RIdx<StorageT>,
     prods_len: PIdx<StorageT>,
     tokens_len: TIdx<StorageT>,
     /// The number of reduce/reduce errors encountered.
@@ -304,7 +304,7 @@ where
             state_shifts,
             core_reduces,
             reduce_states,
-            rules_len: u32::from(grm.rules_len()),
+            rules_len: grm.rules_len(),
             prods_len: grm.prods_len(),
             tokens_len: grm.tokens_len(),
             reduce_reduce,
@@ -400,7 +400,7 @@ where
 
     /// Return the goto state for `stidx` and `ridx`, or `None` if there isn't any.
     pub fn goto(&self, stidx: StIdx, ridx: RIdx<StorageT>) -> Option<StIdx> {
-        let off = ((u32::from(stidx) * self.rules_len) + u32::from(ridx)) as usize;
+        let off = ((u32::from(stidx) * u32::from(self.rules_len)) + u32::from(ridx)) as usize;
         if self.gotos[off] == StIdx::max_value() {
             None
         }

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -86,7 +86,7 @@ pub struct StateTable<StorageT> {
     //   0  shift 1
     //   1  shift 0  reduce B
     // is represented as a hashtable {0: shift 1, 2: shift 0, 3: reduce 4}.
-    actions: PackedVec<u32>,
+    actions: PackedVec<usize>,
     state_actions: Vob,
     gotos: Vec<StIdx>,
     core_reduces: Vob,
@@ -114,10 +114,10 @@ pub enum Action<StorageT> {
     Error
 }
 
-const SHIFT: u8 = 1;
-const REDUCE: u8 = 2;
-const ACCEPT: u8 = 3;
-const ERROR: u8 = 0;
+const SHIFT: usize = 1;
+const REDUCE: usize = 2;
+const ACCEPT: usize = 3;
+const ERROR: usize = 0;
 
 impl<StorageT: 'static + Hash + PrimInt + Unsigned> StateTable<StorageT>
 where
@@ -136,9 +136,10 @@ where
         );
         let maxa = usize::from(grm.tokens_len()) * usize::from(sg.all_states_len());
         let maxg = usize::from(grm.rules_len()) * usize::from(sg.all_states_len());
-        // We only have 30 bits to store state IDs
-        assert!(u32::try_from(sg.all_states_len()) < Ok(u32::max_value() - 4));
-        let mut actions: Vec<u32> = Vec::with_capacity(maxa);
+        // We only have usize-2 bits to store state IDs and rule indexes
+        assert!(usize::try_from(sg.all_states_len()) < Ok(usize::max_value() - 4));
+        assert!(usize::try_from(grm.rules_len()) < Ok(usize::max_value() - 4));
+        let mut actions: Vec<usize> = Vec::with_capacity(maxa);
         actions.resize(maxa, 0);
         let mut gotos: Vec<StIdx> = Vec::with_capacity(maxg);
         gotos.resize(maxg, StIdx::max_value());
@@ -207,17 +208,11 @@ where
             }
 
             let nt_len = grm.rules_len();
-            // Assert that we can fit the goto table into an StIdxStorageT
-            assert!(
-                StIdxStorageT::from(sg.all_states_len())
-                    .checked_mul(nt_len.into())
-                    .is_some()
-            );
             for (&sym, ref_stidx) in sg.edges(stidx) {
                 match sym {
                     Symbol::Rule(s_ridx) => {
                         // Populate gotos
-                        let off = ((u32::from(stidx) * u32::from(nt_len)) + u32::from(s_ridx)) as usize;
+                        let off = (usize::from(stidx) * usize::from(nt_len)) + usize::from(s_ridx);
                         debug_assert!(gotos[off] == StIdx::max_value());
                         gotos[off] = *ref_stidx;
                     }
@@ -313,12 +308,16 @@ where
         })
     }
 
-    fn decode(bits: u32) -> Action<StorageT> {
-        let action = (bits & 0b11) as u8;
-        let val: u32 = bits >> 2;
+    fn decode(bits: usize) -> Action<StorageT> {
+        let action = bits & 0b11;
+        let val = bits >> 2;
 
         match action {
-            SHIFT => Action::Shift(StIdx::from(val)),
+            SHIFT => {
+                // Since val was originally stored in an StIdxStorageT, we know that it's safe to
+                // cast it back to an StIdxStorageT here.
+                Action::Shift(StIdx::from(val as StIdxStorageT))
+            },
             REDUCE => Action::Reduce(PIdx(val.as_())),
             ACCEPT => Action::Accept,
             ERROR => Action::Error,
@@ -326,12 +325,12 @@ where
         }
     }
 
-    fn encode(action: Action<StorageT>) -> u32 {
+    fn encode(action: Action<StorageT>) -> usize {
         match action {
-            Action::Shift(stidx) => SHIFT as u32 | (u32::from(stidx) << 2),
-            Action::Reduce(ridx) => REDUCE as u32 | (u32::from(ridx) << 2),
-            Action::Accept => ACCEPT as u32,
-            Action::Error => ERROR as u32
+            Action::Shift(stidx) => SHIFT | (usize::from(stidx) << 2),
+            Action::Reduce(ridx) => REDUCE | (usize::from(ridx) << 2),
+            Action::Accept => ACCEPT,
+            Action::Error => ERROR
         }
     }
 
@@ -398,7 +397,7 @@ where
 
     /// Return the goto state for `stidx` and `ridx`, or `None` if there isn't any.
     pub fn goto(&self, stidx: StIdx, ridx: RIdx<StorageT>) -> Option<StIdx> {
-        let off = ((u32::from(stidx) * u32::from(self.rules_len)) + u32::from(ridx)) as usize;
+        let off = (usize::from(stidx) * usize::from(self.rules_len)) + usize::from(ridx);
         if self.gotos[off] == StIdx::max_value() {
             None
         }
@@ -412,8 +411,8 @@ fn actions_offset<StorageT: PrimInt + Unsigned>(
     tokens_len: TIdx<StorageT>,
     stidx: StIdx,
     tidx: TIdx<StorageT>
-) -> StIdxStorageT {
-    StIdxStorageT::from(stidx) * StIdxStorageT::from(tokens_len) + StIdxStorageT::from(tidx)
+) -> usize {
+    usize::from(stidx) * usize::from(tokens_len) + usize::from(tidx)
 }
 
 
@@ -458,7 +457,7 @@ where
 
 fn resolve_shift_reduce<StorageT: 'static + Hash + PrimInt + Unsigned>(
     grm: &YaccGrammar<StorageT>,
-    actions: &mut Vec<u32>,
+    actions: &mut Vec<usize>,
     off: usize,
     tidx: TIdx<StorageT>,
     pidx: PIdx<StorageT>,


### PR DESCRIPTION
The `StIdx` type was, previously, something of a mess. We said it stored a `u32`, even though it stored a `u16`, and we relied upon that `u32`ness in a few places. This made it quite a bit more annoying to deal with than the `PIdx`/`RIdx' types.

This PR more-or-less brings `StIdx` into line with those other types: the only guarantee we now make is that an `StIdx` can be infallibly converted into a `usize`. This has various knock-on effects which this PR deals with.

[In the long run, I think we should get rid of the size checks inside `from` methods in `StIdx`. Those, however, are for another day.]