### PR TITLE
Make the epp function contain %epp names and not token names.

### DIFF
--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -513,7 +513,7 @@ where
     fn gen_token_epp(&self, grm: &YaccGrammar<StorageT>) -> String {
         let mut tidxs = Vec::new();
         for tidx in grm.iter_tidxs() {
-            match grm.token_name(tidx) {
+            match grm.token_epp(tidx) {
                 Some(n) => tidxs.push(format!("Some(\"{}\")", n)),
                 None => tidxs.push("None".to_string())
             }


### PR DESCRIPTION
Before this commit, a grammar with `%epp` declarations ignored them if the grammar was generated at compile-time. e.g. an extended calc grammar printed:

```
  >>> 2 3
  Parsing error at line 1 column 3. Repair sequences found:
     1: Delete 3
     2: Insert PLUS
     3: Insert MUL
```

After, things work as expected:

```
  >>> 2 3
  Parsing error at line 1 column 3. Repair sequences found:
     1: Delete 3
     2: Insert +
     3: Insert *
  Result: 2
```