### PR TITLE
Implement actions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members=[
     "lrlex/examples/calclex",
     "lrpar",
     "lrpar/examples/calcparse",
+    "lrpar/examples/actions",
     "lrtable",
     "nimbleparse"
 ]

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -51,7 +51,8 @@ pub struct GrammarAST {
     pub tokens: IndexSet<String>,
     pub precs: HashMap<String, Precedence>,
     pub implicit_tokens: Option<HashSet<String>>,
-    pub programs: Option<String>
+    pub programs: Option<String>,
+    pub actiontype: Option<String>
 }
 
 #[derive(Debug)]
@@ -137,7 +138,8 @@ impl GrammarAST {
             tokens: IndexSet::new(),
             precs: HashMap::new(),
             implicit_tokens: None,
-            programs: None
+            programs: None,
+            actiontype: None
         }
     }
 

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -104,7 +104,8 @@ pub struct YaccGrammar<StorageT = u32> {
     implicit_rule: Option<RIdx<StorageT>>,
     /// User defined Rust programs which can be called within actions
     actions: Vec<Option<String>>,
-    programs: Option<String>
+    programs: Option<String>,
+    actiontype: Option<String>
 }
 
 // Internally, we assume that a grammar's start rule has a single production. Since we manually
@@ -342,13 +343,19 @@ where
             prod_precs: prod_precs.into_iter().map(|x| x.unwrap()).collect(),
             implicit_rule: implicit_rule.and_then(|x| Some(rule_map[&x])),
             actions,
-            programs: ast.programs
+            programs: ast.programs,
+            actiontype: ast.actiontype
         })
     }
 
     /// Get the programs part of the grammar
     pub fn programs(&self) -> &Option<String> {
         &self.programs
+    }
+
+    /// Get the action return type as defined by the user
+    pub fn actiontype(&self) -> &Option<String> {
+        &self.actiontype
     }
 
     /// How many productions does this grammar have?

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -101,7 +101,10 @@ pub struct YaccGrammar<StorageT = u32> {
     prod_precs: Vec<Option<Precedence>>,
     /// The index of the rule added for implicit tokens, if they were specified; otherwise
     /// `None`.
-    implicit_rule: Option<RIdx<StorageT>>
+    implicit_rule: Option<RIdx<StorageT>>,
+    /// User defined Rust programs which can be called within actions
+    actions: Vec<Option<String>>,
+    programs: Option<String>
 }
 
 // Internally, we assume that a grammar's start rule has a single production. Since we manually
@@ -224,6 +227,7 @@ where
         let mut prods = vec![None; ast.prods.len()];
         let mut prod_precs: Vec<Option<Option<Precedence>>> = vec![None; ast.prods.len()];
         let mut prods_rules = vec![None; ast.prods.len()];
+        let mut actions = vec![None; ast.prods.len()];
         for astrulename in &rule_names {
             let ridx = rule_map[astrulename];
             if astrulename == &start_rule {
@@ -245,6 +249,7 @@ where
                 prods.push(Some(start_prod));
                 prod_precs.push(Some(None));
                 prods_rules.push(Some(ridx));
+                actions.push(None);
                 continue;
             } else if implicit_start_rule
                 .as_ref()
@@ -313,6 +318,10 @@ where
                 prods[prod_idx] = Some(prod);
                 prod_precs[prod_idx] = Some(prec);
                 prods_rules[prod_idx] = Some(ridx);
+                match astprod.action {
+                    Some(ref s) => actions[prod_idx] = Some(String::from(s.clone())),
+                    None => ()
+                };
             }
         }
 
@@ -331,8 +340,15 @@ where
             prods_rules: prods_rules.into_iter().map(|x| x.unwrap()).collect(),
             prods: prods.into_iter().map(|x| x.unwrap()).collect(),
             prod_precs: prod_precs.into_iter().map(|x| x.unwrap()).collect(),
