### PR TITLE
Rustfmt everything

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,18 @@ cache:
     - cargo
 install:
     - cargo install --list | grep mdbook || cargo install mdbook --vers "0.2.2"
+before_script:
+    - rustup component add rustfmt-preview
 script:
+    - cargo fmt --all -- --check
     - cargo test --all
     - cd $TRAVIS_BUILD_DIR/cfgrammar && cargo test --features "serde"
     - cd $TRAVIS_BUILD_DIR/lrtable && cargo test --features "serde"
     - cd $TRAVIS_BUILD_DIR/doc && mdbook build
-
 deploy:
-   provider: pages
-   skip-cleanup: true
-   github-token: $GITHUB_TOKEN
-   local-dir: doc/book
-   on:
-      branch: master
+    provider: pages
+    skip-cleanup: true
+    github-token: $GITHUB_TOKEN
+    local-dir: doc/book
+    on:
+        branch: master

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -118,9 +118,11 @@ impl fmt::Display for GrammarValidationError {
                 "Token '{}' used in %prec has no precedence attached",
                 self.sym.as_ref().unwrap()
             ),
-            GrammarValidationErrorKind::UnknownEPP => {
-                write!(f, "Unknown token '{}' in %epp declaration", self.sym.as_ref().unwrap())
-            }
+            GrammarValidationErrorKind::UnknownEPP => write!(
+                f,
+                "Unknown token '{}' in %epp declaration",
+                self.sym.as_ref().unwrap()
+            )
         }
     }
 }
@@ -150,7 +152,13 @@ impl GrammarAST {
         }
     }
 
-    pub fn add_prod(&mut self, key: String, symbols: Vec<Symbol>, precedence: Option<String>, action: Option<String>) {
+    pub fn add_prod(
+        &mut self,
+        key: String,
+        symbols: Vec<Symbol>,
+        precedence: Option<String>,
+        action: Option<String>
+    ) {
         self.rules
             .entry(key)
             .or_insert_with(Vec::new)
@@ -401,7 +409,12 @@ mod test {
         );
         grm.start = Some("A".to_string());
         grm.tokens.insert("b".to_string());
-        grm.add_prod("A".to_string(), vec![token("b")], Some("b".to_string()), None);
+        grm.add_prod(
+            "A".to_string(),
+            vec![token("b")],
+            Some("b".to_string()),
+            None
+        );
         assert!(grm.complete_and_validate().is_ok());
     }
 
@@ -409,7 +422,12 @@ mod test {
     fn test_invalid_precedence_override() {
         let mut grm = GrammarAST::new();
         grm.start = Some("A".to_string());
-        grm.add_prod("A".to_string(), vec![token("b")], Some("b".to_string()), None);
+        grm.add_prod(
+            "A".to_string(),
+            vec![token("b")],
+            Some("b".to_string()),
+            None
+        );
         match grm.complete_and_validate() {
             Err(GrammarValidationError {
                 kind: GrammarValidationErrorKind::UnknownToken,

--- a/cfgrammar/src/lib/yacc/firsts.rs
+++ b/cfgrammar/src/lib/yacc/firsts.rs
@@ -35,8 +35,10 @@ use std::marker::PhantomData;
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 use vob::Vob;
 
-use {RIdx, Symbol, TIdx};
 use yacc::YaccGrammar;
+use RIdx;
+use Symbol;
+use TIdx;
 
 /// `Firsts` stores all the first sets for a given grammar. For example, given this code and
 /// grammar:
@@ -224,7 +226,8 @@ mod test {
           E: D | C;
           F: E;
           "
-        ).unwrap();
+        )
+        .unwrap();
         let firsts = grm.firsts();
         has(&grm, &firsts, "^", vec!["c"]);
         has(&grm, &firsts, "D", vec!["d"]);
@@ -244,7 +247,8 @@ mod test {
           D: 'd';
           E: D C;
           "
-        ).unwrap();
+        )
+        .unwrap();
         let firsts = grm.firsts();
         has(&grm, &firsts, "E", vec!["d"]);
     }
@@ -262,7 +266,8 @@ mod test {
           C: 'c' | ;
           D: C;
           "
-        ).unwrap();
+        )
+        .unwrap();
         let firsts = grm.firsts();
         has(&grm, &firsts, "A", vec!["b", "a"]);
         has(&grm, &firsts, "C", vec!["c", ""]);
@@ -281,7 +286,8 @@ mod test {
           B: 'b' | ;
           C: B 'c' B;
           "
-        ).unwrap();
+        )
+        .unwrap();
         let firsts = grm.firsts();
         has(&grm, &firsts, "A", vec!["b", "c"]);
         has(&grm, &firsts, "B", vec!["b", ""]);
@@ -299,7 +305,8 @@ mod test {
           A: B 'b';
           B: 'b' | ;
           "
-        ).unwrap();
+        )
+        .unwrap();
         let firsts = grm.firsts();
         has(&grm, &firsts, "A", vec!["b"]);
     }
