### PR TITLE
Simplify From conversions

### DIFF
--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -46,9 +46,10 @@ const START_RULE         : &str = "^";
 const IMPLICIT_RULE      : &str = "~";
 const IMPLICIT_START_RULE: &str = "^~";
 
-use yacc::ast;
-use yacc::ast::GrammarValidationError;
-use yacc::parser::YaccParserError;
+use yacc::{
+    ast::{self, GrammarValidationError},
+    parser::YaccParserError
+};
 
 pub type PrecedenceLevel = u64;
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/lrlex/src/lib/parser.rs
+++ b/lrlex/src/lib/parser.rs
@@ -30,10 +30,7 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-use std::{
-    convert::TryFrom,
-    hash::Hash
-};
+use std::{convert::TryFrom, hash::Hash};
 
 use num_traits::{PrimInt, Unsigned};
 

--- a/lrpar/examples/calcparse/src/main.rs
+++ b/lrpar/examples/calcparse/src/main.rs
@@ -7,7 +7,7 @@ extern crate lrlex;
 extern crate lrpar;
 
 use cfgrammar::RIdx;
-use lrpar::{Lexer, LexParseError, Node};
+use lrpar::{LexParseError, Lexer, Node};
 
 // Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
 lrlex_mod!(calc_l);
@@ -34,7 +34,9 @@ fn main() {
                     Ok(pt) => println!("{}", Eval::new(l).eval(&pt)),
                     // We weren't able to fully lex the input, so all we can do is tell the user
                     // at what index the lexer gave up at.
-                    Err(LexParseError::LexError(e)) => println!("Lexing error at column {:?}", e.idx),
+                    Err(LexParseError::LexError(e)) => {
+                        println!("Lexing error at column {:?}", e.idx)
+                    }
                     // Parsing failed, but with the help of error recovery a parse tree was
                     // produced. However, we simply report the error to the user and don't attempt
                     // to do any sort of evaluation.

--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -40,7 +40,7 @@ use std::{
 
 use cactus::Cactus;
 use cfgrammar::{yacc::YaccGrammar, Symbol, TIdx};
-use lrtable::{Action, StIdx, StateGraph, StateTable, StIdxStorageT};
+use lrtable::{Action, StIdx, StIdxStorageT, StateGraph, StateTable};
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 use vob::Vob;
 
@@ -791,7 +791,9 @@ where
                 for prev_stidx in prev.iter_set_bits(..) {
                     // prev.len() == states_len, which we know fits into StIdxStorageT, hence the
                     // cast below is safe.
-                    if let Some(goto_stidx) = stable.goto(StIdx::from(prev_stidx as StIdxStorageT), ridx) {
+                    if let Some(goto_stidx) =
+                        stable.goto(StIdx::from(prev_stidx as StIdxStorageT), ridx)
+                    {
                         goto_states[usize::from(stidx)].set(usize::from(goto_stidx), true);
                     }
                 }

--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -40,7 +40,7 @@ use std::{
 
 use cactus::Cactus;
 use cfgrammar::{yacc::YaccGrammar, Symbol, TIdx};
-use lrtable::{Action, StIdx, StateGraph, StateTable};
+use lrtable::{Action, StIdx, StateGraph, StateTable, StIdxStorageT};
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 use vob::Vob;
 
@@ -699,7 +699,9 @@ where
                 // The second phase takes into account reductions and gotos.
                 for goto_stidx in goto_states[usize::from(stidx)]
                     .iter_set_bits(..)
-                    .map(|x| StIdx::from(x))
+                    // goto_states[i].len() == states.len(), which we know fits into StIdxStorageT,
+                    // hence the cast below is safe.
+                    .map(|x| StIdx::from(x as StIdxStorageT))
                 {
                     for tidx in grm.iter_tidxs() {
                         let this_off = usize::from(stidx) * tokens_len + usize::from(tidx);
@@ -787,7 +789,9 @@ where
 
                 // From the reduction states, find all the goto states.
                 for prev_stidx in prev.iter_set_bits(..) {
-                    if let Some(goto_stidx) = stable.goto(StIdx::from(prev_stidx), ridx) {
+                    // prev.len() == states_len, which we know fits into StIdxStorageT, hence the
+                    // cast below is safe.
+                    if let Some(goto_stidx) = stable.goto(StIdx::from(prev_stidx as StIdxStorageT), ridx) {
                         goto_states[usize::from(stidx)].set(usize::from(goto_stidx), true);
                     }
                 }

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -55,7 +55,7 @@ pub mod lex;
 pub use lex::{LexError, Lexeme, Lexer};
 mod panic;
 pub mod parser;
-pub use parser::{Node, LexParseError, RTParserBuilder, ParseError, ParseRepair, RecoveryKind};
+pub use parser::{LexParseError, Node, ParseError, ParseRepair, RTParserBuilder, RecoveryKind};
 mod mf;
 
 pub use ctbuilder::CTParserBuilder;

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -40,7 +40,7 @@ use std::{
 
 use cactus::Cactus;
 use cfgrammar::{yacc::YaccGrammar, RIdx, TIdx};
-use lrtable::{Action, StIdx, StateGraph, StateTable, StIdxStorageT};
+use lrtable::{Action, StIdx, StIdxStorageT, StateGraph, StateTable};
 use num_traits::{AsPrimitive, PrimInt, Unsigned, Zero};
 
 use cpctplus;
@@ -232,7 +232,7 @@ where
                         return false;
                     }
                     laidx = new_laidx;
-                },
+                }
                 None => ()
             }
         }
@@ -399,7 +399,7 @@ where
                 }
                 Some(Action::Error) => {
                     break;
-                },
+                }
                 None => {
                     break;
                 }
@@ -608,17 +608,16 @@ pub(crate) mod test {
             .collect();
         let lexer_rules = small_lexer(lexs, rule_ids);
         let lexemes = small_lex(lexer_rules, input);
-        let mut lexer = SmallLexer{lexemes, i: 0};
+        let mut lexer = SmallLexer { lexemes, i: 0 };
         let costs_tidx = costs
             .iter()
             .map(|(k, v)| (grm.token_idx(k).unwrap(), v))
             .collect::<HashMap<_, _>>();
-        let r = match RTParserBuilder::new(&grm,
-            &sgraph,
-            &stable)
+        let r = match RTParserBuilder::new(&grm, &sgraph, &stable)
             .recoverer(rcvry_kind)
             .term_costs(&|tidx| **costs_tidx.get(&tidx).unwrap_or(&&1))
-            .parse(&mut lexer) {
+            .parse(&mut lexer)
+        {
             Ok(r) => Ok(r),
             Err(LexParseError::ParseError(r1, r2)) => Err((r1, r2)),
             _ => unreachable!()

--- a/lrtable/src/lib/mod.rs
+++ b/lrtable/src/lib/mod.rs
@@ -38,8 +38,8 @@ extern crate num_traits;
 #[cfg(feature = "serde")]
 #[macro_use]
 extern crate serde;
-extern crate vob;
 extern crate packed_vec;
+extern crate vob;
 
 use std::{hash::Hash, mem::size_of};
 

--- a/lrtable/src/lib/mod.rs
+++ b/lrtable/src/lib/mod.rs
@@ -72,10 +72,7 @@ impl StIdx {
 
 impl From<StIdxStorageT> for StIdx {
     fn from(v: StIdxStorageT) -> Self {
-        if v > StIdxStorageT::max_value() {
-            panic!("Overflow");
-        }
-        StIdx(v as StIdxStorageT)
+        StIdx(v)
     }
 }
 

--- a/lrtable/src/lib/mod.rs
+++ b/lrtable/src/lib/mod.rs
@@ -79,15 +79,6 @@ impl From<StIdxStorageT> for StIdx {
     }
 }
 
-impl From<usize> for StIdx {
-    fn from(v: usize) -> Self {
-        if v > usize::from(StIdxStorageT::max_value()) {
-            panic!("Overflow");
-        }
-        StIdx(v as StIdxStorageT)
-    }
-}
-
 impl From<StIdx> for usize {
     fn from(st: StIdx) -> Self {
         debug_assert!(size_of::<usize>() >= size_of::<StIdxStorageT>());

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -65,9 +65,9 @@ where
     /// Return an iterator which produces (in order from `0..self.rules_len()`) all this
     /// grammar's valid `RIdx`s.
     pub fn iter_stidxs(&self) -> Box<dyn Iterator<Item = StIdx>> {
-        // We can use as_ safely, because we know that we're only generating integers from
+        // We can use as safely, because we know that we're only generating integers from
         // 0..self.states.len() which we've already checked fits within StIdxStorageT.
-        Box::new((0..self.states.len()).map(|x| StIdx::from(x)))
+        Box::new((0..self.states.len()).map(|x| StIdx(x as StIdxStorageT)))
     }
 
     /// Return the itemset for closed state `stidx`. Panics if `stidx` doesn't exist.

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -151,7 +151,9 @@ where
         for (stidx, state) in sg
             .iter_closed_states()
             .enumerate()
-            .map(|(x, y)| (StIdx::from(x), y))
+            // x goes from 0..states_len(), and we know the latter can safely fit into an
+            // StIdxStorageT, so the cast is safe.
+            .map(|(x, y)| (StIdx(x as StIdxStorageT), y))
         {
             // Populate reduce and accepts
             for (&(pidx, dot), ctx) in &state.items {

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -49,7 +49,7 @@ use cfgrammar::yacc::{YaccGrammar, YaccKind};
 use getopts::Options;
 use lrlex::build_lex;
 use lrpar::{
-    parser::{LexParseError, ParseRepair, RecoveryKind, RTParserBuilder},
+    parser::{LexParseError, ParseRepair, RTParserBuilder, RecoveryKind},
     Lexer
 };
 use lrtable::{from_yacc, Minimiser};
@@ -188,14 +188,13 @@ fn main() {
 
     let input = read_file(&matches.free[2]);
     let mut lexer = lexerdef.lexer(&input);
-    let pb = RTParserBuilder::new(&grm, &sgraph, &stable)
-        .recoverer(recoverykind);
+    let pb = RTParserBuilder::new(&grm, &sgraph, &stable).recoverer(recoverykind);
     match pb.parse(&mut lexer) {
         Ok(pt) => println!("{}", pt.pp(&grm, &input)),
         Err(LexParseError::LexError(e)) => {
             println!("Lexing error at position {}", e.idx);
             process::exit(1);
-        },
+        }
         Err(LexParseError::ParseError(o_pt, errs)) => {
             match o_pt {
                 Some(pt) => println!("{}", pt.pp(&grm, &input)),


### PR DESCRIPTION
`StIdx` previously had two dynamic range checks to ensure that run-time values could fit within static types. One of these was obviously dumb (https://github.com/softdevteam/grmtools/commit/2be2b98d576332478733e87e60a67b864a445526) and I can't believe I didn't remove this earlier. The other (https://github.com/softdevteam/grmtools/commit/7a8f5acd29d1961d17c914ea8681649469f49c6d) is more subtle: we allowed people to infallibly convert a `usize` into an `StIdx`, even though this could clearly fail. Therefore remove this conversion, and audit all the points that use it to ensure that they're actually safe.