### PR TITLE
Fix actions and parse errors

### DIFF
--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -356,16 +356,6 @@ where
         })
     }
 
-    /// Get the programs part of the grammar
-    pub fn programs(&self) -> &Option<String> {
-        &self.programs
-    }
-
-    /// Get the action return type as defined by the user
-    pub fn actiontype(&self) -> &Option<String> {
-        &self.actiontype
-    }
-
     /// How many productions does this grammar have?
     pub fn prods_len(&self) -> PIdx<StorageT> {
         self.prods_len
@@ -383,11 +373,6 @@ where
     /// Get the sequence of symbols for production `pidx`. Panics if `pidx` doesn't exist.
     pub fn prod(&self, pidx: PIdx<StorageT>) -> &[Symbol<StorageT>] {
         &self.prods[usize::from(pidx)]
-    }
-
-    /// Get the action for production `pidx`. Panics if `pidx` doesn't exist.
-    pub fn action(&self, pidx: PIdx<StorageT>) -> &Option<String> {
-        &self.actions[usize::from(pidx)]
     }
 
     /// How many symbols does production `pidx` have? Panics if `pidx` doesn't exist.
@@ -496,6 +481,21 @@ where
         self.token_epp[usize::from(tidx)]
             .as_ref()
             .and_then(|x| Some(x.as_str()))
+    }
+
+    /// Get the action for production `pidx`. Panics if `pidx` doesn't exist.
+    pub fn action(&self, pidx: PIdx<StorageT>) -> &Option<String> {
+        &self.actions[usize::from(pidx)]
+    }
+
+    /// Get the action return type as defined by the user
+    pub fn actiontype(&self) -> &Option<String> {
+        &self.actiontype
+    }
+
+    /// Get the programs part of the grammar
+    pub fn programs(&self) -> &Option<String> {
+        &self.programs
     }
 
     /// Returns a map from names to `TIdx`s of all tokens that a lexer will need to generate valid

--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -282,8 +282,8 @@ impl<'a, StorageT: Copy + Eq + Hash + PrimInt + Unsigned> Lexer<StorageT>
         ))
     }
 
-    fn input(&self) -> &str {
-        &self.s
+    fn lexeme_str(&self, l: &Lexeme<StorageT>) -> &str {
+        &self.s[l.start()..l.end()]
     }
 }
 

