### PR TITLE
Fix the visibility of the R_ and T_ constants.

### DIFF
--- a/lrlex/src/lib/builder.rs
+++ b/lrlex/src/lib/builder.rs
@@ -192,7 +192,7 @@ where
         if let Some(ref rim) = self.rule_ids_map {
             for (n, id) in rim {
                 outs.push_str(&format!(
-                    "#[allow(dead_code)]\nconst T_{}: {} = {:?};\n",
+                    "#[allow(dead_code)]\npub const T_{}: {} = {:?};\n",
                     n.to_ascii_uppercase(),
                     StorageT::type_name(),
                     *id

--- a/lrpar/examples/calcparse/src/main.rs
+++ b/lrpar/examples/calcparse/src/main.rs
@@ -64,7 +64,7 @@ impl<'a> Eval<'a> {
 
     fn eval(&self, n: &Node<u8>) -> i64 {
         match *n {
-            Node::Nonterm{ridx: RIdx(ridx), ref nodes} if ridx==R_EXPR => {
+            Node::Nonterm{ridx: RIdx(ridx), ref nodes} if ridx==calc_y::R_EXPR => {
                 if nodes.len() == 1 {
                     self.eval(&nodes[0])
                 } else {
@@ -72,7 +72,7 @@ impl<'a> Eval<'a> {
                     self.eval(&nodes[0]) + self.eval(&nodes[2])
                 }
             },
-            Node::Nonterm{ridx: RIdx(ridx), ref nodes} if ridx==R_TERM => {
+            Node::Nonterm{ridx: RIdx(ridx), ref nodes} if ridx==calc_y::R_TERM => {
                 if nodes.len() == 1 {
                     self.eval(&nodes[0])
                 } else {
@@ -80,7 +80,7 @@ impl<'a> Eval<'a> {
                     self.eval(&nodes[0]) * self.eval(&nodes[2])
                 }
             },
-            Node::Nonterm{ridx: RIdx(ridx), ref nodes} if ridx==R_FACTOR => {
+            Node::Nonterm{ridx: RIdx(ridx), ref nodes} if ridx==calc_y::R_FACTOR => {
                 if nodes.len() == 1 {
                     if let Node::Term{lexeme} = nodes[0] {
                         self.s[lexeme.start()..lexeme.end()].parse().unwrap()

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -251,19 +251,20 @@ pub fn parse(lexer: &mut Lexer<{storaget}>)
         ));
 
         outs.push_str("}\n");
-        outs.push_str("}\n\n");
 
         // The rule constants
         for ridx in grm.iter_rules() {
             if !grm.rule_to_prods(ridx).contains(&grm.start_prod()) {
                 outs.push_str(&format!(
-                    "#[allow(dead_code)]\nconst R_{}: {} = {:?};\n",
+                    "#[allow(dead_code)]\npub const R_{}: {} = {:?};\n",
                     grm.rule_name(ridx).to_ascii_uppercase(),
                     StorageT::type_name(),
                     usize::from(ridx)
                 ));
             }
         }
+
+        outs.push_str("}\n\n");
 
         // Output the cache so that we can check whether the IDs map is stable.
         outs.push_str(&cache);


### PR DESCRIPTION
There are two mistakes here: the R_ constants were contained outside the _y module; and the  T_ constants were private (but, at least, inside the _l module). This commit fixes both aspects.

Fixes https://github.com/softdevteam/grmtools/issues/23