### PR TITLE
Panic mode should check the EOF token.

### DIFF
--- a/lrpar/src/lib/panic.rs
+++ b/lrpar/src/lib/panic.rs
@@ -69,7 +69,7 @@ where
         // is no way the user can adjust their input to get the parser into the same state as the
         // recovery algorithm manages).
         let iter_pstack = in_pstack.clone();
-        for laidx in in_laidx..parser.lexemes.len() {
+        for laidx in in_laidx..parser.lexemes.len() + 1 {
             if Instant::now() >= finish_by {
                 break;
             }


### PR DESCRIPTION
This might allow it (perhaps indirectly) to find a state with an Accept action. It means that we can recover from things like "2 +" which previously caused error recovery to fail.