### PR TITLE
Use PackedVec for the dist table.

### DIFF
--- a/lrpar/Cargo.toml
+++ b/lrpar/Cargo.toml
@@ -20,6 +20,7 @@ getopts = "0.2"
 indexmap = "1.0"
 lrtable = { path="../lrtable", features=["serde"] }
 num-traits = "0.2"
+packedvec = "1.0"
 rmp-serde = "0.13"
 serde = { version="1.0", features=["derive"] }
 typename = "0.1"

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -40,6 +40,7 @@ extern crate filetime;
 extern crate indexmap;
 extern crate lrtable;
 extern crate num_traits;
+extern crate packedvec;
 #[cfg(test)]
 extern crate regex;
 extern crate rmp_serde as rmps;


### PR DESCRIPTION
For the Java grammar, this reduces the size of the table from about 233KiB to about 44KiB. I can't measure any real performance gain from this on small examples (there again, it doesn't slow things down either), but perhaps it helps on a wide corpus.