### PR TITLE
Make grmtools build on stable.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: rust
-rust: nightly
 cache:
     - cargo
 install:
     - cargo install --list | grep mdbook || cargo install mdbook --vers "0.2.2"
 before_script:
-    - rustup component add rustfmt-preview
+    - rustup toolchain install nightly
+    - rustup component add --toolchain nightly rustfmt-preview
+    - which rustfmt || cargo install --force rustfmt-nightly
 script:
-    - cargo fmt --all -- --check
+    - cargo +nightly fmt --all -- --check
     - cargo test --all
     - cd $TRAVIS_BUILD_DIR/cfgrammar && cargo test --features "serde"
     - cd $TRAVIS_BUILD_DIR/lrtable && cargo test --features "serde"

--- a/lrlex/Cargo.toml
+++ b/lrlex/Cargo.toml
@@ -16,4 +16,5 @@ getopts = "0.2.15" # only needed for src/main.rs
 lrpar = { path = "../lrpar" }
 regex = "1.0"
 num-traits = "0.2"
+try_from = "0.2"
 typename = "0.1"

--- a/lrlex/src/lib/builder.rs
+++ b/lrlex/src/lib/builder.rs
@@ -32,7 +32,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
-    convert::{AsRef, TryFrom},
+    convert::AsRef,
     env::{current_dir, var},
     error::Error,
     fmt::Debug,
@@ -43,6 +43,7 @@ use std::{
 };
 
 use num_traits::{PrimInt, Unsigned};
+use try_from::TryFrom;
 use typename::TypeName;
 
 use lexer::LexerDef;

--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -30,16 +30,16 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#![feature(try_from)]
-
 extern crate lrpar;
 extern crate num_traits;
 extern crate regex;
+extern crate try_from;
 extern crate typename;
 
-use std::{convert::TryFrom, error::Error, fmt, hash::Hash};
+use std::{error::Error, fmt, hash::Hash};
 
 use num_traits::{PrimInt, Unsigned};
+use try_from::TryFrom;
 
 mod builder;
 mod lexer;

--- a/lrlex/src/lib/parser.rs
+++ b/lrlex/src/lib/parser.rs
@@ -30,9 +30,10 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-use std::{convert::TryFrom, hash::Hash};
+use std::hash::Hash;
 
 use num_traits::{PrimInt, Unsigned};
+use try_from::TryFrom;
 
 use lexer::{LexerDef, Rule};
 use LexBuildError;

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -363,8 +363,7 @@ where
                         // Iterate over all $-arguments and replace them with their respective
                         // element from the argument vector (e.g. $1 is replaced by args[0]). At
                         // the same time extract &str from tokens and actiontype from nonterminals.
