### PR TITLE
Clearer output

### DIFF
--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -216,9 +216,9 @@ fn main() {
                             ParseRepair::Shift(l) | ParseRepair::Delete(l) => {
                                 let t = &input[l.start()..l.start() + l.len()].replace("\n", "\\n");
                                 if let ParseRepair::Delete(_) = *r {
-                                    out.push(format!("Delete \"{}\"", t));
+                                    out.push(format!("Delete {}", t));
                                 } else {
-                                    out.push(format!("Shift \"{}\"", t));
+                                    out.push(format!("Shift {}", t));
                                 }
                             }
                         }

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -93,12 +93,14 @@ fn main() {
             "recoverer",
             "Recoverer to be used (default: mf)",
             "cpctplus|mf|panic|none"
-        ).optopt(
+        )
+        .optopt(
             "y",
             "yaccvariant",
             "Yacc variant to be parsed (default: Original)",
             "Original|Eco"
-        ).parse(&args[1..])
+        )
+        .parse(&args[1..])
     {
         Ok(m) => m,
         Err(f) => usage(prog, f.to_string().as_str())
@@ -176,7 +178,8 @@ fn main() {
             writeln!(
                 &mut stderr(),
                 "Error: these tokens are referenced in the grammar but not defined in the lexer:"
-            ).ok();
+            )
+            .ok();
             let mut sorted = tokens.iter().cloned().collect::<Vec<&str>>();
             sorted.sort();
             for n in sorted {
@@ -206,14 +209,18 @@ fn main() {
                     println!("Error at line {} col {}. No repairs found.", line, col);
                     continue;
                 }
-                println!("Error at line {} col {}. Repair sequences found:", line, col);
+                println!(
+                    "Error at line {} col {}. Repair sequences found:",
+                    line, col
+                );
                 let repairs_len = e.repairs().len();
                 for (i, repair) in e.repairs().iter().enumerate() {
                     let mut out = vec![];
                     for r in repair.iter() {
                         match *r {
-                            ParseRepair::Insert(token_idx) => out
-                                .push(format!("Insert {}", grm.token_epp(token_idx).unwrap())),
+                            ParseRepair::Insert(token_idx) => {
+                                out.push(format!("Insert {}", grm.token_epp(token_idx).unwrap()))
+                            }
                             ParseRepair::Shift(l) | ParseRepair::Delete(l) => {
                                 let t = &input[l.start()..l.start() + l.len()].replace("\n", "\\n");
                                 if let ParseRepair::Delete(_) = *r {
@@ -224,8 +231,9 @@ fn main() {
                             }
                         }
                     }
-                    let padding = ((repairs_len as f64).log10() as usize) - (((i + 1) as f64).log10() as
-                                                                             usize) + 1;
+                    let padding = ((repairs_len as f64).log10() as usize)
+                        - (((i + 1) as f64).log10() as usize)
+                        + 1;
                     println!("  {}{}: {}", " ".repeat(padding), i + 1, out.join(", "));
                 }
             }

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -206,8 +206,9 @@ fn main() {
                     println!("Error at line {} col {}. No repairs found.", line, col);
                     continue;
                 }
-                println!("Error at line {} col {}. Repairs found:", line, col);
-                for repair in e.repairs() {
+                println!("Error at line {} col {}. Repair sequences found:", line, col);
+                let repairs_len = e.repairs().len();
+                for (i, repair) in e.repairs().iter().enumerate() {
                     let mut out = vec![];
                     for r in repair.iter() {
                         match *r {
@@ -223,7 +224,9 @@ fn main() {
                             }
                         }
                     }
-                    println!("  {}", out.join(", "));
+                    let padding = ((repairs_len as f64).log10() as usize) - (((i + 1) as f64).log10() as
+                                                                             usize) + 1;
+                    println!("  {}{}: {}", " ".repeat(padding), i + 1, out.join(", "));
                 }
             }
             process::exit(1);


### PR DESCRIPTION
The first two commits make nimbleparse's output a bit easier to read (IMHO). For example, one of my standard examples now outputs this:

```
Error at line 2 col 12. Repair sequences found:
   1: Delete (
Error at line 3 col 19. Repair sequences found:
   1: Insert --
   2: Insert ++
Error at line 5 col 13. Repair sequences found:
   1: Insert this, Insert ), Insert ), Insert )
   2: Insert <integer>, Insert ), Insert ), Insert )
   3: Insert <float>, Insert ), Insert ), Insert )
   4: Insert <bool>, Insert ), Insert ), Insert )
   5: Insert '<char>', Insert ), Insert ), Insert )
   6: Insert "<string>", Insert ), Insert ), Insert )
   7: Insert null, Insert ), Insert ), Insert )
   8: Insert <id>, Insert ), Insert ), Insert )
Error at line 6 col 6. Repair sequences found:
   1: Insert }
```
