### PR TITLE
Split apart CTParserBuilder::new and ::new_with_storaget.

### DIFF
--- a/lrpar/examples/calc_actions/build.rs
+++ b/lrpar/examples/calc_actions/build.rs
@@ -43,7 +43,7 @@ fn main() -> Result<(), Box<std::error::Error>> {
     // Note that we specify the integer type (u8) we'll use for token IDs (this type *must* be big
     // enough to fit all IDs in) as well as the input file (which must end in ".y" for lrpar, and
     // ".l" for lrlex).
-    let lex_rule_ids_map = CTParserBuilder::<u8>::new()
+    let lex_rule_ids_map = CTParserBuilder::new()
         .action_kind(ActionKind::CustomAction)
         .process_file_in_src("calc.y")?;
     LexerBuilder::new()

--- a/lrpar/examples/calc_parsetree/build.rs
+++ b/lrpar/examples/calc_parsetree/build.rs
@@ -43,7 +43,8 @@ fn main() -> Result<(), Box<std::error::Error>> {
     // Note that we specify the integer type (u8) we'll use for token IDs (this type *must* be big
     // enough to fit all IDs in) as well as the input file (which must end in ".y" for lrpar, and
     // ".l" for lrlex).
-    let lex_rule_ids_map = CTParserBuilder::<u8>::new().process_file_in_src("calc.y")?;
+    let lex_rule_ids_map =
+        CTParserBuilder::<u8>::new_with_storaget().process_file_in_src("calc.y")?;
     LexerBuilder::new()
         .rule_ids_map(lex_rule_ids_map)
         .process_file_in_src("calc.l")?;

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -89,6 +89,21 @@ pub struct CTParserBuilder<StorageT = u32> {
     actionkind: ActionKind
 }
 
+impl CTParserBuilder<u32> {
+    /// Create a new `CTParserBuilder`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// CTParserBuilder::new()
+    ///     .process_file_in_src("grm.y")
+    ///     .unwrap();
+    /// ```
+    pub fn new() -> Self {
+        CTParserBuilder::<u32>::new_with_storaget()
+    }
+}
+
 impl<StorageT> CTParserBuilder<StorageT>
 where
     StorageT: 'static + Debug + Hash + PrimInt + Serialize + TypeName + Unsigned,
@@ -109,11 +124,11 @@ where
     /// # Examples
     ///
     /// ```rust,ignore
-    /// CTParserBuilder::<u8>::new()
+    /// CTParserBuilder::<u8>::new_with_storaget()
     ///     .process_file_in_src("grm.y")
     ///     .unwrap();
     /// ```
-    pub fn new() -> Self {
+    pub fn new_with_storaget() -> Self {
         CTParserBuilder {
             recoverer: RecoveryKind::MF,
             phantom: PhantomData,


### PR DESCRIPTION
This is an idiom we use in several places in grmtools and should probably have been used in `CTParserBuilder` from the beginning. It means that people who don't want to think about StorageT can just say `CTParserBuilder::new`; people who care can say `CTParserBuilder::<x>::new_with_storaget`.

[I noticed this when working through the book's quickstart guide.]