-                        outs.push_str(&format!("#[allow(clippy::let_and_return)]
-fn {prefix}action_{}({prefix}input: &str, {prefix}args: &[AStackType<{actiont}, {}>]) -> {actiont} {{
+                        outs.push_str(&format!("fn {prefix}action_{}({prefix}input: &str, {prefix}args: &[AStackType<{actiont}, {}>]) -> {actiont} {{
 ",
                             usize::from(pidx),
                             StorageT::type_name(),

--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -856,7 +856,6 @@ mod test {
     use std::{collections::HashMap, fmt::Debug};
 
     use num_traits::{AsPrimitive, PrimInt, ToPrimitive, Unsigned, Zero};
-    use test::{black_box, Bencher};
 
     use cactus::Cactus;
     use cfgrammar::{
@@ -1133,24 +1132,6 @@ W: 'b' ;
         assert_eq!(d.dist(s7, grm.token_idx("a").unwrap()), 0);
         assert_eq!(d.dist(s7, grm.token_idx("b").unwrap()), 1);
         assert_eq!(d.dist(s7, grm.eof_token_idx()), 0);
-    }
-
-    #[bench]
-    fn bench_dist(b: &mut Bencher) {
-        let grms = "%start A
-%%
-A: '(' A ')'
- | 'a'
- | 'b'
- ;
-";
-        let grm = YaccGrammar::new(YaccKind::Original, grms).unwrap();
-        let (sgraph, stable) = from_yacc(&grm, Minimiser::Pager).unwrap();
-        b.iter(|| {
-            for _ in 0..10000 {
-                black_box(Dist::new(&grm, &sgraph, &stable, |_| 1));
-            }
-        });
     }
 
     fn check_some_repairs<StorageT: 'static + PrimInt + Unsigned>(

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -30,8 +30,6 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#![feature(test)]
-
 extern crate bincode;
 extern crate cactus;
 extern crate cfgrammar;
@@ -44,7 +42,6 @@ extern crate packedvec;
 extern crate regex;
 extern crate rmp_serde as rmps;
 extern crate serde;
-extern crate test;
 extern crate typename;
 extern crate vob;
 

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -521,7 +521,7 @@ impl<StorageT> From<(Option<Node<StorageT>>, Vec<ParseError<StorageT>>)>
     }
 }
 
-pub struct RTParserBuilder<'a, StorageT: Eq + Hash> {
+pub struct RTParserBuilder<'a, StorageT: Eq + Hash + 'a> {
     grm: &'a YaccGrammar<StorageT>,
     sgraph: &'a StateGraph<StorageT>,
     stable: &'a StateTable<StorageT>,

--- a/lrtable/Cargo.toml
+++ b/lrtable/Cargo.toml
@@ -17,3 +17,4 @@ cfgrammar = { path="../cfgrammar", features=["serde"] }
 serde = { version="1.0", features=["derive"], optional=true }
 vob = { version="2.0", features=["serde"] }
 sparsevec = { version="0.1", features=["serde"] }
+try_from = "0.2"

--- a/lrtable/src/lib/mod.rs
+++ b/lrtable/src/lib/mod.rs
@@ -30,8 +30,6 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#![feature(try_from)]
-
 extern crate cfgrammar;
 extern crate fnv;
 extern crate num_traits;
@@ -39,6 +37,7 @@ extern crate num_traits;
 #[macro_use]
 extern crate serde;
 extern crate sparsevec;
+extern crate try_from;
 extern crate vob;
 
 use std::{hash::Hash, mem::size_of};

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -30,10 +30,11 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-use std::{collections::hash_map::HashMap, convert::TryFrom, hash::Hash};
+use std::{collections::hash_map::HashMap, hash::Hash};
 
 use cfgrammar::{yacc::YaccGrammar, Symbol, TIdx};
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
+use try_from::TryFrom;
 
 use itemset::Itemset;
 use StIdx;

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -32,7 +32,6 @@
 
 use std::{
     collections::hash_map::HashMap,
-    convert::TryFrom,
     error::Error,
     fmt::{self, Debug},
     hash::Hash,
@@ -139,15 +138,15 @@ where
         let maxa = usize::from(grm.tokens_len()) * usize::from(sg.all_states_len());
         let maxg = usize::from(grm.rules_len()) * usize::from(sg.all_states_len());
         // We only have usize-2 bits to store state IDs and rule indexes
-        assert!(usize::try_from(sg.all_states_len()) < Ok(usize::max_value() - 4));
-        assert!(usize::try_from(grm.rules_len()) < Ok(usize::max_value() - 4));
+        assert!(usize::from(sg.all_states_len()) < (usize::max_value() - 4));
+        assert!(usize::from(grm.rules_len()) < (usize::max_value() - 4));
         let mut actions: Vec<usize> = Vec::with_capacity(maxa);
         actions.resize(maxa, 0);
         let mut gotos: Vec<usize> = Vec::with_capacity(maxg);
 
         // Since 0 is reserved for the error type, and states are encoded by adding 1, we can only
         // store max_value - 1 states within the goto table
-        assert!(usize::try_from(sg.all_states_len()) < Ok(usize::from(StIdx::max_value()) - 1));
+        assert!(usize::from(sg.all_states_len()) < (usize::from(StIdx::max_value()) - 1));
         gotos.resize(maxg, 0);
 
         let mut reduce_reduce = 0; // How many automatically resolved reduce/reduces were made?


### PR DESCRIPTION
There are a couple of compromises involved in this:

  * We have to use the external try_from crate, as TryFrom is not yet stabilised  to be honest, there isn't much sign of that changing).

  * I deleted one benchmark that requires the (unstable) test crate. The  isn't really useful any more.

  * stable doesn't have tool lints so the Clippy shutter-upper `#[allow(clippy::let_and_return)]` has to go. This can probably return when rustc 1.31 is out.

However, I suspect these are worthwhile in order that we no longer require users to use nightly. Thoughts welcome!