### PR TITLE
Remove the Option type from StateTable::action's return.

### DIFF
--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -240,7 +240,7 @@ where
                     .stable
                     .action(*n.pstack.val().unwrap(), parser.next_tidx(n.laidx))
                 {
-                    Some(Action::Accept) => true,
+                    Action::Accept => true,
                     _ => false
                 }
             }

--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -233,7 +233,7 @@ where
                     .stable
                     .action(*n.pstack.val().unwrap(), parser.next_tidx(n.laidx))
                 {
-                    Some(Action::Accept) => true,
+                    Action::Accept => true,
                     _ => false
                 }
             }
@@ -273,7 +273,7 @@ where
                 continue;
             }
 
-            let t_stidx = match self.parser.stable.action(top_pstack, tidx).unwrap() {
+            let t_stidx = match self.parser.stable.action(top_pstack, tidx) {
                 Action::Shift(stidx) => stidx,
                 _ => unreachable!()
             };
@@ -376,7 +376,7 @@ where
     fn shift(&self, n: &PathFNode<StorageT>, nbrs: &mut Vec<(u16, u16, PathFNode<StorageT>)>) {
         let la_tidx = self.parser.next_tidx(n.laidx);
         let top_pstack = *n.pstack.val().unwrap();
-        if let Some(Action::Shift(state_id)) = self.parser.stable.action(top_pstack, la_tidx) {
+        if let Action::Shift(state_id) = self.parser.stable.action(top_pstack, la_tidx) {
             let n_repairs = n.repairs.child(RepairMerge::Repair(Repair::Shift));
             let new_laidx = n.laidx + 1;
             if let Some(d) = self.dyn_dist(&n_repairs, state_id, new_laidx) {

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -171,7 +171,7 @@ where
             let la_tidx = self.next_tidx(laidx);
 
             match self.stable.action(stidx, la_tidx) {
-                Some(Action::Reduce(pidx)) => {
+                Action::Reduce(pidx) => {
                     let ridx = self.grm.prod_to_rule(pidx);
                     let pop_idx = pstack.len() - self.grm.prod(pidx).len();
                     let nodes = tstack.drain(pop_idx - 1..).collect::<Vec<Node<StorageT>>>();
@@ -181,18 +181,18 @@ where
                     let prior = *pstack.last().unwrap();
                     pstack.push(self.stable.goto(prior, ridx).unwrap());
                 }
-                Some(Action::Shift(state_id)) => {
+                Action::Shift(state_id) => {
                     let la_lexeme = self.next_lexeme(laidx);
                     tstack.push(Node::Term { lexeme: la_lexeme });
                     pstack.push(state_id);
                     laidx += 1;
                 }
-                Some(Action::Accept) => {
+                Action::Accept => {
                     debug_assert_eq!(la_tidx, self.grm.eof_token_idx());
                     debug_assert_eq!(tstack.len(), 1);
                     return true;
                 }
-                Some(Action::Error) => {
+                Action::Error => {
                     if recoverer.is_none() {
                         recoverer = Some(match self.rcvry_kind {
                             RecoveryKind::CPCTPlus => cpctplus::recoverer(self),
@@ -233,7 +233,6 @@ where
                     }
                     laidx = new_laidx;
                 }
-                None => ()
             }
         }
     }
@@ -260,7 +259,7 @@ where
             };
 
             match self.stable.action(stidx, la_tidx) {
-                Some(Action::Reduce(pidx)) => {
+                Action::Reduce(pidx) => {
                     let ridx = self.grm.prod_to_rule(pidx);
                     let pop_idx = pstack.len() - self.grm.prod(pidx).len();
                     if let Some(ref mut tstack_uw) = *tstack {
@@ -274,7 +273,7 @@ where
                     let prior = *pstack.last().unwrap();
                     pstack.push(self.stable.goto(prior, ridx).unwrap());
                 }
-                Some(Action::Shift(state_id)) => {
+                Action::Shift(state_id) => {
                     if let Some(ref mut tstack_uw) = *tstack {
                         let la_lexeme = if let Some(l) = lexeme_prefix {
                             l
@@ -286,13 +285,10 @@ where
                     pstack.push(state_id);
                     laidx += 1;
                 }
-                Some(Action::Accept) => {
+                Action::Accept => {
                     break;
                 }
-                Some(Action::Error) => {
-                    break;
-                }
-                None => {
+                Action::Error => {
                     break;
                 }
             }
@@ -362,7 +358,7 @@ where
             };
 
             match self.stable.action(stidx, la_tidx) {
-                Some(Action::Reduce(pidx)) => {
+                Action::Reduce(pidx) => {
                     let ridx = self.grm.prod_to_rule(pidx);
                     let pop_num = self.grm.prod(pidx).len();
                     if let Some(ref mut tstack_uw) = *tstack {
@@ -378,7 +374,7 @@ where
                     let prior = *pstack.val().unwrap();
                     pstack = pstack.child(self.stable.goto(prior, ridx).unwrap());
                 }
-                Some(Action::Shift(state_id)) => {
+                Action::Shift(state_id) => {
                     if let Some(ref mut tstack_uw) = *tstack {
                         let la_lexeme = if let Some(l) = lexeme_prefix {
                             l
@@ -390,17 +386,14 @@ where
                     pstack = pstack.child(state_id);
                     laidx += 1;
                 }
-                Some(Action::Accept) => {
+                Action::Accept => {
                     debug_assert_eq!(la_tidx, self.grm.eof_token_idx());
                     if let Some(ref mut tstack_uw) = *tstack {
                         debug_assert_eq!(tstack_uw.len(), 1);
                     }
                     break;
                 }
-                Some(Action::Error) => {
-                    break;
-                }
-                None => {
+                Action::Error => {
                     break;
                 }
             }


### PR DESCRIPTION
This was the result of an incomplete migration of code with the recent introduction of Action::Error. We ended up with code duplication:

```rust
  match action(...) {
    ...
    Some(Action::Error) => XYZ,
    None => XYZ
  }
```

which is a disaster waiting to happen. Worse, panic mode had been subtly broken by this change (getting into a loop that it only got out of because of the error recovery time out).

This commit simply completes the job, changing:

```rust
  pub fn action(&self, stidx: StIdx, tidx: TIdx<StorageT>) -> Option<Action<StorageT>>
```

to:

```rust
  pub fn action(&self, stidx: StIdx, tidx: TIdx<StorageT>) -> Action<StorageT>
```