### PR TITLE
Allow errors to percolate upwards in the actions API

### DIFF
--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -196,7 +196,7 @@ impl GrammarAST {
                 return Err(GrammarValidationError {
                     kind: GrammarValidationErrorKind::NoStartRule,
                     sym: None
-                })
+                });
             }
             Some(ref s) => {
                 if !self.rules.contains_key(s) {

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -109,7 +109,9 @@ pub struct YaccGrammar<StorageT = u32> {
     implicit_rule: Option<RIdx<StorageT>>,
     /// User defined Rust programs which can be called within actions
     actions: Vec<Option<String>>,
+    /// The programs section of a grammar, if specified; otherwise `None`.
     programs: Option<String>,
+    /// The %actiontype declaration value, if specified; otherwise `None`.
     actiontype: Option<String>
 }
 

--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -245,7 +245,7 @@ impl<'a, StorageT: Copy + Eq + Hash + PrimInt + Unsigned> Lexer<StorageT>
                     match r.tok_id {
                         Some(tok_id) => {
                             self.i += longest;
-                            return Some(Ok(Lexeme::new(tok_id, old_i, longest)));
+                            return Some(Ok(Lexeme::new(tok_id, old_i, Some(longest))));
                         }
                         None => {
                             self.i = self.s.len();
@@ -283,7 +283,8 @@ impl<'a, StorageT: Copy + Eq + Hash + PrimInt + Unsigned> Lexer<StorageT>
     }
 
     fn lexeme_str(&self, l: &Lexeme<StorageT>) -> &str {
-        &self.s[l.start()..l.end()]
+        let st = l.start();
+        &self.s[st..l.end().unwrap_or(st)]
     }
 }
 
@@ -313,11 +314,11 @@ mod test {
         let lex1 = lexemes[0];
         assert_eq!(lex1.tok_id(), 1u8);
         assert_eq!(lex1.start(), 0);
-        assert_eq!(lex1.len(), 3);
+        assert_eq!(lex1.len(), Some(3));
         let lex2 = lexemes[1];
         assert_eq!(lex2.tok_id(), 0);
         assert_eq!(lex2.start(), 4);
-        assert_eq!(lex2.len(), 3);
+        assert_eq!(lex2.len(), Some(3));
     }
 
     #[test]
@@ -353,11 +354,11 @@ if 'IF'
         let lex1 = lexemes[0];
         assert_eq!(lex1.tok_id(), 1u8);
         assert_eq!(lex1.start(), 0);
-        assert_eq!(lex1.len(), 3);
+        assert_eq!(lex1.len(), Some(3));
         let lex2 = lexemes[1];
         assert_eq!(lex2.tok_id(), 0);
         assert_eq!(lex2.start(), 4);
-        assert_eq!(lex2.len(), 2);
+        assert_eq!(lex2.len(), Some(2));
     }
 
     #[test]
@@ -389,7 +390,7 @@ if 'IF'
         assert_eq!(lexer.line_and_col(&lexemes[2]).unwrap(), (3, 3));
         assert_eq!(lexer.line_and_col(&lexemes[3]).unwrap(), (3, 5));
 
-        let fake_lexeme = Lexeme::new(0, 100, 1);
+        let fake_lexeme = Lexeme::new(0, 100, Some(1));
         if let Ok(_) = lexer.line_and_col(&fake_lexeme) {
             panic!("line_and_col returned Ok(_) when it should have returned Err.");
         }

--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -262,24 +262,24 @@ impl<'a, StorageT: Copy + Eq + Hash + PrimInt + Unsigned> Lexer<StorageT>
         None
     }
 
