### PR TITLE
Allow grammars to specify pretty-printed versions of tokens for error recovery

### DIFF
--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -222,14 +222,14 @@ fn main() {
                                         if j > 0 {
                                             s.push_str(" ");
                                         }
-                                        s.push_str(grm.token_name(*tidx).unwrap());
+                                        s.push_str(grm.token_epp(*tidx).unwrap());
                                     }
                                 }
                                 s.push_str("}");
                                 out.push(s);
                             }
                             ParseRepair::Insert(token_idx) => out
-                                .push(format!("Insert \"{}\"", grm.token_name(token_idx).unwrap())),
+                                .push(format!("Insert {}", grm.token_epp(token_idx).unwrap())),
                             ParseRepair::Shift(l) | ParseRepair::Delete(l) => {
                                 let t = &input[l.start()..l.start() + l.len()].replace("\n", "\\n");
                                 if let ParseRepair::Delete(_) = *r {


### PR DESCRIPTION
**This is a request for comments, at least initially: is this a good idea?**

Consider this following Lua fragment:

```lua
  if then end
```

If we run our parser on it we get:

```
  Error at line 1 col 4. Repairs found:
    Insert LONG_STR
    Insert SHORT_STR
    Insert DOTDOTDOT
    Insert NUMERAL
    Insert TRUE
    Insert FALSE
    Insert NIL
    Insert NAME
```

The problem is that the user might not know what those token names mean. What's the difference between LONG_STR and SHORT_STR?

This commit allows users to add %epp <token> <pp> declarations to a grammar such as:

```
  %epp LONG_STR [=[...]=]
  %epp SHORT_STR "..."
```

When an %epp declaration exists for a token that is used instead of the token name. Thus this commit makes error recovery show the following to users:

```
  Error at line 1 col 4. Repairs found:
    Insert [=[...]=]
    Insert "..."
    Insert ...
    Insert <Numeral>
    Insert true
    Insert false
    Insert nil
    Insert <Name>
```

It's a bit of a toss-up as to whether this information should go in the lexer or parser. Since error recovery is an entirely grammar-based thing, I've come down on the side of putting it in the grammar.