### PR TITLE
Skipping the top element in the parsing stack is dangerous.

### DIFF
--- a/lrpar/src/lib/panic.rs
+++ b/lrpar/src/lib/panic.rs
@@ -73,7 +73,7 @@ where
             if Instant::now() >= finish_by {
                 break;
             }
-            for (st_i, st) in iter_pstack.iter().enumerate().rev().skip(1) {
+            for (st_i, st) in iter_pstack.iter().enumerate().rev() {
                 match parser.stable.action(*st, parser.next_tidx(laidx)) {
                     Action::Error => (),
                     _ => {


### PR DESCRIPTION
On the first iteration of panic mode, skipping the top element of the stack is a valid optimisation: however, if the input is advanced, then the stack is restored, and the top element of the stack *might* match. On the big corpus of Java programs, this makes a noticeable (positive) 2% change in the number of files which can be successfully recovered from.