@@ -318,7 +325,8 @@ mod test {
           D: 'd' | ;
           F: C D 'f';
           "
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -349,7 +357,8 @@ mod test {
           F: 'f' | ;
           G: C D;
           "
-        ).unwrap();
+        )
+        .unwrap();
         let firsts = grm.firsts();
         has(&grm, &firsts, "E", vec!["a"]);
         has(&grm, &firsts, "T", vec!["a"]);

--- a/cfgrammar/src/lib/yacc/follows.rs
+++ b/cfgrammar/src/lib/yacc/follows.rs
@@ -35,8 +35,10 @@ use std::marker::PhantomData;
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 use vob::Vob;
 
-use {RIdx, Symbol, TIdx};
 use yacc::YaccGrammar;
+use RIdx;
+use Symbol;
+use TIdx;
 
 /// `Follows` stores all the Follow sets for a given grammar. For example, given this code and
 /// grammar:
@@ -93,8 +95,9 @@ where
                         Symbol::Rule(s_ridx) => {
                             if epsilon {
                                 for tidx in grm.iter_tidxs() {
-                                    if follows[usize::from(ridx)][usize::from(tidx)] &&
-                                        follows[usize::from(s_ridx)].set(usize::from(tidx), true) {
+                                    if follows[usize::from(ridx)][usize::from(tidx)]
+                                        && follows[usize::from(s_ridx)].set(usize::from(tidx), true)
+                                    {
                                         changed = true;
                                     }
                                 }
@@ -105,12 +108,15 @@ where
                             if sidx < prod.len() - 1 {
                                 match prod[sidx + 1] {
                                     Symbol::Token(nxt_tidx) => {
-                                        if follows[usize::from(s_ridx)].set(usize::from(nxt_tidx), true) {
+                                        if follows[usize::from(s_ridx)]
+                                            .set(usize::from(nxt_tidx), true)
+                                        {
                                             changed = true;
                                         }
                                     }
                                     Symbol::Rule(nxt_ridx) => {
-                                        if follows[usize::from(s_ridx)].or(firsts.firsts(nxt_ridx)) {
+                                        if follows[usize::from(s_ridx)].or(firsts.firsts(nxt_ridx))
+                                        {
                                             changed = true;
                                         }
                                     }
@@ -121,7 +127,10 @@ where
                 }
             }
             if !changed {
-                return YaccFollows{follows, phantom: PhantomData};
+                return YaccFollows {
+                    follows,
+                    phantom: PhantomData
+                };
             }
         }
     }
@@ -183,7 +192,9 @@ mod test {
                 T: F T2 ;
                 T2: '*' F T2 | ;
                 F: '(' E ')' | 'ID' ;
-          ").unwrap();
+          "
+        )
+        .unwrap();
         let follows = grm.follows();
         has(&grm, &follows, "E", vec![")", "$"]);
         has(&grm, &follows, "E2", vec![")", "$"]);
@@ -205,7 +216,9 @@ mod test {
                 B2: 'w' B | 'u' 'w' B ;
                 D : 'v' D2 ;
                 D2: 'x' B D2 | ;
-          ").unwrap();
+          "
+        )
+        .unwrap();
         let follows = grm.follows();
         has(&grm, &follows, "A", vec!["$"]);
         has(&grm, &follows, "B", vec!["v", "x", "$"]);
@@ -223,7 +236,9 @@ mod test {
                 %%
                 S: A 'b';
                 A: 'b' | ;
-          ").unwrap();
+          "
+        )
+        .unwrap();
         let follows = grm.follows();
         has(&grm, &follows, "S", vec!["$"]);
         has(&grm, &follows, "A", vec!["b"]);
@@ -240,7 +255,9 @@ mod test {
                   | E '+' 'N'
                   | '(' E ')'
                   ;
-          ").unwrap();
+          "
+        )
+        .unwrap();
         let follows = grm.follows();
         has(&grm, &follows, "E", vec!["+", ")", "$"]);
     }

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -30,21 +30,20 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::error::Error;
-use std::fmt;
+use std::{cell::RefCell, collections::HashMap, error::Error, fmt};
 
 use num_traits::{self, AsPrimitive, PrimInt, Unsigned};
 
-use {RIdx, PIdx, SIdx, Symbol, TIdx};
 use super::YaccKind;
-use yacc::firsts::YaccFirsts;
-use yacc::follows::YaccFollows;
-use yacc::parser::YaccParser;
+use yacc::{firsts::YaccFirsts, follows::YaccFollows, parser::YaccParser};
+use PIdx;
+use RIdx;
+use SIdx;
+use Symbol;
+use TIdx;
 
-const START_RULE         : &str = "^";
-const IMPLICIT_RULE      : &str = "~";
+const START_RULE: &str = "^";
+const IMPLICIT_RULE: &str = "~";
 const IMPLICIT_START_RULE: &str = "^~";
 
 use yacc::{
@@ -997,10 +996,13 @@ impl fmt::Display for YaccGrammarError {
 
 #[cfg(test)]
 mod test {
+    use super::{rule_max_costs, rule_min_costs, IMPLICIT_RULE, IMPLICIT_START_RULE};
     use std::collections::HashMap;
-    use super::{IMPLICIT_RULE, IMPLICIT_START_RULE, rule_max_costs, rule_min_costs};
-    use {RIdx, PIdx, Symbol, TIdx};
     use yacc::{AssocKind, Precedence, YaccGrammar, YaccKind};
+    use PIdx;
+    use RIdx;
+    use Symbol;
+    use TIdx;
 
     #[test]
     fn test_minimal() {
@@ -1099,7 +1101,8 @@ mod test {
             C: 'y'
              | 'z';
           "
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(
             grm.prods_rules,
@@ -1307,7 +1310,8 @@ mod test {
             C: 'x' B | 'x';
             D: 'y' B | 'y' 'z';
           "
-        ).unwrap();
+        )
+        .unwrap();
 
         let sg = grm.sentence_generator(|_| 1);
 
@@ -1318,7 +1322,8 @@ mod test {
                     x.iter()
                         .map(|y| grm.token_idx(y).unwrap())
                         .collect::<Vec<_>>()
-                }).collect::<Vec<_>>();
+                })
+                .collect::<Vec<_>>();
 
             let ms = sg.min_sentence(grm.rule_idx(nt_name).unwrap());
             if !cnds.iter().any(|x| x == &ms) {
@@ -1401,7 +1406,8 @@ mod test {
              | 'b';
             A: 'b';
             "
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(
             grm.prods_rules,

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -838,6 +838,7 @@ where
             all_done = false;
             let mut ls_cmplt = None; // lowest completed cost
             let mut ls_noncmplt = None; // lowest non-completed cost
+
             // The call to as_() is guaranteed safe because done.len() == grm.rules_len(), and
             // we guarantee that grm.rules_len() can fit in StorageT.
             for pidx in grm.rule_to_prods(RIdx(i.as_())).iter() {
@@ -913,6 +914,7 @@ where
             all_done = false;
             let mut hs_cmplt = None; // highest completed cost
             let mut hs_noncmplt = None; // highest non-completed cost
+
             // The call to as_() is guaranteed safe because done.len() == grm.rules_len(), and
             // we guarantee that grm.rules_len() can fit in StorageT.
             'a: for pidx in grm.rule_to_prods(RIdx(i.as_())).iter() {

--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -173,7 +173,8 @@ impl<StorageT: Copy + Eq + Hash + PrimInt + Unsigned> LexerDef<StorageT> {
                             .filter(|x| x.name.is_some())
                             .map(|x| &**x.name.as_ref().unwrap())
                             .collect::<HashSet<&str>>()
-                    ).cloned()
+                    )
+                    .cloned()
                     .collect::<HashSet<&str>>()
             );
         }
@@ -299,7 +300,8 @@ mod test {
 [0-9]+ 'int'
 [a-zA-Z]+ 'id'
 [ \t] ;
-        ".to_string();
+        "
+        .to_string();
         let mut lexer = parse_lex(&src).unwrap();
         let mut map = HashMap::new();
         map.insert("int", 0);
@@ -323,7 +325,8 @@ mod test {
         let src = "
 %%
 [0-9]+ 'int'
-        ".to_string();
+        "
+        .to_string();
         let lexer = parse_lex::<u8>(&src).unwrap();
         match lexer.lexer(&"abc").all_lexemes() {
             Ok(_) => panic!("Invalid input lexed"),

--- a/lrlex/src/lib/parser.rs
+++ b/lrlex/src/lib/parser.rs
@@ -34,8 +34,10 @@ use std::{convert::TryFrom, hash::Hash};
 
 use num_traits::{PrimInt, Unsigned};
 
-use {LexErrorKind, LexBuildError, LexBuildResult};
 use lexer::{LexerDef, Rule};
+use LexBuildError;
+use LexBuildResult;
+use LexErrorKind;
 
 pub struct LexParser<StorageT> {
     src: String,
@@ -199,13 +201,15 @@ pub fn parse_lex<StorageT: Copy + Eq + Hash + PrimInt + TryFrom<usize> + Unsigne
 #[cfg(test)]
 mod test {
     use super::*;
-    use {LexBuildError, LexErrorKind};
+    use LexBuildError;
+    use LexErrorKind;
 
     #[test]
     fn test_nooptions() {
         let src = "
 %option nounput
-        ".to_string();
+        "
+        .to_string();
         assert!(parse_lex::<u8>(&src).is_err());
     }
 
@@ -221,7 +225,8 @@ mod test {
 [0-9]+ 'int'
 [a-zA-Z]+ 'id'
 \\+ '+'
-".to_string();
+"
+        .to_string();
         let ast = parse_lex::<u8>(&src).unwrap();
         let intrule = ast.get_rule_by_name("int").unwrap();
         assert_eq!("int", intrule.name.as_ref().unwrap());
@@ -238,7 +243,8 @@ mod test {
     fn test_no_name() {
         let src = "%%
 [0-9]+ ;
-".to_string();
+"
+        .to_string();
         let ast = parse_lex::<u8>(&src).unwrap();
         let intrule = ast.get_rule(0).unwrap();
         assert!(intrule.name.is_none());
@@ -335,7 +341,8 @@ mod test {
     #[should_panic]
     fn exceed_tok_id_capacity() {
         let mut src = "%%
-".to_string();
+"
+        .to_string();
         for i in 0..257 {
             src.push_str(&format!("x 'x{}'\n", i));
         }

--- a/lrpar/examples/actions/build.rs
+++ b/lrpar/examples/actions/build.rs
@@ -34,7 +34,7 @@ extern crate lrlex;
 extern crate lrpar;
 
 use lrlex::LexerBuilder;
-use lrpar::{CTParserBuilder, ActionKind};
+use lrpar::{ActionKind, CTParserBuilder};
 
 fn main() -> Result<(), Box<std::error::Error>> {
     // First we create the parser, which returns a HashMap of all the tokens used, then we pass
@@ -43,7 +43,9 @@ fn main() -> Result<(), Box<std::error::Error>> {
     // Note that we specify the integer type (u8) we'll use for token IDs (this type *must* be big
     // enough to fit all IDs in) as well as the input file (which must end in ".y" for lrpar, and
     // ".l" for lrlex).
-    let lex_rule_ids_map = CTParserBuilder::<u8>::new().action_kind(ActionKind::CustomAction).process_file_in_src("calc.y")?;
+    let lex_rule_ids_map = CTParserBuilder::<u8>::new()
+        .action_kind(ActionKind::CustomAction)
+        .process_file_in_src("calc.y")?;
     LexerBuilder::new()
         .rule_ids_map(lex_rule_ids_map)
         .process_file_in_src("calc.l")?;

--- a/lrpar/examples/calcparse/src/main.rs
+++ b/lrpar/examples/calcparse/src/main.rs
@@ -66,25 +66,34 @@ impl<'a> Eval<'a> {
 
     fn eval(&self, n: &Node<u8>) -> i64 {
         match *n {
-            Node::Nonterm{ridx: RIdx(ridx), ref nodes} if ridx==calc_y::R_EXPR => {
+            Node::Nonterm {
+                ridx: RIdx(ridx),
+                ref nodes
+            } if ridx == calc_y::R_EXPR => {
                 if nodes.len() == 1 {
                     self.eval(&nodes[0])
                 } else {
                     debug_assert_eq!(nodes.len(), 3);
                     self.eval(&nodes[0]) + self.eval(&nodes[2])
                 }
-            },
-            Node::Nonterm{ridx: RIdx(ridx), ref nodes} if ridx==calc_y::R_TERM => {
+            }
+            Node::Nonterm {
+                ridx: RIdx(ridx),
+                ref nodes
+            } if ridx == calc_y::R_TERM => {
                 if nodes.len() == 1 {
                     self.eval(&nodes[0])
                 } else {
                     debug_assert_eq!(nodes.len(), 3);
                     self.eval(&nodes[0]) * self.eval(&nodes[2])
                 }
-            },
-            Node::Nonterm{ridx: RIdx(ridx), ref nodes} if ridx==calc_y::R_FACTOR => {
+            }
+            Node::Nonterm {
+                ridx: RIdx(ridx),
+                ref nodes
+            } if ridx == calc_y::R_FACTOR => {
                 if nodes.len() == 1 {
-                    if let Node::Term{lexeme} = nodes[0] {
+                    if let Node::Term { lexeme } = nodes[0] {
                         self.s[lexeme.start()..lexeme.end()].parse().unwrap()
                     } else {
                         unreachable!();
@@ -93,7 +102,7 @@ impl<'a> Eval<'a> {
                     debug_assert_eq!(nodes.len(), 3);
                     self.eval(&nodes[1])
                 }
-            },
+            }
             _ => unreachable!()
         }
     }

--- a/lrpar/src/lib/astar.rs
+++ b/lrpar/src/lib/astar.rs
@@ -67,7 +67,7 @@ where
 
     // First phase: search for the first success node.
 
-    let mut scs_nodes = Vec::new(); // Store success nodes
+    let mut scs_nodes = Vec::new();
     // todo is a map from "original node" to "merged node". We never change "original node", but,
     // as we find compatible repairs, continually update merged node. This means that when we pop
     // things off the todo we *must* use "merged node" as our node to work with.

--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -425,7 +425,11 @@ where
         all_rprs
     }
 
-    fn repair_to_parse_repair(&self, mut laidx: usize, from: &[Repair<StorageT>]) -> Vec<ParseRepair<StorageT>> {
+    fn repair_to_parse_repair(
+        &self,
+        mut laidx: usize,
+        from: &[Repair<StorageT>]
+    ) -> Vec<ParseRepair<StorageT>> {
         from.iter()
             .map(|y| match *y {
                 Repair::InsertTerm(token_idx) => ParseRepair::Insert(token_idx),
@@ -439,7 +443,8 @@ where
                     laidx += 1;
                     rpr
                 }
-            }).collect()
+            })
+            .collect()
     }
 }
 
@@ -559,7 +564,8 @@ E : 'N'
  + 
  N n
 ",
-        ].iter()
+        ]
+        .iter()
         .any(|x| *x == pp)
         {
             panic!("Can't find a match for {}", pp);

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -44,14 +44,16 @@ use std::{
 };
 
 use bincode::{deserialize, serialize_into};
-use cfgrammar::yacc::{YaccGrammar, YaccKind};
-use cfgrammar::Symbol;
+use cfgrammar::{
+    yacc::{YaccGrammar, YaccKind},
+    Symbol
+};
 use filetime::FileTime;
 use lrtable::{from_yacc, Minimiser, StateGraph, StateTable};
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use typename::TypeName;
-use regex::Regex;
 
 use RecoveryKind;
 
@@ -62,7 +64,6 @@ const GRM_FILE_EXT: &str = "grm";
 const RUST_FILE_EXT: &str = "rs";
 const SGRAPH_FILE_EXT: &str = "sgraph";
 const STABLE_FILE_EXT: &str = "stable";
-
 
 /// By default `CTParserBuilder` generates a parse tree which is returned after a successful parse.
 /// If the user wants to supply custom actions to be executed during reductions and return their
@@ -240,9 +241,7 @@ where
             Some(t) => t,
             None => {
                 match self.actionkind {
-                    ActionKind::CustomAction => {
-                        panic!("Action return type not defined!")
-                    }
+                    ActionKind::CustomAction => panic!("Action return type not defined!"),
                     ActionKind::GenericParseTree => {
                         "" // Dummy string that will never be used
                     }
@@ -250,28 +249,31 @@ where
             }
         };
         outs.push_str(&format!("mod {}_y {{\n", mod_name));
-        outs.push_str("    use lrpar::{{Lexer, LexParseError, RecoveryKind, RTParserBuilder}};
-    use lrpar::ctbuilder::_reconstitute;",
+        outs.push_str(
+            "    use lrpar::{{Lexer, LexParseError, RecoveryKind, RTParserBuilder}};
+    use lrpar::ctbuilder::_reconstitute;"
         );
 
         match self.actionkind {
             ActionKind::CustomAction => {
-                outs.push_str(&format!("use lrpar::parser::AStackType;
+                outs.push_str(&format!(
+                    "use lrpar::parser::AStackType;
 
     pub fn parse(lexer: &mut Lexer<{storaget}>)
           -> Result<{actiont}, LexParseError<{storaget}>>
     {{",
-                storaget = StorageT::type_name(),
-                actiont = actiontype
+                    storaget = StorageT::type_name(),
+                    actiont = actiontype
                 ));
             }
             ActionKind::GenericParseTree => {
-                outs.push_str(&format!("use lrpar::Node;
+                outs.push_str(&format!(
+                    "use lrpar::Node;
 
     pub fn parse(lexer: &mut Lexer<{storaget}>)
           -> Result<Node<{storaget}>, LexParseError<{storaget}>>
     {{",
-                storaget = StorageT::type_name()
+                    storaget = StorageT::type_name()
                 ));
             }
         };
@@ -284,13 +286,15 @@ where
             RecoveryKind::None => "None"
         };
 
-        outs.push_str(&format!("
+        outs.push_str(&format!(
+            "
         let (grm, sgraph, stable) = _reconstitute(include_bytes!(\"{}\"),
                                                   include_bytes!(\"{}\"),
                                                   include_bytes!(\"{}\"));",
-                out_grm.to_str().unwrap(),
-                out_sgraph.to_str().unwrap(),
-                out_stable.to_str().unwrap()));
+            out_grm.to_str().unwrap(),
+            out_sgraph.to_str().unwrap(),
+            out_stable.to_str().unwrap()
+        ));
 
         match self.actionkind {
             ActionKind::CustomAction => {
@@ -301,26 +305,31 @@ where
                 );
                 for pidx in grm.iter_pidxs() {
                     if grm.action(pidx).is_some() {
-                        outs.push_str(&format!("        actions.push(Some(&{prefix}action_{}));\n", usize::from(pidx), prefix=ACTION_PREFIX))
-                    }
-                    else {
+                        outs.push_str(&format!(
+                            "        actions.push(Some(&{prefix}action_{}));\n",
+                            usize::from(pidx),
+                            prefix = ACTION_PREFIX
+                        ))
+                    } else {
                         outs.push_str("        actions.push(None);")
                     };
                 }
-                outs.push_str(&format!("
+                outs.push_str(&format!(
+                    "
         let s = lexer.input().to_string();
         RTParserBuilder::new(&grm, &sgraph, &stable)
             .recoverer(RecoveryKind::{})
             .parse2(lexer, actions, &s)\n",
-                recoverer,
+                    recoverer,
                 ));
-            },
+            }
             ActionKind::GenericParseTree => {
-                outs.push_str(&format!("
+                outs.push_str(&format!(
+                    "
         RTParserBuilder::new(&grm, &sgraph, &stable)
             .recoverer(RecoveryKind::{})
             .parse(lexer)\n",
-                recoverer
+                    recoverer
                 ));
             }
         };
@@ -360,34 +369,43 @@ where
                             prefix=ACTION_PREFIX,
                             actiont=actiontype));
                         for m in re.find_iter(s) {
-                            let num = match &s[m.start()+1..m.end()].parse::<usize>() {
+                            let num = match &s[m.start() + 1..m.end()].parse::<usize>() {
                                 Ok(val) => val - 1,
                                 Err(_) => unreachable!()
                             };
-                            outs.push_str(&format!("    let {prefix}arg_{} = match {prefix}args[{}] {{", num+1, num, prefix=ACTION_PREFIX));
+                            outs.push_str(&format!(
+                                "    let {prefix}arg_{} = match {prefix}args[{}] {{",
+                                num + 1,
+                                num,
+                                prefix = ACTION_PREFIX
+                            ));
                             match grm.prod(pidx)[num] {
-                                Symbol::Rule(_) => {
-                                    outs.push_str("
+                                Symbol::Rule(_) => outs.push_str(
+                                    "
         AStackType::ActionType(v) => v,
         AStackType::Lexeme(_) => unreachable!()
     };
-")
-                                },
-                                Symbol::Token(_) => {
-                                    outs.push_str(&format!("
+"
+                                ),
+                                Symbol::Token(_) => outs.push_str(&format!(
+                                    "
         AStackType::ActionType(_) => unreachable!(),
         AStackType::Lexeme(l) => &{prefix}input[l.start()..l.end()]
     }};
-", prefix=ACTION_PREFIX))
-                                }
+",
+                                    prefix = ACTION_PREFIX
+                                ))
                             };
                         }
-                        let ns = re.replace_all(s, format!("{prefix}arg_$1", prefix=ACTION_PREFIX).as_str());
-                        outs.push_str(&format!("    {}", &ns, ));
+                        let ns = re.replace_all(
+                            s,
+                            format!("{prefix}arg_$1", prefix = ACTION_PREFIX).as_str()
+                        );
+                        outs.push_str(&format!("    {}", &ns,));
                         outs.push_str("\n}\n\n");
                     }
                 }
-            },
+            }
             ActionKind::GenericParseTree => ()
         };
 

--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -448,7 +448,11 @@ where
         all_rprs
     }
 
-    fn repair_to_parse_repair(&self, mut laidx: usize, from: &[Repair<StorageT>]) -> Vec<ParseRepair<StorageT>> {
+    fn repair_to_parse_repair(
+        &self,
+        mut laidx: usize,
+        from: &[Repair<StorageT>]
+    ) -> Vec<ParseRepair<StorageT>> {
         from.iter()
             .map(|y| match *y {
                 Repair::InsertTerm(token_idx) => ParseRepair::Insert(token_idx),
@@ -462,7 +466,8 @@ where
                     laidx += 1;
                     rpr
                 }
-            }).collect()
+            })
+            .collect()
     }
 
     /// Return the distance from `stidx` at input position `laidx`, given the current `repairs`.
@@ -1313,7 +1318,8 @@ E: '(' E ')'
   ) 
  ) 
 ",
-        ].iter()
+        ]
+        .iter()
         .any(|x| *x == pp)
         {
             panic!("Can't find a match for {}", pp);

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -58,8 +58,7 @@ pub mod parser;
 pub use parser::{LexParseError, Node, ParseError, ParseRepair, RTParserBuilder, RecoveryKind};
 mod mf;
 
-pub use ctbuilder::CTParserBuilder;
-pub use ctbuilder::ActionKind;
+pub use ctbuilder::{ActionKind, CTParserBuilder};
 
 /// A convenience macro for including statically compiled `.y` files. A file `src/x.y` which is
 /// statically compiled by lrpar can then be used in a crate with `lrpar_mod!(x)`.

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -157,7 +157,7 @@ where
         stable: &StateTable<StorageT>,
         lexemes: &[Lexeme<StorageT>],
         actions: Vec<Option<&Fn(&str, &Vec<AStackType<ActionT, StorageT>>) -> ActionT>>,
-        input: &str,
+        input: &str
     ) -> Result<ActionT, (Option<Node<StorageT>>, Vec<ParseError<StorageT>>)>
     where
         F: Fn(TIdx<StorageT>) -> u8
@@ -177,13 +177,17 @@ where
         let mut tstack: Vec<Node<StorageT>> = Vec::new();
         let mut errors: Vec<ParseError<StorageT>> = Vec::new();
         let mut astack: Vec<AStackType<ActionT, StorageT>> = Vec::new();
-        let accpt = psr.lr(0, &mut pstack, &mut tstack, &mut errors, Some((&actions, &mut astack, &input)));
+        let accpt = psr.lr(
+            0,
+            &mut pstack,
+            &mut tstack,
+            &mut errors,
+            Some((&actions, &mut astack, &input))
+        );
         match (accpt, errors.is_empty()) {
-            (true, true) => {
-                match astack.drain(..).nth(0).unwrap() {
-                    AStackType::ActionType(u) => Ok(u),
-                    AStackType::Lexeme(_) => unreachable!()
-                }
+            (true, true) => match astack.drain(..).nth(0).unwrap() {
+                AStackType::ActionType(u) => Ok(u),
+                AStackType::Lexeme(_) => unreachable!()
             },
             (true, false) => Err((Some(tstack.drain(..).nth(0).unwrap()), errors)),
             (false, false) => Err((None, errors)),
@@ -210,7 +214,11 @@ where
         pstack: &mut PStack,
         tstack: &mut TStack<StorageT>,
         errors: &mut Vec<ParseError<StorageT>>,
-        mut actiondata: Option<(&Vec<Option<&Fn(&str, &Vec<AStackType<ActionT, StorageT>>) -> ActionT>>, &mut Vec<AStackType<ActionT, StorageT>>, &str)>
+        mut actiondata: Option<(
+            &Vec<Option<&Fn(&str, &Vec<AStackType<ActionT, StorageT>>) -> ActionT>>,
+            &mut Vec<AStackType<ActionT, StorageT>>,
+            &str
+        )>
     ) -> bool {
         let mut recoverer = None;
         let mut recovery_budget = Duration::from_millis(RECOVERY_TIME_BUDGET);
@@ -232,11 +240,11 @@ where
 
                     // Process actions
                     if let Some((actions, ref mut astack, input)) = actiondata {
-                            action_vec.clear();
-                            action_vec.extend(astack.drain(pop_idx -1..));
-                            if let Some(f) = actions[usize::from(pidx)] {
-                                astack.push(AStackType::ActionType(f(input, &action_vec)));
-                            }
+                        action_vec.clear();
+                        action_vec.extend(astack.drain(pop_idx - 1..));
+                        if let Some(f) = actions[usize::from(pidx)] {
+                            astack.push(AStackType::ActionType(f(input, &action_vec)));
+                        }
                     }
                 }
                 Action::Shift(state_id) => {
@@ -244,9 +252,7 @@ where
                     tstack.push(Node::Term { lexeme: la_lexeme });
                     pstack.push(state_id);
                     match actiondata {
-                        Some((_, ref mut astack, _)) => {
-                            astack.push(AStackType::Lexeme(la_lexeme))
-                        },
+                        Some((_, ref mut astack, _)) => astack.push(AStackType::Lexeme(la_lexeme)),
                         None => ()
                     };
                     laidx += 1;
@@ -580,7 +586,7 @@ where
         &self,
         lexer: &mut Lexer<StorageT>,
         actions: Vec<Option<&Fn(&str, &Vec<AStackType<ActionT, StorageT>>) -> ActionT>>,
-        input: &str,
+        input: &str
     ) -> Result<ActionT, LexParseError<StorageT>> {
         Ok(Parser::parse2(
             self.recoverer,
@@ -590,7 +596,7 @@ where
             self.stable,
             &lexer.all_lexemes()?[..],
             actions,
-            input,
+            input
         )?)
     }
 }

--- a/lrtable/src/lib/itemset.rs
+++ b/lrtable/src/lib/itemset.rs
@@ -240,7 +240,8 @@ mod test {
           D: 'd' | ;
           F: C D 'f';
           "
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -286,7 +287,8 @@ mod test {
           S: S 'b' | 'b' A 'a';
           A: 'a' S 'c' | 'a' | 'a' S 'b';
           "
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]

--- a/lrtable/src/lib/mod.rs
+++ b/lrtable/src/lib/mod.rs
@@ -38,8 +38,8 @@ extern crate num_traits;
 #[cfg(feature = "serde")]
 #[macro_use]
 extern crate serde;
-extern crate vob;
 extern crate sparsevec;
+extern crate vob;
 
 use std::{hash::Hash, mem::size_of};
 

--- a/lrtable/src/lib/pager.rs
+++ b/lrtable/src/lib/pager.rs
@@ -41,7 +41,8 @@ use vob::Vob;
 
 use itemset::Itemset;
 use stategraph::StateGraph;
-use {StIdx, StIdxStorageT};
+use StIdx;
+use StIdxStorageT;
 
 // This file creates stategraphs from grammars. Unfortunately there is no perfect guide to how to
 // do this that I know of -- certainly not one that talks about sensible ways to arrange data and
@@ -471,7 +472,8 @@ mod test {
           S: S 'b' | 'b' A 'a';
           A: 'a' S 'c' | 'a' | 'a' S 'b';
           "
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -552,7 +554,8 @@ mod test {
              W : 'u' V;
              V : ;
           "
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[rustfmt::skip]

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -44,11 +44,12 @@ use cfgrammar::{
     PIdx, RIdx, Symbol, TIdx
 };
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
-use vob::{IterSetBits, Vob};
 use sparsevec::SparseVec;
+use vob::{IterSetBits, Vob};
 
-use {StIdx, StIdxStorageT};
 use stategraph::StateGraph;
+use StIdx;
+use StIdxStorageT;
 
 /// The various different possible Yacc parser errors.
 #[derive(Debug)]
@@ -351,7 +352,11 @@ where
 
     /// Return the action for `stidx` and `sym`, or `None` if there isn't any.
     pub fn action(&self, stidx: StIdx, tidx: TIdx<StorageT>) -> Action<StorageT> {
-        StateTable::decode(self.actions.get(usize::from(stidx), usize::from(tidx)).unwrap())
+        StateTable::decode(
+            self.actions
+                .get(usize::from(stidx), usize::from(tidx))
+                .unwrap()
+        )
     }
 
     /// Return an iterator over the indexes of all non-empty actions of `stidx`.
@@ -875,18 +880,15 @@ mod test {
 %%
 D : D;
           "
-        ).unwrap();
+        )
+        .unwrap();
         let sg = pager_stategraph(&grm);
         match StateTable::new(&grm, &sg) {
             Ok(_) => panic!("Infinitely recursive rule let through"),
             Err(StateTableError {
                 kind: StateTableErrorKind::AcceptReduceConflict,
                 pidx
-            })
-                if pidx == PIdx(1) =>
-            {
-                ()
-            }
+            }) if pidx == PIdx(1) => (),
             Err(e) => panic!("Incorrect error returned {:?}", e)
         }
     }


### PR DESCRIPTION
We previously partly rustfmt'd the codebase. Unfortunately there were a few places where rustfmt made things worse, and I fixed most, and manually excluded a few more. However, this isn't really a good long-term plan. I've now fixed the remaining cases that rustfmt mangles (https://github.com/softdevteam/grmtools/commit/51d02cbed70a2d135d11aab553d5b89d25dc4e39) so that we can run rustfmt over the entire code base (https://github.com/softdevteam/grmtools/commit/6d9a554ae0bc78736e33a6925eedd6f6159e7d96) and enforce its use in future PRs with Travis. Probably only the first and third commits really need checking in depth.