### PR TITLE
Change the parsing API's return results.

### DIFF
--- a/lrpar/examples/calc_parsetree/src/main.rs
+++ b/lrpar/examples/calc_parsetree/src/main.rs
@@ -29,20 +29,17 @@ fn main() {
                 // Now we create a lexer with the `lexer` method with which we can lex an input.
                 let mut lexer = lexerdef.lexer(l);
                 // Pass the lexer to the parser and lex and parse the input.
-                match calc_y::parse(&mut lexer) {
+                let (pt, errs) = calc_y::parse(&mut lexer);
+                if let Some(pt) = pt {
                     // Success! We parsed the input and created a parse tree.
-                    Ok(pt) => println!("{}", Eval::new(l).eval(&pt)),
-                    // We weren't able to fully lex the input, so all we can do is tell the user
-                    // at what index the lexer gave up at.
-                    Err(LexParseError::LexError(e)) => {
-                        println!("Lexing error at column {:?}", e.idx)
-                    }
-                    // Parsing failed, but with the help of error recovery a parse tree was
-                    // produced. However, we simply report the error to the user and don't attempt
-                    // to do any sort of evaluation.
-                    Err(LexParseError::ParseError(_, errs)) => {
-                        // One or more errors were detected during parsing.
-                        for e in errs {
+                    println!("{}", Eval::new(l).eval(&pt));
+                }
+                for e in errs {
+                    match e {
+                        LexParseError::LexError(e) => {
+                            eprintln!("Lexing error at column {:?}", e.idx);
+                        }
+                        LexParseError::ParseError(e) => {
                             let (line, col) = lexer.line_and_col(e.lexeme());
                             assert_eq!(line, 1);
                             println!("Parsing error at column {}.", col);

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -128,11 +128,12 @@ where
 
     /// Given the filename `x/y.z` as input, statically compile the grammar `src/x/y.z` into a Rust
     /// module which can then be imported using `lrpar_mod!(x_y)`. This is a convenience function
-    /// around [`process_file`](struct.CTParserBuilder.html#method.process_file) which makes it
-    /// easier to compile `.y` files stored in a project's `src/` directory. Note that leaf names
-    /// must be unique within a single project, even if they are in different directories: in other
-    /// words, `y.z` and `x/y.z` will both be mapped to the same module `y_z` (and it is undefined
-    /// which of the input files will "win" the compilation race).
+    /// around [`process_file`](#method.process_file) which makes it easier to compile `.y` files
+    /// stored in a project's `src/` directory.
+    ///
+    /// Note that leaf names must be unique within a single project, even if they are in different
+    /// directories: in other words, `y.z` and `x/y.z` will both be mapped to the same module `y_z`
+    /// (and it is undefined which of the input files will "win" the compilation race).
     ///
     /// # Panics
     ///
@@ -150,6 +151,7 @@ where
         self.process_file(inp, outd)
     }
 
+    /// Set the action kind for this parser to `ak`.
     pub fn action_kind(mut self, ak: ActionKind) -> Self {
         self.actionkind = ak;
         self
@@ -160,9 +162,14 @@ where
     ///
     /// ```rust,ignore
     ///      parser(lexemes: &Vec<Lexeme<StorageT>>)
-    ///   -> Result<Node<StorageT>,
-    ///            (Option<Node<StorageT>>, Vec<ParseError<StorageT>>)>
+    ///   -> (Option<ActionT>, Vec<LexParseError<StorageT>>)>
     /// ```
+    ///
+    /// Where `ActionT` is either:
+    ///
+    ///   * the `%type` value given to the grammar
+    ///   * or, if the `action_kind` was set to `ActionKind::GenericParseTree`, it is
+    ///     [`Node<StorageT>`](../parser/enum.Node.html)
     ///
     /// # Panics
     ///
@@ -268,7 +275,7 @@ where
     use std::vec;
 
     pub fn parse(lexer: &mut Lexer<{storaget}>)
-          -> Result<{actiont}, LexParseError<{storaget}, {actiont}>>
+          -> (Option<{actiont}>, Vec<LexParseError<{storaget}>>)
     {{",
                     storaget = StorageT::type_name(),
                     actiont = actiontype
@@ -279,7 +286,7 @@ where
                     "use lrpar::Node;
 
     pub fn parse(lexer: &mut Lexer<{storaget}>)
-          -> Result<Node<{storaget}>, LexParseError<{storaget}, Node<{storaget}>>>
+          -> (Option<Node<{storaget}>>, Vec<LexParseError<{storaget}>>)
     {{",
                     storaget = StorageT::type_name()
                 ));


### PR DESCRIPTION
The API for getting results from parsing had become a nightmare to use. For example the custom action parse method had this return type:

```
  Result<Node<{storaget}>, LexParseError<{storaget}, Node<{storaget}>>>
```

This looks innocuous, but required huge duplication to deal with correctly
e.g. this taken from calc_actions:

```
  match parse(&mut lexer) {
       Ok(Ok(v)) => println!("Result: {}", v),
       Ok(Err(_)) => println!("Unable to evaluate a result."),
       Err(LexParseError::LexError(e)) => // lexing error
       Err(LexParseError::ParseError(v, errs)) => {
           match v {
               Some(Ok(v)) => println!("Result: {}", v),
               _ => eprintln!("Unable to evaluate a result.")
           }
           for e in errs {
               // print parsing error
           }
       }
  }
```

Notice that we had to handle the success and failure conditions for the main result twice. And, to add insult to injury, the API suggested that if things went wrong, one either got a single lexing error, or one or more parsing errors.

This commit changes the return type to the simpler:

```
  (Option<Node<{storaget}>>, Vec<LexParseError<{storaget}>>) 
```

One can achieve the same result as above with just:

```
  let (res, errs) = parse(&mut lexer);
  for e in errs {
      match e {
          LexParseError::LexError(e) => // print lexing error
          LexParseError::ParseError(e) => // print parsing error
      }
  }
  match res {
      Some(Ok(r)) => println!("Result: {}", r),
      _ => println!("Unable to evaluate expression.")
  }
```

Notice also that LexParseError is now much simpler: it's just one lexing error, or one parsing error (whereas before it was one lexing error or multiple parsing errors). Even better, it's now clear that one can receive multiple lexing or parsing errors, and that they can be intertwined. [OK, the current implementation stops on the first lexing error, but at least that's just because
we're lazy, and not because the API forces us to!]

Comparse `calc_actions/src/main.rs` before (https://github.com/softdevteam/grmtools/blob/faee83c26bea71c0040ccbf47194bb88cec523fc/lrpar/examples/calc_actions/src/main.rs) and after (https://github.com/softdevteam/grmtools/blob/0802111691a97d575735f44571b3ca48c80703a6/lrpar/examples/calc_actions/src/main.rs) to see what this looks like in practise.