-            implicit_rule: implicit_rule.and_then(|x| Some(rule_map[&x]))
+            implicit_rule: implicit_rule.and_then(|x| Some(rule_map[&x])),
+            actions,
+            programs: ast.programs
         })
+    }
+
+    /// Get the programs part of the grammar
+    pub fn programs(&self) -> &Option<String> {
+        &self.programs
     }
 
     /// How many productions does this grammar have?
@@ -352,6 +368,11 @@ where
     /// Get the sequence of symbols for production `pidx`. Panics if `pidx` doesn't exist.
     pub fn prod(&self, pidx: PIdx<StorageT>) -> &[Symbol<StorageT>] {
         &self.prods[usize::from(pidx)]
+    }
+
+    /// Get the action for production `pidx`. Panics if `pidx` doesn't exist.
+    pub fn action(&self, pidx: PIdx<StorageT>) -> &Option<String> {
+        &self.actions[usize::from(pidx)]
     }
 
     /// How many symbols does production `pidx` have? Panics if `pidx` doesn't exist.

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -151,6 +151,18 @@ impl YaccParser {
                 }
                 continue;
             }
+            if let Some(j) = self.lookahead_is("%type", i) {
+                i = self.parse_ws(j)?;
+                while i < self.src.len() {
+                    if self.lookahead_is("%", i).is_some() {
+                        break;
+                    }
+                    let (j, n) = self.parse_name(i)?;
+                    self.ast.actiontype = Some(n);
+                    i = self.parse_ws(j)?;
+                }
+                continue;
+            }
             if let Some(j) = self.lookahead_is("%start", i) {
                 if self.ast.start.is_some() {
                     return Err(self.mk_error(YaccParserErrorKind::DuplicateStartDeclaration, i));

--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -280,6 +280,10 @@ impl<'a, StorageT: Copy + Eq + Hash + PrimInt + Unsigned> Lexer<StorageT>
             l.start() - self.newlines[self.newlines.len() - 1] + 1
         ))
     }
+
+    fn input(&self) -> &str {
+        &self.s
+    }
 }
 
 #[cfg(test)]

--- a/lrpar/Cargo.toml
+++ b/lrpar/Cargo.toml
@@ -25,6 +25,6 @@ rmp-serde = "0.13"
 serde = { version="1.0", features=["derive"] }
 typename = "0.1"
 vob = "2.0"
+regex = "1.0"
 
 [dev-dependencies]
-regex = "1.0"

--- a/lrpar/examples/actions/Cargo.toml
+++ b/lrpar/examples/actions/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "actions"
+version = "0.1.0"
+authors = ["Laurence Tratt <http://tratt.net/laurie/>"]
+
+[[bin]]
+doc = false
+name = "actions"
+
+[build-dependencies]
+lrlex = { path="../../../lrlex" }
+lrpar = { path="../.." }
+
+[dependencies]
+cfgrammar = { path="../../../cfgrammar" }
+lrlex = { path="../../../lrlex" }
+lrpar = { path="../.." }

