### PR TITLE
Convenience error printing

### DIFF
--- a/lrpar/examples/calc_actions/src/calc.y
+++ b/lrpar/examples/calc_actions/src/calc.y
@@ -15,7 +15,7 @@ Factor: 'LBRACK' Expr 'RBRACK' { $2 }
             match $lexer.lexeme_str(&l).parse::<u64>() {
                 Ok(v) => Ok(v),
                 Err(_) => {
-                    let (_, col) = $lexer.line_and_col(&l);
+                    let (_, col) = $lexer.offset_line_col(l.start());
                     eprintln!("Error at column {}: '{}' cannot be represented as a u64",
                               col,
                               $lexer.lexeme_str(&l));

--- a/lrpar/examples/calc_actions/src/main.rs
+++ b/lrpar/examples/calc_actions/src/main.rs
@@ -35,7 +35,7 @@ fn main() {
                             eprintln!("Lexing error at column {:?}", e.idx)
                         }
                         LexParseError::ParseError(e) => {
-                            let (line, col) = lexer.line_and_col(e.lexeme());
+                            let (line, col) = lexer.offset_line_col(e.lexeme().start());
                             assert_eq!(line, 1);
                             eprintln!("Parsing error at column {}", col);
                         }

--- a/lrpar/examples/calc_actions/src/main.rs
+++ b/lrpar/examples/calc_actions/src/main.rs
@@ -6,8 +6,6 @@ extern crate lrlex;
 #[macro_use]
 extern crate lrpar;
 
-use lrpar::{LexParseError, Lexer};
-
 // Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
 lrlex_mod!(calc_l);
 // Using `lrpar_mod!` brings the lexer for `calc.l` into scope.
@@ -30,16 +28,7 @@ fn main() {
                 // Pass the lexer to the parser and lex and parse the input.
                 let (res, errs) = calc_y::parse(&mut lexer);
                 for e in errs {
-                    match e {
-                        LexParseError::LexError(e) => {
-                            eprintln!("Lexing error at column {:?}", e.idx)
-                        }
-                        LexParseError::ParseError(e) => {
-                            let (line, col) = lexer.offset_line_col(e.lexeme().start());
-                            assert_eq!(line, 1);
-                            eprintln!("Parsing error at column {}", col);
-                        }
-                    }
+                    println!("{}", e.pp(&lexer, &calc_y::token_epp));
                 }
                 match res {
                     Some(Ok(r)) => println!("Result: {}", r),

--- a/lrpar/examples/calc_parsetree/src/main.rs
+++ b/lrpar/examples/calc_parsetree/src/main.rs
@@ -40,7 +40,7 @@ fn main() {
                             eprintln!("Lexing error at column {:?}", e.idx);
                         }
                         LexParseError::ParseError(e) => {
-                            let (line, col) = lexer.line_and_col(e.lexeme());
+                            let (line, col) = lexer.offset_line_col(e.lexeme().start());
                             assert_eq!(line, 1);
                             println!("Parsing error at column {}.", col);
                         }

--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -489,7 +489,7 @@ mod test {
         for r in repairs.iter() {
             match *r {
                 ParseRepair::Insert(token_idx) => {
-                    out.push(format!("Insert \"{}\"", grm.token_name(token_idx).unwrap()))
+                    out.push(format!("Insert \"{}\"", grm.token_epp(token_idx).unwrap()))
                 }
                 ParseRepair::Delete(_) => out.push(format!("Delete")),
                 ParseRepair::Shift(_) => out.push(format!("Shift"))

--- a/lrpar/src/lib/lex.rs
+++ b/lrpar/src/lib/lex.rs
@@ -22,12 +22,14 @@ pub trait Lexer<StorageT: Hash + PrimInt + Unsigned> {
     /// Return the next `Lexeme` in the input or a `LexError`. Returns `None` if the input has been
     /// fully lexed (or if an error occurred which prevents further lexing).
     fn next(&mut self) -> Option<Result<Lexeme<StorageT>, LexError>>;
-    /// Return the line and column number of a `Lexeme`. Panics if the lexeme is invalid (i.e. was
-    /// not produced by next()).
-    fn line_and_col(&self, &Lexeme<StorageT>) -> (usize, usize);
+
     /// Return the user input associated with a lexeme. Panics if the lexeme is invalid (i.e. was
     /// not produced by next()).
     fn lexeme_str(&self, &Lexeme<StorageT>) -> &str;
+
+    /// Return the line and column number of a given offset. Panics if the offset exceeds the known
+    /// input.
+    fn offset_line_col(&self, usize) -> (usize, usize);
 
     /// Return all this lexer's remaining lexemes or a `LexError` if there was a problem when lexing.
     fn all_lexemes(&mut self) -> Result<Vec<Lexeme<StorageT>>, LexError> {

--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -891,7 +891,7 @@ mod test {
         for r in repairs.iter() {
             match *r {
                 ParseRepair::Insert(token_idx) => {
-                    out.push(format!("Insert \"{}\"", grm.token_name(token_idx).unwrap()))
+                    out.push(format!("Insert \"{}\"", grm.token_epp(token_idx).unwrap()))
                 }
                 ParseRepair::Delete(_) => out.push(format!("Delete")),
                 ParseRepair::Shift(_) => out.push(format!("Shift"))

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -525,7 +525,70 @@ pub enum LexParseError<StorageT> {
     ParseError(ParseError<StorageT>)
 }
 
-impl<StorageT: Debug> Error for LexParseError<StorageT> {}
+impl<StorageT: Hash + PrimInt + Unsigned> LexParseError<StorageT> {
+    /// A pretty-printer of a lexer/parser error. This isn't suitable for all purposes, but it's
+    /// often good enough. The output format is not guaranteed to be stable but is likely to be of
+    /// the form:
+    ///
+    /// ```text,ignore
+    /// Parsing error at line 3 column 8. Repair sequences found:
+    ///   1: Insert ID
+    ///   2: Delete +, Shift 3
+    /// ```
+    ///
+    /// If you are using the compile-time parse system, your `grm_y` module exposes a suitable
+    /// [`epp`](../ctbuilder/struct.CTParserBuilder.html#method.process_file) function; if you are
+    /// using the run-time system,
+    /// [`YaccGrammar`](../../cfgrammar/yacc/grammar/struct.YaccGrammar.html) exposes a suitable
+    /// [`epp`](../../cfgrammar/yacc/grammar/struct.YaccGrammar.html#method.token_epp) function,
+    /// though you will have to wrap it in a closure e.g. `&|t| grm.token_epp(t)`.
+    pub fn pp<'a>(
+        &self,
+        lexer: &Lexer<StorageT>,
+        epp: &Fn(TIdx<StorageT>) -> Option<&'a str>
+    ) -> String {
+        match self {
+            LexParseError::LexError(e) => {
+                let (line, col) = lexer.offset_line_col(e.idx);
+                format!("Lexing error at line {} column {}.", line, col)
+            }
+            LexParseError::ParseError(e) => {
+                let (line, col) = lexer.offset_line_col(e.lexeme().start());
+                let mut out = format!("Parsing error at line {} column {}.", line, col);
+                let repairs_len = e.repairs().len();
+                if repairs_len == 0 {
+                    out.push_str(" No repair sequences found.");
+                } else {
+                    out.push_str(" Repair sequences found:");
+                    for (i, rs) in e.repairs().iter().enumerate() {
+                        let padding = ((repairs_len as f64).log10() as usize)
+                            - (((i + 1) as f64).log10() as usize)
+                            + 1;
+                        out.push_str(&format!("\n  {}{}: ", " ".repeat(padding), i + 1));
+                        let mut rs_out = Vec::new();
+                        for r in rs {
+                            match r {
+                                ParseRepair::Insert(tidx) => {
+                                    rs_out.push(format!("Insert {}", epp(*tidx).unwrap()));
+                                }
+                                ParseRepair::Shift(l) | ParseRepair::Delete(l) => {
+                                    let t = &lexer.lexeme_str(l).replace("\n", "\\n");
+                                    if let ParseRepair::Delete(_) = *r {
+                                        rs_out.push(format!("Delete {}", t));
+                                    } else {
+                                        rs_out.push(format!("Shift {}", t));
+                                    }
+                                }
+                            }
+                        }
+                        out.push_str(&rs_out.join(", "));
+                    }
+                }
+                out
+            }
+        }
+    }
+}
 
 impl<StorageT: Debug> fmt::Display for LexParseError<StorageT> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -535,6 +598,8 @@ impl<StorageT: Debug> fmt::Display for LexParseError<StorageT> {
         }
     }
 }
+
+impl<StorageT: Debug> Error for LexParseError<StorageT> {}
 
 impl<StorageT> From<LexError> for LexParseError<StorageT> {
     fn from(err: LexError) -> LexParseError<StorageT> {

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -233,8 +233,8 @@ where
     /// `end_laidx` *must* be set to `laidx + 1` in order that the parser doesn't skip the real
     /// lexeme at position `laidx`.
     ///
-    /// Return `true` if the parse reached an accept state (i.e. all the input was consumed,
-    /// possibly after making repairs) or `false` (i.e. some of the input was not consumed, even
+    /// Return `Some(value)` if the parse reached an accept state (i.e. all the input was consumed,
+    /// possibly after making repairs) or `None` (i.e. some of the input was not consumed, even
     /// after possibly making repairs) otherwise.
     pub fn lr(
         &self,

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -774,7 +774,7 @@ pub(crate) mod test {
             None
         }
 
-        fn line_and_col(&self, _: &Lexeme<StorageT>) -> (usize, usize) {
+        fn offset_line_col(&self, _: usize) -> (usize, usize) {
             unreachable!();
         }
 

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -204,7 +204,7 @@ fn main() {
         match e {
             LexParseError::LexError(e) => println!("Lexing error at position {}", e.idx),
             LexParseError::ParseError(e) => {
-                let (line, col) = lexer.line_and_col(e.lexeme());
+                let (line, col) = lexer.offset_line_col(e.lexeme().start());
                 if e.repairs().is_empty() {
                     println!("Error at line {} col {}. No repairs found.", line, col);
                     continue;


### PR DESCRIPTION
The main purpose of this PR is to make it more convenient to print out repair sequences (which was made plausible by #60). First, we make it possible to tell users where lexing errors occur (as a result of https://github.com/softdevteam/grmtools/commit/fb01c980dbabef3dab806cdad8dd8b7722a7e2ce). Then comes the main part of the PR (https://github.com/softdevteam/grmtools/commit/b38510e1f543e665e99458f839d87ec22c528485).

The outcome of this is that as well as simplifying user code (see e.g. the calc action's much reduced main file https://github.com/softdevteam/grmtools/commit/b38510e1f543e665e99458f839d87ec22c528485#diff-e28ab8922abad59d48711e8edc3de52f) we get much nicer output:

```
>>> 2+3
Result: 5
>>> 2+x
Lexing error at line 1 column 3.
Unable to evaluate expression.
>>> 2++3  
Parsing error at line 1 column 3. Repair sequences found:
   1: Delete +
   2: Insert INT
Result: 5
>>> 2++3++4++
Parsing error at line 1 column 3. Repair sequences found:
   1: Insert INT
Parsing error at line 1 column 6. Repair sequences found:
   1: Insert INT
Parsing error at line 1 column 9. Repair sequences found:
   1: Insert INT, Delete +
   2: Insert INT, Shift +, Insert INT
Unable to evaluate expression.
>>> 
```