### PR TITLE
Started work on conflict API

### DIFF
--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -491,8 +491,8 @@ where
     }
 
     /// Get the action return type as defined by the user
-    pub fn actiontype(&self) -> &Option<String> {
-        &self.actiontype
+    pub fn actiontype(&self) -> Option<&String> {
+        self.actiontype.as_ref()
     }
 
     /// Get the programs part of the grammar
@@ -555,6 +555,22 @@ where
                 return false;
             }
         }
+    }
+
+    /// Returns the string representation of a given production `pidx`.
+    pub fn pp_prod(&self, pidx: PIdx<StorageT>) -> String {
+        let mut sprod = String::new();
+        let ridx = self.prod_to_rule(pidx);
+        sprod.push_str(self.rule_name(ridx));
+        sprod.push_str(":");
+        for sym in self.prod(pidx) {
+            let s = match sym {
+                Symbol::Token(tidx) => self.token_name(*tidx).unwrap(),
+                Symbol::Rule(ridx) => self.rule_name(*ridx)
+            };
+            sprod.push_str(&format!(" \"{}\"", s));
+        }
+        sprod
     }
 
     /// Return a `SentenceGenerator` which can then generate minimal sentences for any rule

--- a/lrpar/Cargo.toml
+++ b/lrpar/Cargo.toml
@@ -29,3 +29,4 @@ vob = "2.0"
 regex = "1.0"
 
 [dev-dependencies]
+temp_testdir = "0.2"

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -159,6 +159,11 @@ fn main() {
         }
     };
 
+    if let Some(c) = stable.conflicts() {
+        println!("{}", c.pp(&grm));
+        println!("Stategraph:\n{}\n", sgraph.pp_core_states(&grm));
+    }
+
     {
         let rule_ids = grm
             .tokens_map()


### PR DESCRIPTION
** PR in progress **

The goal of this PR is to provide a nice API for the user (i.e. the language developer) to inspect shift/reduce and reduce/reduce conflicts and handle them manually.

At the moment the API is **very** basic, but I thought I get some early thoughts on the direction before continuing. An example usage of the API can be found in nimbleparse, where it just pretty prints the conflicts to the terminal.

My main question would be, where the user would be expected to handle these errors. For example within the calc examples, would that be in `main.rs` or `build.rs`? Or am I off track again, and we want to allow the user to handle the conflict as it happens and they then can manually change how the parser generator resolves those conflicts?