### PR TITLE
Remove InsertSeq.

### DIFF
--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -478,7 +478,6 @@ mod test {
         let mut out = vec![];
         for r in repairs.iter() {
             match *r {
-                ParseRepair::InsertSeq { .. } => panic!("Internal error"),
                 ParseRepair::Insert(token_idx) => {
                     out.push(format!("Insert \"{}\"", grm.token_name(token_idx).unwrap()))
                 }

--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -599,7 +599,6 @@ where
 {
     for r in repairs.iter() {
         match *r {
-            ParseRepair::InsertSeq(_) => unreachable!(),
             ParseRepair::Insert(tidx) => {
                 let next_lexeme = parser.next_lexeme(laidx);
                 let new_lexeme = Lexeme::new(
@@ -879,23 +878,6 @@ mod test {
         let mut out = vec![];
         for r in repairs.iter() {
             match *r {
-                ParseRepair::InsertSeq(ref seqs) => {
-                    let mut s = String::new();
-                    s.push_str("Insert {");
-                    for (i, seq) in seqs.iter().enumerate() {
-                        if i > 0 {
-                            s.push_str(", ");
-                        }
-                        for (j, tidx) in seq.iter().enumerate() {
-                            if j > 0 {
-                                s.push_str(" ");
-                            }
-                            s.push_str(&format!("\"{}\"", grm.token_name(*tidx).unwrap()));
-                        }
-                    }
-                    s.push_str("}");
-                    out.push(s);
-                }
                 ParseRepair::Insert(token_idx) => {
                     out.push(format!("Insert \"{}\"", grm.token_name(token_idx).unwrap()))
                 }

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -601,8 +601,6 @@ where
 pub enum ParseRepair<StorageT> {
     /// Insert a `Symbol::Token`.
     Insert(TIdx<StorageT>),
-    /// Insert one of the sequences of `Symbol::Token`s.
-    InsertSeq(Vec<Vec<TIdx<StorageT>>>),
     /// Delete a symbol.
     Delete(Lexeme<StorageT>),
     /// Shift a symbol.

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -211,23 +211,6 @@ fn main() {
                     let mut out = vec![];
                     for r in repair.iter() {
                         match *r {
-                            ParseRepair::InsertSeq(ref seqs) => {
-                                let mut s = String::new();
-                                s.push_str("Insert {");
-                                for (i, seq) in seqs.iter().enumerate() {
-                                    if i > 0 {
-                                        s.push_str(", ");
-                                    }
-                                    for (j, tidx) in seq.iter().enumerate() {
-                                        if j > 0 {
-                                            s.push_str(" ");
-                                        }
-                                        s.push_str(grm.token_epp(*tidx).unwrap());
-                                    }
-                                }
-                                s.push_str("}");
-                                out.push(s);
-                            }
                             ParseRepair::Insert(token_idx) => out
                                 .push(format!("Insert {}", grm.token_epp(token_idx).unwrap())),
                             ParseRepair::Shift(l) | ParseRepair::Delete(l) => {


### PR DESCRIPTION
This was, once upon a time, needed by the KimYi recoverer, but that no longer exists, and thus this is all dead code. Off with its head!