--- a/lrpar/examples/calc_actions/src/main.rs
+++ b/lrpar/examples/calc_actions/src/main.rs
@@ -53,3 +53,34 @@ fn main() {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use lrpar::LexParseError;
+
+    #[test]
+    fn test_basic_actions() {
+        let lexerdef = calc_l::lexerdef();
+        let mut lexer = lexerdef.lexer("2+3");
+        match calc_y::parse(&mut lexer) {
+            Ok(5) => (),
+            _ => unreachable!()
+        }
+    }
+
+    #[test]
+    fn test_error_recovery_and_actions() {
+        let lexerdef = calc_l::lexerdef();
+        let mut lexer = lexerdef.lexer("2++3");
+        match calc_y::parse(&mut lexer) {
+            Err(LexParseError::ParseError(Some(5), ..)) => (),
+            _ => unreachable!()
+        }
+        let mut lexer = lexerdef.lexer("2+3)");
+        match calc_y::parse(&mut lexer) {
+            Err(LexParseError::ParseError(Some(5), ..)) => (),
+            _ => unreachable!()
+        }
+    }
+}

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -301,7 +301,7 @@ where
         match self.actionkind {
             ActionKind::CustomAction => {
                 // action function references
-                outs.push_str(&format!("\n        let mut actions: Vec<Option<&Fn(RIdx<{storaget}>, &str, vec::Drain<AStackType<{actiont}, {storaget}>>) -> {actiont}>> = Vec::new();\n",
+                outs.push_str(&format!("\n        let mut actions: Vec<Option<&Fn(RIdx<{storaget}>, &Lexer<{storaget}>, vec::Drain<AStackType<{actiont}, {storaget}>>) -> {actiont}>> = Vec::new();\n",
                     storaget=StorageT::type_name(),
                     actiont=actiontype)
                 );
@@ -318,10 +318,9 @@ where
                 }
                 outs.push_str(&format!(
                     "
-        let s = lexer.input().to_string();
         RTParserBuilder::new(&grm, &sgraph, &stable)
             .recoverer(RecoveryKind::{})
-            .parse_actions(lexer, &actions, &s)\n",
+            .parse_actions(lexer, &actions)\n",
                     recoverer,
                 ));
             }
@@ -365,7 +364,7 @@ where
                         // Iterate over all $-arguments and replace them with their respective
                         // element from the argument vector (e.g. $1 is replaced by args[0]). At
                         // the same time extract &str from tokens and actiontype from nonterminals.
-                        outs.push_str(&format!("fn {prefix}action_{}(_ridx: RIdx<{storaget}>, {prefix}input: &str, mut {prefix}args: vec::Drain<AStackType<{actiont}, {storaget}>>) -> {actiont} {{
+                        outs.push_str(&format!("fn {prefix}action_{}({prefix}ridx: RIdx<{storaget}>, {prefix}lexer: &Lexer<{storaget}>, mut {prefix}args: vec::Drain<AStackType<{actiont}, {storaget}>>) -> {actiont} {{
 ",
                             usize::from(pidx),
                             storaget=StorageT::type_name(),
@@ -388,7 +387,7 @@ where
                                 Symbol::Token(_) => outs.push_str(&format!(
                                     "
         AStackType::ActionType(_) => unreachable!(),
-        AStackType::Lexeme(l) => &{prefix}input[l.start()..l.end()]
+        AStackType::Lexeme(ref l) => {prefix}lexer.lexeme_str(l)
     }};
 ",
                                     prefix = ACTION_PREFIX

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -258,9 +258,11 @@ where
             ActionKind::CustomAction => {
                 outs.push_str(&format!(
                     "use lrpar::parser::AStackType;
+    use cfgrammar::RIdx;
+    use std::vec;
 
     pub fn parse(lexer: &mut Lexer<{storaget}>)
-          -> Result<{actiont}, LexParseError<{storaget}>>
+          -> Result<{actiont}, LexParseError<{storaget}, {actiont}>>
     {{",
                     storaget = StorageT::type_name(),
                     actiont = actiontype
@@ -271,7 +273,7 @@ where
                     "use lrpar::Node;
 
     pub fn parse(lexer: &mut Lexer<{storaget}>)
-          -> Result<Node<{storaget}>, LexParseError<{storaget}>>
+          -> Result<Node<{storaget}>, LexParseError<{storaget}, Node<{storaget}>>>
     {{",
                     storaget = StorageT::type_name()
                 ));
@@ -299,8 +301,8 @@ where
         match self.actionkind {
             ActionKind::CustomAction => {
                 // action function references
-                outs.push_str(&format!("\n        let mut actions: Vec<Option<&Fn(&str, &[AStackType<{actiont}, {}>]) -> {actiont}>> = Vec::new();\n",
-                    StorageT::type_name(),
+                outs.push_str(&format!("\n        let mut actions: Vec<Option<&Fn(RIdx<{storaget}>, &str, vec::Drain<AStackType<{actiont}, {storaget}>>) -> {actiont}>> = Vec::new();\n",
+                    storaget=StorageT::type_name(),
                     actiont=actiontype)
                 );
                 for pidx in grm.iter_pidxs() {
@@ -363,24 +365,19 @@ where
                         // Iterate over all $-arguments and replace them with their respective
                         // element from the argument vector (e.g. $1 is replaced by args[0]). At
                         // the same time extract &str from tokens and actiontype from nonterminals.
-                        outs.push_str(&format!("fn {prefix}action_{}({prefix}input: &str, {prefix}args: &[AStackType<{actiont}, {}>]) -> {actiont} {{
+                        outs.push_str(&format!("fn {prefix}action_{}(_ridx: RIdx<{storaget}>, {prefix}input: &str, mut {prefix}args: vec::Drain<AStackType<{actiont}, {storaget}>>) -> {actiont} {{
 ",
                             usize::from(pidx),
-                            StorageT::type_name(),
+                            storaget=StorageT::type_name(),
                             prefix=ACTION_PREFIX,
                             actiont=actiontype));
-                        for m in re.find_iter(s) {
-                            let num = match &s[m.start() + 1..m.end()].parse::<usize>() {
-                                Ok(val) => val - 1,
-                                Err(_) => unreachable!()
-                            };
+                        for i in 0..grm.prod(pidx).len() {
                             outs.push_str(&format!(
-                                "    let {prefix}arg_{} = match {prefix}args[{}] {{",
-                                num + 1,
-                                num,
+                                "    let {prefix}arg_{} = match {prefix}args.next().unwrap() {{",
+                                i + 1,
                                 prefix = ACTION_PREFIX
                             ));
-                            match grm.prod(pidx)[num] {
+                            match grm.prod(pidx)[i] {
                                 Symbol::Rule(_) => outs.push_str(
                                     "
         AStackType::ActionType(v) => v,

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -319,7 +319,7 @@ where
         let s = lexer.input().to_string();
         RTParserBuilder::new(&grm, &sgraph, &stable)
             .recoverer(RecoveryKind::{})
-            .parse2(lexer, &actions, &s)\n",
+            .parse_actions(lexer, &actions, &s)\n",
                     recoverer,
                 ));
             }
@@ -328,7 +328,7 @@ where
                     "
         RTParserBuilder::new(&grm, &sgraph, &stable)
             .recoverer(RecoveryKind::{})
-            .parse(lexer)\n",
+            .parse_generictree(lexer)\n",
                     recoverer
                 ));
             }

--- a/lrpar/src/lib/lex.rs
+++ b/lrpar/src/lib/lex.rs
@@ -25,7 +25,9 @@ pub trait Lexer<StorageT: Hash + PrimInt + Unsigned> {
     /// Return the line and column number of a `Lexeme`, or `Err` if it is out of bounds, or no
     /// line number information was collected.
     fn line_and_col(&self, &Lexeme<StorageT>) -> Result<(usize, usize), ()>;
-    fn input(&self) -> &str;
+    /// Return the user input associated with a lexeme. Panics if the lexeme is invalid (i.e. was
+    /// not produced by next()).
+    fn lexeme_str(&self, &Lexeme<StorageT>) -> &str;
 
     /// Return all this lexer's remaining lexemes or a `LexError` if there was a problem when lexing.
     fn all_lexemes(&mut self) -> Result<Vec<Lexeme<StorageT>>, LexError> {

--- a/lrpar/src/lib/panic.rs
+++ b/lrpar/src/lib/panic.rs
@@ -35,13 +35,17 @@ use std::{fmt::Debug, hash::Hash, time::Instant};
 use lrtable::{Action, StIdx};
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 
-use parser::{Node, ParseRepair, Parser, Recoverer};
+use parser::{AStackType, ParseRepair, Parser, Recoverer};
 
 struct Panic;
 
-pub(crate) fn recoverer<'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned>(
-    _: &'a Parser<StorageT>
-) -> Box<Recoverer<StorageT> + 'a>
+pub(crate) fn recoverer<
+    'a,
+    StorageT: 'static + Debug + Hash + PrimInt + Unsigned,
+    ActionT: 'static
+>(
+    _: &'a Parser<StorageT, ActionT>
+) -> Box<Recoverer<StorageT, ActionT> + 'a>
 where
     usize: AsPrimitive<StorageT>,
     u32: AsPrimitive<StorageT>
@@ -49,7 +53,8 @@ where
     Box::new(Panic)
 }
 
-impl<StorageT: 'static + Debug + Hash + PrimInt + Unsigned> Recoverer<StorageT> for Panic
+impl<StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'static>
+    Recoverer<StorageT, ActionT> for Panic
 where
     usize: AsPrimitive<StorageT>,
     u32: AsPrimitive<StorageT>
@@ -57,10 +62,10 @@ where
     fn recover(
         &self,
         finish_by: Instant,
-        parser: &Parser<StorageT>,
+        parser: &Parser<StorageT, ActionT>,
         in_laidx: usize,
         in_pstack: &mut Vec<StIdx>,
-        _: &mut Vec<Node<StorageT>>
+        _: &mut Vec<AStackType<ActionT, StorageT>>
     ) -> (usize, Vec<Vec<ParseRepair<StorageT>>>) {
         // This recoverer is based on that in Compiler Design in C by Allen I. Holub p.348.
         //

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -115,7 +115,7 @@ where
     usize: AsPrimitive<StorageT>,
     u32: AsPrimitive<StorageT>
 {
-    fn parse<F>(
+    fn parse_generictree<F>(
         rcvry_kind: RecoveryKind,
         grm: &YaccGrammar<StorageT>,
         token_cost: F,
@@ -149,7 +149,7 @@ where
         }
     }
 
-    fn parse2<F, ActionT>(
+    fn parse_actions<F, ActionT>(
         rcvry_kind: RecoveryKind,
         grm: &YaccGrammar<StorageT>,
         token_cost: F,
@@ -564,11 +564,11 @@ where
     /// Parse input. On success return a parse tree. On failure, return a `LexParseError`: a
     /// `LexError` means that no parse tree was produced; a `ParseError` may (if its first element
     /// is `Some(...)`) return a parse tree (with parts filled in by this builder's recoverer).
-    pub fn parse(
+    pub fn parse_generictree(
         &self,
         lexer: &mut Lexer<StorageT>
     ) -> Result<Node<StorageT>, LexParseError<StorageT>> {
-        Ok(Parser::parse(
+        Ok(Parser::parse_generictree(
             self.recoverer,
             self.grm,
             self.term_costs,
@@ -578,16 +578,16 @@ where
         )?)
     }
 
-    /// Parse input. On success return a parse tree. On failure, return a `LexParseError`: a
-    /// `LexError` means that no parse tree was produced; a `ParseError` may (if its first element
-    /// is `Some(...)`) return a parse tree (with parts filled in by this builder's recoverer).
-    pub fn parse2<ActionT>(
+    /// Parse input, execute actions, and return the associated value. On failure, return a
+    /// `LexParseError`: a `LexError` means that no value was produced; a `ParseError` may (if its
+    /// first element is `Some(...)`) return a value.
+    pub fn parse_actions<ActionT>(
         &self,
         lexer: &mut Lexer<StorageT>,
         actions: &[Option<&Fn(&str, &[AStackType<ActionT, StorageT>]) -> ActionT>],
         input: &str
     ) -> Result<ActionT, LexParseError<StorageT>> {
-        Ok(Parser::parse2(
+        Ok(Parser::parse_actions(
             self.recoverer,
             self.grm,
             self.term_costs,
@@ -697,7 +697,7 @@ pub(crate) mod test {
         let r = match RTParserBuilder::new(&grm, &sgraph, &stable)
             .recoverer(rcvry_kind)
             .term_costs(&|tidx| **costs_tidx.get(&tidx).unwrap_or(&&1))
-            .parse(&mut lexer)
+            .parse_generictree(&mut lexer)
         {
             Ok(r) => Ok(r),
             Err(LexParseError::ParseError(r1, r2)) => Err((r1, r2)),

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -35,7 +35,8 @@ use std::{
     fmt::{self, Debug, Display},
     hash::Hash,
     marker::PhantomData,
-    time::{Duration, Instant}
+    time::{Duration, Instant},
+    vec
 };
 
 use cactus::Cactus;
@@ -94,23 +95,25 @@ where
 }
 
 pub(crate) type PStack = Vec<StIdx>; // Parse stack
-pub(crate) type TStack<StorageT> = Vec<Node<StorageT>>; // Parse tree stack
 
 pub enum AStackType<ActionT, StorageT> {
     ActionType(ActionT),
     Lexeme(Lexeme<StorageT>)
 }
 
-pub struct Parser<'a, StorageT: 'a + Eq + Hash> {
+pub struct Parser<'a, StorageT: 'a + Eq + Hash, ActionT: 'a> {
     pub rcvry_kind: RecoveryKind,
     pub grm: &'a YaccGrammar<StorageT>,
     pub token_cost: &'a Fn(TIdx<StorageT>) -> u8,
     pub sgraph: &'a StateGraph<StorageT>,
     pub stable: &'a StateTable<StorageT>,
-    pub lexemes: &'a [Lexeme<StorageT>]
+    pub lexemes: &'a [Lexeme<StorageT>],
+    actions: &'a [Option<
+        &'a Fn(RIdx<StorageT>, &str, vec::Drain<AStackType<ActionT, StorageT>>) -> ActionT
+    >]
 }
 
-impl<'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned> Parser<'a, StorageT>
+impl<'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned> Parser<'a, StorageT, Node<StorageT>>
 where
     usize: AsPrimitive<StorageT>,
     u32: AsPrimitive<StorageT>
@@ -129,36 +132,68 @@ where
         for tidx in grm.iter_tidxs() {
             assert!(token_cost(tidx) > 0);
         }
+        let mut actions: Vec<
+            Option<
+                &'a Fn(RIdx<StorageT>, &str, vec::Drain<AStackType<Node<StorageT>, StorageT>>)
+                    -> Node<StorageT>
+            >
+        > = Vec::new();
+        actions.resize(usize::from(grm.prods_len()), Some(&Parser::generic_ptree));
         let psr = Parser {
             rcvry_kind,
             grm,
             token_cost: &token_cost,
             sgraph,
             stable,
-            lexemes
+            lexemes,
+            actions: actions.as_slice()
         };
         let mut pstack = vec![StIdx::from(StIdxStorageT::zero())];
-        let mut tstack: Vec<Node<StorageT>> = Vec::new();
+        let mut astack: Vec<AStackType<Node<StorageT>, StorageT>> = Vec::new();
         let mut errors: Vec<ParseError<StorageT>> = Vec::new();
-        let accpt = psr.lr::<StorageT>(0, &mut pstack, &mut tstack, &mut errors, None);
+        let accpt = psr.lr(0, &mut pstack, &mut astack, &mut errors, ""); // XXX
         match (accpt, errors.is_empty()) {
-            (true, true) => Ok(tstack.drain(..).nth(0).unwrap()),
-            (true, false) => Err((Some(tstack.drain(..).nth(0).unwrap()), errors)),
-            (false, false) => Err((None, errors)),
-            (false, true) => panic!("Internal error")
+            (Some(v), true) => Ok(v),
+            (Some(v), false) => Err((Some(v), errors)),
+            (None, false) => Err((None, errors)),
+            (None, true) => unreachable!()
         }
     }
 
-    fn parse_actions<F, ActionT>(
+    fn generic_ptree(
+        ridx: RIdx<StorageT>,
+        _input: &str,
+        astack: vec::Drain<AStackType<Node<StorageT>, StorageT>>
+    ) -> Node<StorageT> {
+        let mut nodes = Vec::with_capacity(astack.len());
+        for a in astack {
+            nodes.push(match a {
+                AStackType::ActionType(n) => n,
+                AStackType::Lexeme(lexeme) => Node::Term { lexeme }
+            });
+        }
+        Node::Nonterm { ridx, nodes }
+    }
+}
+
+impl<'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'static>
+    Parser<'a, StorageT, ActionT>
+where
+    usize: AsPrimitive<StorageT>,
+    u32: AsPrimitive<StorageT>
+{
+    fn parse_actions<F>(
         rcvry_kind: RecoveryKind,
         grm: &YaccGrammar<StorageT>,
         token_cost: F,
         sgraph: &StateGraph<StorageT>,
         stable: &StateTable<StorageT>,
         lexemes: &[Lexeme<StorageT>],
-        actions: &[Option<&Fn(&str, &[AStackType<ActionT, StorageT>]) -> ActionT>],
+        actions: &[Option<
+            &Fn(RIdx<StorageT>, &str, vec::Drain<AStackType<ActionT, StorageT>>) -> ActionT
+        >],
         input: &str
-    ) -> Result<ActionT, (Option<Node<StorageT>>, Vec<ParseError<StorageT>>)>
+    ) -> Result<ActionT, (Option<ActionT>, Vec<ParseError<StorageT>>)>
     where
         F: Fn(TIdx<StorageT>) -> u8
     {
@@ -171,27 +206,18 @@ where
             token_cost: &token_cost,
             sgraph,
             stable,
-            lexemes
+            lexemes,
+            actions
         };
         let mut pstack = vec![StIdx::from(StIdxStorageT::zero())];
-        let mut tstack: Vec<Node<StorageT>> = Vec::new();
-        let mut errors: Vec<ParseError<StorageT>> = Vec::new();
         let mut astack: Vec<AStackType<ActionT, StorageT>> = Vec::new();
-        let accpt = psr.lr(
-            0,
-            &mut pstack,
-            &mut tstack,
-            &mut errors,
-            Some((&actions, &mut astack, &input))
-        );
+        let mut errors: Vec<ParseError<StorageT>> = Vec::new();
+        let accpt = psr.lr(0, &mut pstack, &mut astack, &mut errors, input);
         match (accpt, errors.is_empty()) {
-            (true, true) => match astack.drain(..).nth(0).unwrap() {
-                AStackType::ActionType(u) => Ok(u),
-                AStackType::Lexeme(_) => unreachable!()
-            },
-            (true, false) => Err((Some(tstack.drain(..).nth(0).unwrap()), errors)),
-            (false, false) => Err((None, errors)),
-            (false, true) => panic!("Internal error")
+            (Some(v), true) => Ok(v),
+            (Some(v), false) => Err((Some(v), errors)),
+            (None, false) => Err((None, errors)),
+            (None, true) => unreachable!()
         }
     }
 
@@ -208,21 +234,16 @@ where
     /// Return `true` if the parse reached an accept state (i.e. all the input was consumed,
     /// possibly after making repairs) or `false` (i.e. some of the input was not consumed, even
     /// after possibly making repairs) otherwise.
-    pub fn lr<ActionT>(
+    pub fn lr(
         &self,
         mut laidx: usize,
         pstack: &mut PStack,
-        tstack: &mut TStack<StorageT>,
+        astack: &mut Vec<AStackType<ActionT, StorageT>>,
         errors: &mut Vec<ParseError<StorageT>>,
-        mut actiondata: Option<(
-            &[Option<&Fn(&str, &[AStackType<ActionT, StorageT>]) -> ActionT>],
-            &mut Vec<AStackType<ActionT, StorageT>>,
-            &str
-        )>
-    ) -> bool {
+        input: &str
+    ) -> Option<ActionT> {
         let mut recoverer = None;
         let mut recovery_budget = Duration::from_millis(RECOVERY_TIME_BUDGET);
-        let mut action_vec: Vec<AStackType<ActionT, StorageT>> = Vec::new();
         loop {
             let stidx = *pstack.last().unwrap();
             let la_tidx = self.next_tidx(laidx);
@@ -231,35 +252,30 @@ where
                 Action::Reduce(pidx) => {
                     let ridx = self.grm.prod_to_rule(pidx);
                     let pop_idx = pstack.len() - self.grm.prod(pidx).len();
-                    let nodes = tstack.drain(pop_idx - 1..).collect::<Vec<Node<StorageT>>>();
-                    tstack.push(Node::Nonterm { ridx, nodes });
 
                     pstack.drain(pop_idx..);
                     let prior = *pstack.last().unwrap();
                     pstack.push(self.stable.goto(prior, ridx).unwrap());
 
                     // Process actions
-                    if let Some((actions, ref mut astack, input)) = actiondata {
-                        action_vec.clear();
-                        action_vec.extend(astack.drain(pop_idx - 1..));
-                        if let Some(f) = actions[usize::from(pidx)] {
-                            astack.push(AStackType::ActionType(f(input, &action_vec)));
-                        }
+                    if let Some(f) = self.actions[usize::from(pidx)] {
+                        let v = AStackType::ActionType(f(ridx, input, astack.drain(pop_idx - 1..)));
+                        astack.push(v);
                     }
                 }
                 Action::Shift(state_id) => {
                     let la_lexeme = self.next_lexeme(laidx);
-                    tstack.push(Node::Term { lexeme: la_lexeme });
                     pstack.push(state_id);
-                    if let Some((_, ref mut astack, _)) = actiondata {
-                        astack.push(AStackType::Lexeme(la_lexeme));
-                    }
+                    astack.push(AStackType::Lexeme(la_lexeme));
                     laidx += 1;
                 }
                 Action::Accept => {
                     debug_assert_eq!(la_tidx, self.grm.eof_token_idx());
-                    debug_assert_eq!(tstack.len(), 1);
-                    return true;
+                    debug_assert_eq!(astack.len(), 1);
+                    match astack.drain(..).nth(0).unwrap() {
+                        AStackType::ActionType(v) => return Some(v),
+                        _ => unreachable!()
+                    }
                 }
                 Action::Error => {
                     if recoverer.is_none() {
@@ -274,7 +290,7 @@ where
                                     lexeme: la_lexeme,
                                     repairs: vec![]
                                 });
-                                return false;
+                                return None;
                             }
                         });
                     }
@@ -285,7 +301,7 @@ where
                         .as_ref()
                         .unwrap()
                         .as_ref()
-                        .recover(finish_by, self, laidx, pstack, tstack);
+                        .recover(finish_by, self, laidx, pstack, astack);
                     let after = Instant::now();
                     recovery_budget = recovery_budget
                         .checked_sub(after - before)
@@ -298,7 +314,7 @@ where
                         repairs
                     });
                     if !keep_going {
-                        return false;
+                        return None;
                     }
                     laidx = new_laidx;
                 }
@@ -316,7 +332,7 @@ where
         mut laidx: usize,
         end_laidx: usize,
         pstack: &mut PStack,
-        tstack: &mut Option<&mut Vec<Node<StorageT>>>
+        astack: &mut Option<&mut Vec<AStackType<ActionT, StorageT>>>
     ) -> usize {
         assert!(lexeme_prefix.is_none() || end_laidx == laidx + 1);
         while laidx != end_laidx && laidx <= self.lexemes.len() {
@@ -331,11 +347,15 @@ where
                 Action::Reduce(pidx) => {
                     let ridx = self.grm.prod_to_rule(pidx);
                     let pop_idx = pstack.len() - self.grm.prod(pidx).len();
-                    if let Some(ref mut tstack_uw) = *tstack {
-                        let nodes = tstack_uw
-                            .drain(pop_idx - 1..)
-                            .collect::<Vec<Node<StorageT>>>();
-                        tstack_uw.push(Node::Nonterm { ridx, nodes });
+                    if let Some(ref mut astack_uw) = *astack {
+                        if let Some(f) = self.actions[usize::from(pidx)] {
+                            let v = AStackType::ActionType(f(
+                                ridx,
+                                "", // XXX,
+                                astack_uw.drain(pop_idx - 1..)
+                            ));
+                            astack_uw.push(v);
+                        }
                     }
 
                     pstack.drain(pop_idx..);
@@ -343,13 +363,13 @@ where
                     pstack.push(self.stable.goto(prior, ridx).unwrap());
                 }
                 Action::Shift(state_id) => {
-                    if let Some(ref mut tstack_uw) = *tstack {
+                    if let Some(ref mut astack_uw) = *astack {
                         let la_lexeme = if let Some(l) = lexeme_prefix {
                             l
                         } else {
                             self.next_lexeme(laidx)
                         };
-                        tstack_uw.push(Node::Term { lexeme: la_lexeme });
+                        astack_uw.push(AStackType::Lexeme(la_lexeme));
                     }
                     pstack.push(state_id);
                     laidx += 1;
@@ -471,14 +491,14 @@ where
     }
 }
 
-pub trait Recoverer<StorageT: Hash + PrimInt + Unsigned> {
+pub trait Recoverer<StorageT: Hash + PrimInt + Unsigned, ActionT> {
     fn recover(
         &self,
         Instant,
-        &Parser<StorageT>,
+        &Parser<StorageT, ActionT>,
         usize,
         &mut PStack,
-        &mut TStack<StorageT>
+        &mut Vec<AStackType<ActionT, StorageT>>
     ) -> (usize, Vec<Vec<ParseRepair<StorageT>>>);
 }
 
@@ -491,14 +511,14 @@ pub enum RecoveryKind {
 }
 
 #[derive(Debug)]
-pub enum LexParseError<StorageT> {
+pub enum LexParseError<StorageT, ActionT> {
     LexError(LexError),
-    ParseError(Option<Node<StorageT>>, Vec<ParseError<StorageT>>)
+    ParseError(Option<ActionT>, Vec<ParseError<StorageT>>)
 }
 
-impl<StorageT: Debug> Error for LexParseError<StorageT> {}
+impl<StorageT: Debug, ActionT: Debug> Error for LexParseError<StorageT, ActionT> {}
 
-impl<StorageT: Debug> fmt::Display for LexParseError<StorageT> {
+impl<StorageT: Debug, ActionT: Debug> fmt::Display for LexParseError<StorageT, ActionT> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             LexParseError::LexError(ref e) => Display::fmt(e, f),
@@ -507,16 +527,16 @@ impl<StorageT: Debug> fmt::Display for LexParseError<StorageT> {
     }
 }
 
-impl<StorageT> From<LexError> for LexParseError<StorageT> {
-    fn from(err: LexError) -> LexParseError<StorageT> {
+impl<StorageT, ActionT> From<LexError> for LexParseError<StorageT, ActionT> {
+    fn from(err: LexError) -> LexParseError<StorageT, ActionT> {
         LexParseError::LexError(err)
     }
 }
 
-impl<StorageT> From<(Option<Node<StorageT>>, Vec<ParseError<StorageT>>)>
-    for LexParseError<StorageT>
+impl<StorageT, ActionT> From<(Option<ActionT>, Vec<ParseError<StorageT>>)>
+    for LexParseError<StorageT, ActionT>
 {
-    fn from(err: (Option<Node<StorageT>>, Vec<ParseError<StorageT>>)) -> LexParseError<StorageT> {
+    fn from(err: (Option<ActionT>, Vec<ParseError<StorageT>>)) -> LexParseError<StorageT, ActionT> {
         LexParseError::ParseError(err.0, err.1)
     }
 }
@@ -567,8 +587,8 @@ where
     pub fn parse_generictree(
         &self,
         lexer: &mut Lexer<StorageT>
-    ) -> Result<Node<StorageT>, LexParseError<StorageT>> {
-        Ok(Parser::parse_generictree(
+    ) -> Result<Node<StorageT>, LexParseError<StorageT, Node<StorageT>>> {
+        Ok(Parser::<StorageT, Node<StorageT>>::parse_generictree(
             self.recoverer,
             self.grm,
             self.term_costs,
@@ -581,12 +601,14 @@ where
     /// Parse input, execute actions, and return the associated value. On failure, return a
     /// `LexParseError`: a `LexError` means that no value was produced; a `ParseError` may (if its
     /// first element is `Some(...)`) return a value.
-    pub fn parse_actions<ActionT>(
+    pub fn parse_actions<ActionT: 'static>(
         &self,
         lexer: &mut Lexer<StorageT>,
-        actions: &[Option<&Fn(&str, &[AStackType<ActionT, StorageT>]) -> ActionT>],
+        actions: &[Option<
+            &Fn(RIdx<StorageT>, &str, vec::Drain<AStackType<ActionT, StorageT>>) -> ActionT
+        >],
         input: &str
-    ) -> Result<ActionT, LexParseError<StorageT>> {
+    ) -> Result<ActionT, LexParseError<StorageT, ActionT>> {
         Ok(Parser::parse_actions(
             self.recoverer,
             self.grm,

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -140,7 +140,7 @@ where
         let mut pstack = vec![StIdx::from(StIdxStorageT::zero())];
         let mut tstack: Vec<Node<StorageT>> = Vec::new();
         let mut errors: Vec<ParseError<StorageT>> = Vec::new();
-        let accpt = psr.lr::<u64>(0, &mut pstack, &mut tstack, &mut errors, None);
+        let accpt = psr.lr::<StorageT>(0, &mut pstack, &mut tstack, &mut errors, None);
         match (accpt, errors.is_empty()) {
             (true, true) => Ok(tstack.drain(..).nth(0).unwrap()),
             (true, false) => Err((Some(tstack.drain(..).nth(0).unwrap()), errors)),

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -64,9 +64,12 @@ fn usage(prog: &str, msg: &str) -> ! {
     if !msg.is_empty() {
         writeln!(&mut stderr(), "{}", msg).ok();
     }
-    writeln!(&mut stderr(),
-             "Usage: {} [-r <cpctplus|mf|panic|none>] [-y <eco|original>] <lexer.l> <parser.y> <input file>",
-             leaf).ok();
+    writeln!(
+        &mut stderr(),
+        "Usage: {} [-r <cpctplus|mf|none>] [-y <eco|original>] <lexer.l> <parser.y> <input file>",
+        leaf
+    )
+    .ok();
     process::exit(1);
 }
 
@@ -92,7 +95,7 @@ fn main() {
             "r",
             "recoverer",
             "Recoverer to be used (default: mf)",
-            "cpctplus|mf|panic|none"
+            "cpctplus|mf|none"
         )
         .optopt(
             "y",

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -195,7 +195,7 @@ fn main() {
     let input = read_file(&matches.free[2]);
     let mut lexer = lexerdef.lexer(&input);
     let pb = RTParserBuilder::new(&grm, &sgraph, &stable).recoverer(recoverykind);
-    match pb.parse(&mut lexer) {
+    match pb.parse_generictree(&mut lexer) {
         Ok(pt) => println!("{}", pt.pp(&grm, &input)),
         Err(LexParseError::LexError(e)) => {
             println!("Lexing error at position {}", e.idx);


### PR DESCRIPTION
I wanted to do more in this PR, but it's already getting quite big, and the next stage is going to take me a little while. So it's probably best to get this in now as it already makes things somewhat better.

After a few minor commits, the meat of this PR is in https://github.com/softdevteam/grmtools/commit/9f2961e7939dc237dad725869d934f1b147038fd. This means that we no longer get hard crashes when error recovery occurs on grammars with actions, and it moves us towards (but doesn't get all the way) to a more powerful actions API. The commit message goes into a lot more detail. Finally, https://github.com/softdevteam/grmtools/commit/c1e352dd0ba8318772e79083971a6b5a6005dfa7 is a small but useful commit which gives us more flexibility going forwards.