### PR TITLE
Adjust for recent changes in PackedVec

### DIFF
--- a/lrtable/Cargo.toml
+++ b/lrtable/Cargo.toml
@@ -16,4 +16,4 @@ num-traits = "0.2"
 cfgrammar = { path="../cfgrammar", features=["serde"] }
 serde = { version="1.0", features=["derive"], optional=true }
 vob = { version="1.3", features=["serde"] }
-packed_vec = { git = "https://github.com/gabi-250/packed-vec", features=["serde"] }
+packed_vec = { git = "https://github.com/softdevteam/packed-vec", features=["serde"] }

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -304,8 +304,8 @@ where
             }
         }
 
-        let actions = PackedVec::new(actions);
-        let gotos = PackedVec::new(gotos);
+        let actions = PackedVec::<usize, usize>::new(actions);
+        let gotos = PackedVec::<usize, usize>::new(gotos);
 
         Ok(StateTable {
             actions,


### PR DESCRIPTION
The changes in https://github.com/softdevteam/packed-vec/commit/4cac71f1441febaf0acde66503816943abd9b8c1 broke this library to the extend that the type inference seems unable to infer the types, so we need to help it a bit.