-    fn line_and_col(&self, l: &Lexeme<StorageT>) -> Result<(usize, usize), ()> {
-        if l.start() > self.s.len() {
-            return Err(());
+    fn line_and_col(&self, l: &Lexeme<StorageT>) -> (usize, usize) {
+        if l.start() + l.len().unwrap_or(0) > self.s.len() {
+            panic!("Invalid lexeme");
         }
 
         if self.newlines.is_empty() || l.start() < self.newlines[0] {
-            return Ok((1, l.start() + 1));
+            return (1, l.start() + 1);
         }
 
         for i in 0..self.newlines.len() - 1 {
             if self.newlines[i + 1] > l.start() {
-                return Ok((i + 2, l.start() - self.newlines[i] + 1));
+                return (i + 2, l.start() - self.newlines[i] + 1);
             }
         }
-        Ok((
+        (
             self.newlines.len() + 1,
             l.start() - self.newlines[self.newlines.len() - 1] + 1
-        ))
+        )
     }
 
     fn lexeme_str(&self, l: &Lexeme<StorageT>) -> &str {
@@ -375,25 +375,38 @@ if 'IF'
         let mut lexer = lexerdef.lexer("a b c");
         let lexemes = lexer.all_lexemes().unwrap();
         assert_eq!(lexemes.len(), 3);
-        assert_eq!(lexer.line_and_col(&lexemes[1]).unwrap(), (1, 3));
+        assert_eq!(lexer.line_and_col(&lexemes[1]), (1, 3));
 
         let mut lexer = lexerdef.lexer("a b c\n");
         let lexemes = lexer.all_lexemes().unwrap();
         assert_eq!(lexemes.len(), 3);
-        assert_eq!(lexer.line_and_col(&lexemes[1]).unwrap(), (1, 3));
+        assert_eq!(lexer.line_and_col(&lexemes[1]), (1, 3));
 
         let mut lexer = lexerdef.lexer(" a\nb\n  c d");
         let lexemes = lexer.all_lexemes().unwrap();
         assert_eq!(lexemes.len(), 4);
-        assert_eq!(lexer.line_and_col(&lexemes[0]).unwrap(), (1, 2));
-        assert_eq!(lexer.line_and_col(&lexemes[1]).unwrap(), (2, 1));
-        assert_eq!(lexer.line_and_col(&lexemes[2]).unwrap(), (3, 3));
-        assert_eq!(lexer.line_and_col(&lexemes[3]).unwrap(), (3, 5));
+        assert_eq!(lexer.line_and_col(&lexemes[0]), (1, 2));
+        assert_eq!(lexer.line_and_col(&lexemes[1]), (2, 1));
+        assert_eq!(lexer.line_and_col(&lexemes[2]), (3, 3));
+        assert_eq!(lexer.line_and_col(&lexemes[3]), (3, 5));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_bad_line_and_col() {
+        let src = "%%
+[a-z]+ 'ID'
+[ \\n] ;"
+            .to_string();
+        let mut lexerdef = parse_lex(&src).unwrap();
+        let mut map = HashMap::new();
+        map.insert("ID", 0u8);
+        assert_eq!(lexerdef.set_rule_ids(&map), (None, None));
+
+        let lexer = lexerdef.lexer("a b c");
 
         let fake_lexeme = Lexeme::new(0, 100, Some(1));
-        if let Ok(_) = lexer.line_and_col(&fake_lexeme) {
-            panic!("line_and_col returned Ok(_) when it should have returned Err.");
-        }
+        lexer.line_and_col(&fake_lexeme);
     }
 
     #[test]

--- a/lrlex/src/main.rs
+++ b/lrlex/src/main.rs
@@ -98,7 +98,7 @@ fn main() {
         println!(
             "{} {}",
             lexerdef.get_rule_by_id(l.tok_id()).name.as_ref().unwrap(),
-            &input[l.start()..l.start() + l.len()]
+            &input[l.start()..l.end().unwrap_or(l.start())]
         );
     }
 }

--- a/lrpar/Cargo.toml
+++ b/lrpar/Cargo.toml
@@ -18,6 +18,7 @@ cfgrammar = { path="../cfgrammar", features=["serde"] }
 filetime = "0.2"
 getopts = "0.2"
 indexmap = "1.0"
+lazy_static = "1.2"
 lrtable = { path="../lrtable", features=["serde"] }
 num-traits = "0.2"
 packedvec = "1.0"

--- a/lrpar/examples/calc_actions/src/main.rs
+++ b/lrpar/examples/calc_actions/src/main.rs
@@ -29,22 +29,26 @@ fn main() {
                 let mut lexer = lexerdef.lexer(l);
                 // Pass the lexer to the parser and lex and parse the input.
                 match calc_y::parse(&mut lexer) {
-                    // Success! We parsed the input and created a parse tree.
-                    Ok(pt) => println!("Result: {}", pt),
+                    // Success! We parsed the input and evaluated a result.
+                    Ok(Ok(v)) => println!("Result: {}", v),
+                    Ok(Err(_)) => eprintln!("Unable to evaluate a result."),
                     // We weren't able to fully lex the input, so all we can do is tell the user
                     // at what index the lexer gave up at.
                     Err(LexParseError::LexError(e)) => {
-                        println!("Lexing error at column {:?}", e.idx)
+                        eprintln!("Lexing error at column {:?}", e.idx)
                     }
-                    // Parsing failed, but with the help of error recovery a parse tree was
-                    // produced. However, we simply report the error to the user and don't attempt
-                    // to do any sort of evaluation.
-                    Err(LexParseError::ParseError(_, errs)) => {
+                    // Parsing failed, but with the help of error recovery a value was
+                    // produced.
+                    Err(LexParseError::ParseError(v, errs)) => {
                         // One or more errors were detected during parsing.
                         for e in errs {
                             let (line, col) = lexer.line_and_col(e.lexeme());
                             assert_eq!(line, 1);
-                            println!("Parsing error at column {}.", col);
+                            eprintln!("Parsing error at column {}.", col);
+                        }
+                        match v {
+                            Some(Ok(v)) => println!("Result: {}", v),
+                            _ => eprintln!("Unable to evaluate a result.")
                         }
                     }
                 }
@@ -64,7 +68,7 @@ mod test {
         let lexerdef = calc_l::lexerdef();
         let mut lexer = lexerdef.lexer("2+3");
         match calc_y::parse(&mut lexer) {
-            Ok(5) => (),
+            Ok(Ok(5)) => (),
             _ => unreachable!()
         }
     }
@@ -74,12 +78,17 @@ mod test {
         let lexerdef = calc_l::lexerdef();
         let mut lexer = lexerdef.lexer("2++3");
         match calc_y::parse(&mut lexer) {
-            Err(LexParseError::ParseError(Some(5), ..)) => (),
+            Err(LexParseError::ParseError(Some(Ok(5)), ..)) => (),
             _ => unreachable!()
         }
         let mut lexer = lexerdef.lexer("2+3)");
         match calc_y::parse(&mut lexer) {
-            Err(LexParseError::ParseError(Some(5), ..)) => (),
+            Err(LexParseError::ParseError(Some(Ok(5)), ..)) => (),
+            _ => unreachable!()
+        }
+        let mut lexer = lexerdef.lexer("2+3+18446744073709551616");
+        match calc_y::parse(&mut lexer) {
+            Ok(Err(_)) => (),
             _ => unreachable!()
         }
     }

--- a/lrpar/examples/calc_actions/src/main.rs
+++ b/lrpar/examples/calc_actions/src/main.rs
@@ -42,7 +42,7 @@ fn main() {
                     Err(LexParseError::ParseError(_, errs)) => {
                         // One or more errors were detected during parsing.
                         for e in errs {
-                            let (line, col) = lexer.line_and_col(e.lexeme()).unwrap();
+                            let (line, col) = lexer.line_and_col(e.lexeme());
                             assert_eq!(line, 1);
                             println!("Parsing error at column {}.", col);
                         }

--- a/lrpar/examples/calc_parsetree/src/main.rs
+++ b/lrpar/examples/calc_parsetree/src/main.rs
@@ -94,7 +94,9 @@ impl<'a> Eval<'a> {
             } if ridx == calc_y::R_FACTOR => {
                 if nodes.len() == 1 {
                     if let Node::Term { lexeme } = nodes[0] {
-                        self.s[lexeme.start()..lexeme.end()].parse().unwrap()
+                        self.s[lexeme.start()..lexeme.end().unwrap_or(lexeme.start())]
+                            .parse()
+                            .unwrap()
                     } else {
                         unreachable!();
                     }

--- a/lrpar/examples/calc_parsetree/src/main.rs
+++ b/lrpar/examples/calc_parsetree/src/main.rs
@@ -43,7 +43,7 @@ fn main() {
                     Err(LexParseError::ParseError(_, errs)) => {
                         // One or more errors were detected during parsing.
                         for e in errs {
-                            let (line, col) = lexer.line_and_col(e.lexeme()).unwrap();
+                            let (line, col) = lexer.line_and_col(e.lexeme());
                             assert_eq!(line, 1);
                             println!("Parsing error at column {}.", col);
                         }

--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -289,7 +289,7 @@ where
             let new_lexeme = Lexeme::new(
                 StorageT::from(u32::from(tidx)).unwrap(),
                 next_lexeme.start(),
-                0
+                None
             );
             let (new_laidx, n_pstack) = self.parser.lr_cactus(
                 Some(new_lexeme),
@@ -578,7 +578,7 @@ E : 'N'
 
         assert_eq!(errs.len(), 1);
         let err_tok_id = u32::from(grm.token_idx("N").unwrap()).to_u16().unwrap();
-        assert_eq!(errs[0].lexeme(), &Lexeme::new(err_tok_id, 2, 1));
+        assert_eq!(errs[0].lexeme(), &Lexeme::new(err_tok_id, 2, Some(1)));
         check_all_repairs(
             &grm,
             errs[0].repairs(),

--- a/lrpar/src/lib/lex.rs
+++ b/lrpar/src/lib/lex.rs
@@ -22,9 +22,9 @@ pub trait Lexer<StorageT: Hash + PrimInt + Unsigned> {
     /// Return the next `Lexeme` in the input or a `LexError`. Returns `None` if the input has been
     /// fully lexed (or if an error occurred which prevents further lexing).
     fn next(&mut self) -> Option<Result<Lexeme<StorageT>, LexError>>;
-    /// Return the line and column number of a `Lexeme`, or `Err` if it is out of bounds, or no
-    /// line number information was collected.
-    fn line_and_col(&self, &Lexeme<StorageT>) -> Result<(usize, usize), ()>;
+    /// Return the line and column number of a `Lexeme`. Panics if the lexeme is invalid (i.e. was
+    /// not produced by next()).
+    fn line_and_col(&self, &Lexeme<StorageT>) -> (usize, usize);
     /// Return the user input associated with a lexeme. Panics if the lexeme is invalid (i.e. was
     /// not produced by next()).
     fn lexeme_str(&self, &Lexeme<StorageT>) -> &str;

--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -617,7 +617,7 @@ where
                 let new_lexeme = Lexeme::new(
                     StorageT::from(u32::from(tidx)).unwrap(),
                     next_lexeme.start(),
-                    0
+                    None
                 );
                 parser.lr_upto(Some(new_lexeme), laidx, laidx + 1, &mut pstack, &mut astack);
             }
@@ -1239,7 +1239,7 @@ E : 'N'
 
         assert_eq!(errs.len(), 1);
         let err_tok_id = u32::from(grm.token_idx("N").unwrap()).to_u16().unwrap();
-        assert_eq!(errs[0].lexeme(), &Lexeme::new(err_tok_id, 2, 1));
+        assert_eq!(errs[0].lexeme(), &Lexeme::new(err_tok_id, 2, Some(1)));
         check_all_repairs(
             &grm,
             errs[0].repairs(),
@@ -1315,7 +1315,7 @@ E: '(' E ')'
         }
         assert_eq!(errs.len(), 1);
         let err_tok_id = u32::from(grm.eof_token_idx()).to_u16().unwrap();
-        assert_eq!(errs[0].lexeme(), &Lexeme::new(err_tok_id, 2, 0));
+        assert_eq!(errs[0].lexeme(), &Lexeme::new(err_tok_id, 2, None));
         check_all_repairs(
             &grm,
             errs[0].repairs(),

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -36,6 +36,8 @@ extern crate cfgrammar;
 extern crate filetime;
 #[macro_use]
 extern crate indexmap;
+#[macro_use]
+extern crate lazy_static;
 extern crate lrtable;
 extern crate num_traits;
 extern crate packedvec;

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -765,7 +765,7 @@ pub(crate) mod test {
             None
         }
 
-        fn line_and_col(&self, _: &Lexeme<StorageT>) -> Result<(usize, usize), ()> {
+        fn line_and_col(&self, _: &Lexeme<StorageT>) -> (usize, usize) {
             unreachable!();
         }
 

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -196,7 +196,7 @@ where
                             return Err(StateTableError {
                                 kind: StateTableErrorKind::AcceptReduceConflict,
                                 pidx
-                            })
+                            });
                         }
                         Action::Error => {
                             if pidx == grm.start_prod() && tidx == usize::from(grm.eof_token_idx())

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -207,7 +207,7 @@ fn main() {
                 None => println!("Unable to repair input sufficiently to produce parse tree.\n")
             }
             for e in errs {
-                let (line, col) = lexer.line_and_col(e.lexeme()).unwrap();
+                let (line, col) = lexer.line_and_col(e.lexeme());
                 if e.repairs().is_empty() {
                     println!("Error at line {} col {}. No repairs found.", line, col);
                     continue;

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -225,7 +225,8 @@ fn main() {
                                 out.push(format!("Insert {}", grm.token_epp(token_idx).unwrap()))
                             }
                             ParseRepair::Shift(l) | ParseRepair::Delete(l) => {
-                                let t = &input[l.start()..l.start() + l.len()].replace("\n", "\\n");
+                                let t = &input[l.start()..l.end().unwrap_or(l.start())]
+                                    .replace("\n", "\\n");
                                 if let ParseRepair::Delete(_) = *r {
                                     out.push(format!("Delete {}", t));
                                 } else {


### PR DESCRIPTION
This PR contains two major things.

First it provides a way to differentiate between lexemes of zero length (e.g. `DEDENT` tokens in Python) and lexemes created by error recovery (which have no content) in https://github.com/softdevteam/grmtools/commit/3db2be06e5c0980d272739dee322360007195c86.

Second it changes the actions API in two related ways in https://github.com/softdevteam/grmtools/commit/faee83c26bea71c0040ccbf47194bb88cec523fc: it now passes `Lexeme`s to actions (instead of strings); and it passes `Lexeme`s in an a `Result<Lexeme, Lexeme>` type, allowing users to easily tell if a lexeme is the result of user input (the `Ok` case) or error recovery (the `Err` case).

When combined with the ability to use arbitrary types for `%type` https://github.com/softdevteam/grmtools/commit/46c4265ebdf20d41dc0cd068105dbad4d34175ab, this allows users a lot of flexibility to write flexible actions, but also makes it relatively painless to do so. For example, here's the new calculator grammar:

```
start Expr
%type Result<u64, ()>
%%
Expr: Term 'PLUS' Expr { Ok($1? + $3?) }
    | Term { $1 }
    ;

Term: Factor 'MUL' Term { Ok($1? * $3?) }
    | Factor { $1 }
    ;

Factor: 'LBRACK' Expr 'RBRACK' { $2 }
      | 'INT' {
            let l = $1.map_err(|_| ())?;
            match $lexer.lexeme_str(&l).parse::<u64>() {
                Ok(v) => Ok(v),
                Err(_) => {
                    let (_, col) = $lexer.line_and_col(&l);
                    eprintln!("Error at column {}: '{}' cannot be represented as a u64",
                              col,
                              $lexer.lexeme_str(&l));
                    Err(())
                }
            }
        }
      ;
```

and here's a session using it:

```
>>> 1+2
Result: 3
>>> 1++2
Parsing error at column 3.
Result: 3
>>> 1+18446744073709551616
Error at column 3: '18446744073709551616' cannot be represented as a u64
Unable to evaluate
>>> 1+18446744073709551616+18446744073709551616
Error at column 3: '18446744073709551616' cannot be represented as a u64
Error at column 24: '18446744073709551616' cannot be represented as a u64
Unable to evaluate
```

In essence, we give users the choice for how to handle the semantic consequences of syntactic errors. Interestingly, my first attempt at this embedded the `Resulte<u64, ()>` idiom into `lrpar`, before I realised that we can let the user do it themselves just as easily.

There is one part of `lrpar`'s API which this PR makes even worse: the return type of `parse_action` is a mess, requiring the user to deal with too many cases. Fixing that is a medium sized job and best left to a subsequent PR IMHO. [It might also be a good idea to provide easy functions for the user to pretty print things like repair sequences, but that might turn out to be bloat. I'll experiment.]