--- a/lrpar/examples/actions/README.md
+++ b/lrpar/examples/actions/README.md
@@ -1,0 +1,10 @@
+# Parsing a simple calculator language
+
+This directory contains a very simple example of a calculator in `lrpar`.
+Executing `cargo run` processes `src/calc.l` and `src/calc.y` at compile-time;
+the resulting binary then takes input from stdin. You can type anything in here
+(though you'll only get useful output for valid input!) -- parsing and lexing
+errors are reported.
+
+Look at `build.rs`, `src/calc.y`, and `src/main.rs` to see how to use `lrpar` in
+your project.

--- a/lrpar/examples/actions/build.rs
+++ b/lrpar/examples/actions/build.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 King's College London
+// Copyright (c) 2018 King's College London
 // created by the Software Development Team <http://soft-dev.org/>
 //
 // The Universal Permissive License (UPL), Version 1.0
@@ -30,45 +30,22 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#![feature(test)]
+extern crate lrlex;
+extern crate lrpar;
 
-extern crate bincode;
-extern crate cactus;
-extern crate cfgrammar;
-extern crate filetime;
-#[macro_use]
-extern crate indexmap;
-extern crate lrtable;
-extern crate num_traits;
-extern crate packedvec;
-extern crate regex;
-extern crate rmp_serde as rmps;
-extern crate serde;
-extern crate test;
-extern crate typename;
-extern crate vob;
+use lrlex::LexerBuilder;
+use lrpar::{CTParserBuilder, ActionKind};
 
-mod astar;
-mod cpctplus;
-pub mod ctbuilder;
-pub mod lex;
-pub use lex::{LexError, Lexeme, Lexer};
-mod panic;
-pub mod parser;
-pub use parser::{LexParseError, Node, ParseError, ParseRepair, RTParserBuilder, RecoveryKind};
-mod mf;
-
-pub use ctbuilder::CTParserBuilder;
-pub use ctbuilder::ActionKind;
-
-/// A convenience macro for including statically compiled `.y` files. A file `src/x.y` which is
-/// statically compiled by lrpar can then be used in a crate with `lrpar_mod!(x)`.
-#[macro_export]
-macro_rules! lrpar_mod {
-    ($n:ident) => {
-        include!(concat!(env!("OUT_DIR"), "/", stringify!($n), ".rs"));
-    };
+fn main() -> Result<(), Box<std::error::Error>> {
+    // First we create the parser, which returns a HashMap of all the tokens used, then we pass
+    // that HashMap to the lexer.
+    //
+    // Note that we specify the integer type (u8) we'll use for token IDs (this type *must* be big
+    // enough to fit all IDs in) as well as the input file (which must end in ".y" for lrpar, and
+    // ".l" for lrlex).
+    let lex_rule_ids_map = CTParserBuilder::<u8>::new().action_kind(ActionKind::CustomAction).process_file_in_src("calc.y")?;
+    LexerBuilder::new()
+        .rule_ids_map(lex_rule_ids_map)
+        .process_file_in_src("calc.l")?;
+    Ok(())
 }
-
-#[doc(hidden)]
-pub use cfgrammar::RIdx;

--- a/lrpar/examples/actions/src/calc.l
+++ b/lrpar/examples/actions/src/calc.l
@@ -1,0 +1,7 @@
+%%
+[0-9]+ "INT"
+\+ "PLUS"
+\* "MUL"
+\( "LBRACK"
+\) "RBRACK"
+[\t ]+ ;

--- a/lrpar/examples/actions/src/calc.y
+++ b/lrpar/examples/actions/src/calc.y
@@ -1,24 +1,24 @@
 %start Expr
 %%
-Expr: Term 'PLUS' Expr { add($0, $2) }
-    | Term { $0 }
+Expr: Term 'PLUS' Expr { add($1, $3) }
+    | Term { $1 }
     ;
 
-Term: Factor 'MUL' Term { mul ($0, $2) }
-    | Factor { $0 }
+Term: Factor 'MUL' Term { mul ($1, $3) }
+    | Factor { $1 }
     ;
 
-Factor: 'LBRACK' Expr 'RBRACK' { $1 }
-      | 'INT' { $0 }
+Factor: 'LBRACK' Expr 'RBRACK' { $2 }
+      | 'INT' { int($1) }
       ;
 %%
 
 type TYPE = u64;
 
-fn convert(s: &str) -> TYPE {
+fn int(s: &str) -> TYPE {
     match s.parse::<u64>() {
     	Ok(val) => val as TYPE,
-	Err(_) => 0 as TYPE
+	Err(_) => unreachable!()
     }
 }
 

--- a/lrpar/examples/actions/src/calc.y
+++ b/lrpar/examples/actions/src/calc.y
@@ -1,4 +1,5 @@
 %start Expr
+%type MYTYPE
 %%
 Expr: Term 'PLUS' Expr { add($1, $3) }
     | Term { $1 }
@@ -13,11 +14,11 @@ Factor: 'LBRACK' Expr 'RBRACK' { $2 }
       ;
 %%
 
-type TYPE = u64;
+type MYTYPE = u64;
 
-fn int(s: &str) -> TYPE {
+fn int(s: &str) -> MYTYPE {
     match s.parse::<u64>() {
-    	Ok(val) => val as TYPE,
+    	Ok(val) => val as MYTYPE,
 	Err(_) => unreachable!()
     }
 }

--- a/lrpar/examples/actions/src/calc.y
+++ b/lrpar/examples/actions/src/calc.y
@@ -1,0 +1,31 @@
+%start Expr
+%%
+Expr: Term 'PLUS' Expr { add($0, $2) }
+    | Term { $0 }
+    ;
+
+Term: Factor 'MUL' Term { mul ($0, $2) }
+    | Factor { $0 }
+    ;
+
+Factor: 'LBRACK' Expr 'RBRACK' { $1 }
+      | 'INT' { $0 }
+      ;
+%%
+
+type TYPE = u64;
+
+fn convert(s: &str) -> TYPE {
+    match s.parse::<u64>() {
+    	Ok(val) => val as TYPE,
+	Err(_) => 0 as TYPE
+    }
+}
+
+fn add(arg1: u64, arg2: u64) -> u64 {
+    arg1 + arg2
+}
+
+fn mul(arg1: u64, arg2: u64) -> u64 {
+    arg1 * arg2
+}

--- a/lrpar/examples/actions/src/main.rs
+++ b/lrpar/examples/actions/src/main.rs
@@ -1,0 +1,55 @@
+use std::io::{self, BufRead, Write};
+
+extern crate cfgrammar;
+#[macro_use]
+extern crate lrlex;
+#[macro_use]
+extern crate lrpar;
+
+use lrpar::{LexParseError, Lexer};
+
+// Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
+lrlex_mod!(calc_l);
+// Using `lrpar_mod!` brings the lexer for `calc.l` into scope.
+lrpar_mod!(calc_y);
+
+fn main() {
+    // We need to get a `LexerDef` for the `calc` language in order that we can lex input.
+    let lexerdef = calc_l::lexerdef();
+    let stdin = io::stdin();
+    loop {
+        print!(">>> ");
+        io::stdout().flush().ok();
+        match stdin.lock().lines().next() {
+            Some(Ok(ref l)) => {
+                if l.trim().is_empty() {
+                    continue;
+                }
+                // Now we create a lexer with the `lexer` method with which we can lex an input.
+                let mut lexer = lexerdef.lexer(l);
+                // Pass the lexer to the parser and lex and parse the input.
+                match calc_y::parse(&mut lexer) {
+                    // Success! We parsed the input and created a parse tree.
+                    Ok(pt) => println!("Result: {}", pt),
+                    // We weren't able to fully lex the input, so all we can do is tell the user
+                    // at what index the lexer gave up at.
+                    Err(LexParseError::LexError(e)) => {
+                        println!("Lexing error at column {:?}", e.idx)
+                    }
+                    // Parsing failed, but with the help of error recovery a parse tree was
+                    // produced. However, we simply report the error to the user and don't attempt
+                    // to do any sort of evaluation.
+                    Err(LexParseError::ParseError(_, errs)) => {
+                        // One or more errors were detected during parsing.
+                        for e in errs {
+                            let (line, col) = lexer.line_and_col(e.lexeme()).unwrap();
+                            assert_eq!(line, 1);
+                            println!("Parsing error at column {}.", col);
+                        }
+                    }
+                }
+            }
+            _ => break
+        }
+    }
+}

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -294,7 +294,7 @@ where
         match self.actionkind {
             ActionKind::CustomAction => {
                 // action function references
-                outs.push_str(&format!("\n        let mut actions: Vec<Option<&Fn(&str, Vec<AStackType<{actiont}, {}>>) -> {actiont}>> = Vec::new();\n",
+                outs.push_str(&format!("\n        let mut actions: Vec<Option<&Fn(&str, &Vec<AStackType<{actiont}, {}>>) -> {actiont}>> = Vec::new();\n",
                     StorageT::type_name(),
                     actiont=actiontype)
                 );
@@ -353,7 +353,7 @@ where
                         // Iterate over all $-arguments and replace them with their respective
                         // element from the argument vector (e.g. $1 is replaced by args[0]). At
                         // the same time extract &str from tokens and actiontype from nonterminals.
-                        outs.push_str(&format!("fn {prefix}action_{}({prefix}input: &str, {prefix}args: Vec<AStackType<{actiont}, {}>>) -> {actiont} {{\n",
+                        outs.push_str(&format!("fn {prefix}action_{}({prefix}input: &str, {prefix}args: &Vec<AStackType<{actiont}, {}>>) -> {actiont} {{\n",
                             usize::from(pidx),
                             StorageT::type_name(),
                             prefix=ACTION_PREFIX,

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -50,6 +50,7 @@ use lrtable::{from_yacc, Minimiser, StateGraph, StateTable};
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 use serde::{Deserialize, Serialize};
 use typename::TypeName;
+use regex::Regex;
 
 use RecoveryKind;
 
@@ -60,13 +61,22 @@ const RUST_FILE_EXT: &str = "rs";
 const SGRAPH_FILE_EXT: &str = "sgraph";
 const STABLE_FILE_EXT: &str = "stable";
 
+/// By default `CTParserBuilder` generates a parse tree which is returned after a successful parse.
+/// If the user wants to supply custom actions to be executed during reductions and return their
+/// results, they may change `ActionKind` to `CustomAction` instead.
+pub enum ActionKind {
+    CustomAction,
+    GenericParseTree
+}
+
 /// A `CTParserBuilder` allows one to specify the criteria for building a statically generated
 /// parser.
 pub struct CTParserBuilder<StorageT = u32> {
     // Anything stored in here almost certainly needs to be included as part of the rebuild_cache
     // function below so that, if it's changed, the grammar is rebuilt.
     recoverer: RecoveryKind,
-    phantom: PhantomData<StorageT>
+    phantom: PhantomData<StorageT>,
+    actionkind: ActionKind
 }
 
 impl<StorageT> CTParserBuilder<StorageT>
@@ -96,7 +106,8 @@ where
     pub fn new() -> Self {
         CTParserBuilder {
             recoverer: RecoveryKind::MF,
-            phantom: PhantomData
+            phantom: PhantomData,
+            actionkind: ActionKind::GenericParseTree
         }
     }
 
@@ -128,6 +139,11 @@ where
         let mut outd = PathBuf::new();
         outd.push(var("OUT_DIR").unwrap());
         self.process_file(inp, outd)
+    }
+
+    pub fn action_kind(mut self, ak: ActionKind) -> Self {
+        self.actionkind = ak;
+        self
     }
 
     /// Statically compile the Yacc file `inp` into Rust, placing the output file(s) into
@@ -217,16 +233,29 @@ where
         let mut outs = String::new();
         // Header
         let mod_name = inp.as_ref().file_stem().unwrap().to_str().unwrap();
-        outs.push_str(&format!("mod {}_y {{", mod_name));
-        outs.push_str(&format!(
-            "use lrpar::{{Lexer, Node, LexParseError, RecoveryKind, RTParserBuilder}};
-use lrpar::ctbuilder::_reconstitute;
+        outs.push_str(&format!("mod {}_y {{\n", mod_name));
+        outs.push_str("    use lrpar::{{Lexer, Node, LexParseError, RecoveryKind, RTParserBuilder}};
+    use lrpar::ctbuilder::_reconstitute;",
+        );
 
-pub fn parse(lexer: &mut Lexer<{storaget}>)
+        match self.actionkind {
+            ActionKind::CustomAction => {
+                outs.push_str(&format!("
+    pub fn parse(lexer: &mut Lexer<{storaget}>)
+          -> Result<TYPE, LexParseError<{storaget}>>
+    {{",
+                storaget = StorageT::type_name()
+                ));
+            }
+            ActionKind::GenericParseTree => {
+                outs.push_str(&format!("
+    pub fn parse(lexer: &mut Lexer<{storaget}>)
           -> Result<Node<{storaget}>, LexParseError<{storaget}>>
-{{",
-            storaget = StorageT::type_name()
-        ));
+    {{",
+                storaget = StorageT::type_name()
+                ));
+            }
+        };
 
         // grm, sgraph, stable
         let recoverer = match self.recoverer {
@@ -235,34 +264,78 @@ pub fn parse(lexer: &mut Lexer<{storaget}>)
             RecoveryKind::Panic => "Panic",
             RecoveryKind::None => "None"
         };
-        outs.push_str(&format!(
-            "
-    let (grm, sgraph, stable) = _reconstitute(include_bytes!(\"{}\"),
-                                              include_bytes!(\"{}\"),
-                                              include_bytes!(\"{}\"));
-    RTParserBuilder::new(&grm, &sgraph, &stable)
-        .recoverer(RecoveryKind::{})
-        .parse(lexer)
-",
-            out_grm.to_str().unwrap(),
-            out_sgraph.to_str().unwrap(),
-            out_stable.to_str().unwrap(),
-            recoverer
-        ));
 
-        outs.push_str("}\n");
+        outs.push_str(&format!("
+        let (grm, sgraph, stable) = _reconstitute(include_bytes!(\"{}\"),
+                                                  include_bytes!(\"{}\"),
+                                                  include_bytes!(\"{}\"));",
+                out_grm.to_str().unwrap(),
+                out_sgraph.to_str().unwrap(),
+                out_stable.to_str().unwrap()));
+
+        match self.actionkind {
+            ActionKind::CustomAction => {
+                // action function references
+                outs.push_str("\n        let mut actions: Vec<Option<&Fn(Vec<TYPE>) -> TYPE>> = Vec::new();\n");
+                for pidx in grm.iter_pidxs() {
+                    if grm.action(pidx).is_some() {
+                        outs.push_str(&format!("        actions.push(Some(&action_{}));\n", usize::from(pidx)))
+                    }
+                    else {
+                        outs.push_str("        actions.push(None);")
+                    };
+                }
+                outs.push_str(&format!("
+        let s = lexer.input().to_string();
+        RTParserBuilder::new(&grm, &sgraph, &stable)
+            .recoverer(RecoveryKind::{})
+            .parse2(lexer, actions, &s, &convert)\n",
+                recoverer,
+                ));
+            },
+            ActionKind::GenericParseTree => {
+                outs.push_str(&format!("
+        RTParserBuilder::new(&grm, &sgraph, &stable)
+            .recoverer(RecoveryKind::{})
+            .parse(lexer)\n",
+                recoverer
+                ));
+            }
+        };
+
+        outs.push_str("    }\n\n");
 
         // The rule constants
         for ridx in grm.iter_rules() {
             if !grm.rule_to_prods(ridx).contains(&grm.start_prod()) {
                 outs.push_str(&format!(
-                    "#[allow(dead_code)]\npub const R_{}: {} = {:?};\n",
+                    "    #[allow(dead_code)]\n    pub const R_{}: {} = {:?};\n",
                     grm.rule_name(ridx).to_ascii_uppercase(),
                     StorageT::type_name(),
                     usize::from(ridx)
                 ));
             }
         }
+
+        match self.actionkind {
+            ActionKind::CustomAction => {
+                let re: Regex = { Regex::new(r"\$([0-9]+)").unwrap() };
+                if let Some(s) = grm.programs() {
+                    outs.push_str("\n/* User code */\n\n");
+                    outs.push_str(s);
+                }
+
+                // Convert actions to functions
+                outs.push_str("\n/* Converted actions */\n\n");
+                for pidx in grm.iter_pidxs() {
+                    if let Some(s) = grm.action(pidx) {
+                        let ns = re.replace_all(s, "args[$1]");
+                        outs.push_str(&format!("fn action_{}(args: Vec<TYPE>) -> TYPE {{\n    {}\n}}\n\n", usize::from(pidx), ns));
+                    }
+                }
+            },
+            ActionKind::GenericParseTree => ()
+        };
 
         outs.push_str("}\n\n");
 
@@ -280,7 +353,7 @@ pub fn parse(lexer: &mut Lexer<{storaget}>)
         // We don't need to be particularly clever here: we just need to record the various things
         // that could change between builds.
         let mut cache = String::new();
-        cache.push_str(" \n/* CACHE INFORMATION\n");
+        cache.push_str("\n/* CACHE INFORMATION\n");
 
         // Record the time that this version of lrpar was built. If the source code changes and
         // rustc forces a recompile, this will change this value, causing anything which depends on

--- a/lrpar/src/lib/lex.rs
+++ b/lrpar/src/lib/lex.rs
@@ -25,6 +25,7 @@ pub trait Lexer<StorageT: Hash + PrimInt + Unsigned> {
     /// Return the line and column number of a `Lexeme`, or `Err` if it is out of bounds, or no
     /// line number information was collected.
     fn line_and_col(&self, &Lexeme<StorageT>) -> Result<(usize, usize), ()>;
+    fn input(&self) -> &str;
 
     /// Return all this lexer's remaining lexemes or a `LexError` if there was a problem when lexing.
     fn all_lexemes(&mut self) -> Result<Vec<Lexeme<StorageT>>, LexError> {

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -135,9 +135,47 @@ where
         let mut pstack = vec![StIdx::from(StIdxStorageT::zero())];
         let mut tstack: Vec<Node<StorageT>> = Vec::new();
         let mut errors: Vec<ParseError<StorageT>> = Vec::new();
-        let accpt = psr.lr(0, &mut pstack, &mut tstack, &mut errors);
+        let accpt = psr.lr::<u64>(0, &mut pstack, &mut tstack, &mut errors, None);
         match (accpt, errors.is_empty()) {
             (true, true) => Ok(tstack.drain(..).nth(0).unwrap()),
+            (true, false) => Err((Some(tstack.drain(..).nth(0).unwrap()), errors)),
+            (false, false) => Err((None, errors)),
+            (false, true) => panic!("Internal error")
+        }
+    }
+
+    fn parse2<F, K>(
+        rcvry_kind: RecoveryKind,
+        grm: &YaccGrammar<StorageT>,
+        token_cost: F,
+        sgraph: &StateGraph<StorageT>,
+        stable: &StateTable<StorageT>,
+        lexemes: &[Lexeme<StorageT>],
+        actions: Vec<Option<&Fn(Vec<K>) -> K>>,
+        input: &str,
+        convert: &Fn(&str) -> K
+    ) -> Result<K, (Option<Node<StorageT>>, Vec<ParseError<StorageT>>)>
+    where
+        F: Fn(TIdx<StorageT>) -> u8
+    {
+        for tidx in grm.iter_tidxs() {
+            assert!(token_cost(tidx) > 0);
+        }
+        let psr = Parser {
+            rcvry_kind,
+            grm,
+            token_cost: &token_cost,
+            sgraph,
+            stable,
+            lexemes
+        };
+        let mut pstack = vec![StIdx::from(StIdxStorageT::zero())];
+        let mut tstack: Vec<Node<StorageT>> = Vec::new();
+        let mut errors: Vec<ParseError<StorageT>> = Vec::new();
+        let mut astack: Vec<K> = Vec::new();
+        let accpt = psr.lr(0, &mut pstack, &mut tstack, &mut errors, Some((&actions, &mut astack, &input, convert)));
+        match (accpt, errors.is_empty()) {
+            (true, true) => Ok(astack.drain(..).nth(0).unwrap()),
             (true, false) => Err((Some(tstack.drain(..).nth(0).unwrap()), errors)),
             (false, false) => Err((None, errors)),
             (false, true) => panic!("Internal error")
@@ -157,12 +195,13 @@ where
     /// Return `true` if the parse reached an accept state (i.e. all the input was consumed,
     /// possibly after making repairs) or `false` (i.e. some of the input was not consumed, even
     /// after possibly making repairs) otherwise.
-    pub fn lr(
+    pub fn lr<K>(
         &self,
         mut laidx: usize,
         pstack: &mut PStack,
         tstack: &mut TStack<StorageT>,
-        errors: &mut Vec<ParseError<StorageT>>
+        errors: &mut Vec<ParseError<StorageT>>,
+        mut actiondata: Option<(&Vec<Option<&Fn(Vec<K>) -> K>>, &mut Vec<K>, &str, &Fn(&str) -> K)>
     ) -> bool {
         let mut recoverer = None;
         let mut recovery_budget = Duration::from_millis(RECOVERY_TIME_BUDGET);
@@ -180,11 +219,25 @@ where
                     pstack.drain(pop_idx..);
                     let prior = *pstack.last().unwrap();
                     pstack.push(self.stable.goto(prior, ridx).unwrap());
+
+                    // Process actions
+                    if let Some((actions, ref mut astack, _, _)) = actiondata {
+                            let args: Vec<K> = astack.drain(pop_idx -1..).collect();
+                            if let Some(f) = actions[usize::from(pidx)] {
+                                astack.push(f(args));
+                            }
+                    }
                 }
                 Action::Shift(state_id) => {
                     let la_lexeme = self.next_lexeme(laidx);
                     tstack.push(Node::Term { lexeme: la_lexeme });
                     pstack.push(state_id);
+                    match actiondata {
+                        Some((_, ref mut astack, input, convert)) => {
+                            astack.push(convert(&input[la_lexeme.start()..la_lexeme.end()]))
+                        },
+                        None => ()
+                    };
                     laidx += 1;
                 }
                 Action::Accept => {
@@ -508,6 +561,29 @@ where
             &lexer.all_lexemes()?[..]
         )?)
     }
+
+    /// Parse input. On success return a parse tree. On failure, return a `LexParseError`: a
+    /// `LexError` means that no parse tree was produced; a `ParseError` may (if its first element
+    /// is `Some(...)`) return a parse tree (with parts filled in by this builder's recoverer).
+    pub fn parse2<K>(
+        &self,
+        lexer: &mut Lexer<StorageT>,
+        actions: Vec<Option<&Fn(Vec<K>) -> K>>,
+        input: &str,
+        convert: &Fn(&str) -> K
+    ) -> Result<K, LexParseError<StorageT>> {
+        Ok(Parser::parse2(
+            self.recoverer,
+            self.grm,
+            self.term_costs,
+            self.sgraph,
+            self.stable,
+            &lexer.all_lexemes()?[..],
+            actions,
+            input,
+            convert
+        )?)
+    }
 }
 
 /// After a parse error is encountered, the parser attempts to find a way of recovering. Each entry
@@ -643,6 +719,10 @@ pub(crate) mod test {
         }
 
         fn line_and_col(&self, _: &Lexeme<StorageT>) -> Result<(usize, usize), ()> {
+            unreachable!();
+        }
+
+        fn input(&self) -> &str {
             unreachable!();
         }
     }


### PR DESCRIPTION
This PR is under construction and should not be merged in its current state. The goal of this PR is to implement grammar actions similar to YACC, for example:

```
%start Expr
%%
Expr: Term 'PLUS' Expr { add($0, $2) }
    | Term { $0 }
    ;
Term: Factor 'MUL' Term { mul ($0, $2) }
    | Factor { $0 }
    ;
Factor: 'LBRACK' Expr 'RBRACK' { $1 }
      | 'INT' { $0 }
      ;
%%
type TYPE = u64;

fn add(arg1: u64, arg2: u64) -> u64 {
    arg1 + arg2
}
fn mul(arg1: u64, arg2: u64) -> u64 {
    arg1 * arg2
}
```