### PR TITLE
Use sparsevec for parsing tables

### DIFF
--- a/cfgrammar/Cargo.toml
+++ b/cfgrammar/Cargo.toml
@@ -14,4 +14,4 @@ indexmap = "1.0"
 num-traits = "0.2"
 regex = "1.0"
 serde = { version="1.0", features=["derive"], optional=true }
-vob = "1.3"
+vob = "2.0"

--- a/lrpar/Cargo.toml
+++ b/lrpar/Cargo.toml
@@ -24,7 +24,7 @@ packedvec = "1.0"
 rmp-serde = "0.13"
 serde = { version="1.0", features=["derive"] }
 typename = "0.1"
-vob = "1.3"
+vob = "2.0"
 
 [dev-dependencies]
 regex = "1.0"

--- a/lrtable/Cargo.toml
+++ b/lrtable/Cargo.toml
@@ -15,5 +15,5 @@ newtype_derive = "0.1.6"
 num-traits = "0.2"
 cfgrammar = { path="../cfgrammar", features=["serde"] }
 serde = { version="1.0", features=["derive"], optional=true }
-vob = { version="1.3", features=["serde"] }
-packedvec = { git = "https://github.com/softdevteam/packedvec", features=["serde"] }
+vob = { version="2.0", features=["serde"] }
+sparsevec = { version="0.1", features=["serde"] }

--- a/lrtable/src/lib/mod.rs
+++ b/lrtable/src/lib/mod.rs
@@ -38,8 +38,8 @@ extern crate num_traits;
 #[cfg(feature = "serde")]
 #[macro_use]
 extern crate serde;
-extern crate packedvec;
 extern crate vob;
+extern crate sparsevec;
 
 use std::{hash::Hash, mem::size_of};
 


### PR DESCRIPTION
This PR changes the datastructure for storing the actions and goto tables from PackedVec to SparseVec. This new data structure first compresses the tables using row displacement and then stores the result in a PackedVec.

For the Java parser, this results in a 8% smaller binary, saves 67% of memory for the actions table, and 83% for the gotos table, and gives a speed improvement of 2% when parsing the Java Standard Library.