### PR TITLE
Newlines in grammar actions break error line numbers

### DIFF
--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -345,6 +345,10 @@ impl YaccParser {
                     break;
                 }
                 '}' => -1,
+                '\n' | '\r' => {
+                    self.newlines.push(j + 1);
+                    0
+                },
                 _ => 0
             };
             j += ch.len_utf8();
@@ -1100,6 +1104,25 @@ A:
         ).unwrap();
         assert_eq!(grm.programs, Some("fn foo() {}".to_string()));
     }
+
+    #[test]
+    fn test_actions_with_newlines() {
+        match parse(
+            YaccKind::Original,
+            &"
+         %%
+         A: 'a' { foo();
+                  bar(); }
+         ;
+         B: b';") {
+            Ok(_) => panic!(),
+            Err(YaccParserError {
+                line: 6,
+                ..
+            }) => (),
+            Err(e) => panic!("Incorrect error returned {}", e)
+        }
+     }
 
     #[test]
     fn test_comments() {


### PR DESCRIPTION
Since grammar actions can spread over multiple lines, we need to take note
of any line numbers within them. Otherwise, this can result in the wrong
line numbers in parse-error messages.