### PR TITLE
Start packaging

### DIFF
--- a/cfgrammar/Cargo.toml
+++ b/cfgrammar/Cargo.toml
@@ -1,7 +1,15 @@
 [package]
 name = "cfgrammar"
+description = "Grammar manipulation"
+repository = "https://github.com/softdevteam/grmtools"
 version = "0.1.0"
 authors = ["Laurence Tratt <http://tratt.net/laurie/>"]
+readme = "README.md"
+# This should be "Apache-2.0 OR MIT OR UPL-1.0" but crates.io doesn't know about
+# UPL-1.0.
+license = "Apache-2.0 OR MIT"
+categories = ["parsing"]
+keywords = ["yacc", "grammar"]
 
 [lib]
 name = "cfgrammar"

--- a/cfgrammar/src/lib/idxnewtype.rs
+++ b/cfgrammar/src/lib/idxnewtype.rs
@@ -1,34 +1,11 @@
 // Copyright (c) 2018 King's College London
 // created by the Software Development Team <http://soft-dev.org/>
 //
-// The Universal Permissive License (UPL), Version 1.0
-//
-// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
-// copy of this software, associated documentation and/or data (collectively the "Software"), free
-// of charge and under any and all copyright rights in the Software, and any and all patent rights
-// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
-// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
-// below), to deal in both
-//
-// (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
-// if one is included with the Software (each a "Larger Work" to which the Software is contributed
-// by such licensors),
-//
-// without restriction, including without limitation the rights to copy, create derivative works
-// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
-// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
-// foregoing rights on either these or other terms.
-//
-// This license is subject to the following condition: The above copyright notice and either this
-// complete permission notice or at a minimum a reference to the UPL must be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
 
 // This macro generates a struct which exposes a u32 API (but which may, internally, use a smaller
 // storage size).

--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -1,34 +1,11 @@
 // Copyright (c) 2017 King's College London
 // created by the Software Development Team <http://soft-dev.org/>
 //
-// The Universal Permissive License (UPL), Version 1.0
-//
-// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
-// copy of this software, associated documentation and/or data (collectively the "Software"), free
-// of charge and under any and all copyright rights in the Software, and any and all patent rights
-// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
-// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
-// below), to deal in both
-//
-// (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
-// if one is included with the Software (each a "Larger Work" to which the Software is contributed
-// by such licensors),
-//
-// without restriction, including without limitation the rights to copy, create derivative works
-// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
-// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
-// foregoing rights on either these or other terms.
-//
-// This license is subject to the following condition: The above copyright notice and either this
-// complete permission notice or at a minimum a reference to the UPL must be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
 
 //! A library for manipulating Context Free Grammars (CFG). It is impractical to fully homogenise
 //! all the types of grammars out there, so the aim is for different grammar types

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -1,34 +1,11 @@
 // Copyright (c) 2017 King's College London
 // created by the Software Development Team <http://soft-dev.org/>
 //
-// The Universal Permissive License (UPL), Version 1.0
-//
-// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
-// copy of this software, associated documentation and/or data (collectively the "Software"), free
-// of charge and under any and all copyright rights in the Software, and any and all patent rights
-// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
-// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
-// below), to deal in both
-//
-// (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
-// if one is included with the Software (each a "Larger Work" to which the Software is contributed
-// by such licensors),
-//
-// without restriction, including without limitation the rights to copy, create derivative works
-// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
-// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
-// foregoing rights on either these or other terms.
-//
-// This license is subject to the following condition: The above copyright notice and either this
-// complete permission notice or at a minimum a reference to the UPL must be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
 
 use std::{
     collections::{HashMap, HashSet},

--- a/cfgrammar/src/lib/yacc/firsts.rs
+++ b/cfgrammar/src/lib/yacc/firsts.rs
@@ -1,34 +1,11 @@
 // Copyright (c) 2017 King's College London
 // created by the Software Development Team <http://soft-dev.org/>
 //
-// The Universal Permissive License (UPL), Version 1.0
-//
-// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
-// copy of this software, associated documentation and/or data (collectively the "Software"), free
-// of charge and under any and all copyright rights in the Software, and any and all patent rights
-// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
-// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
-// below), to deal in both
-//
-// (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
-// if one is included with the Software (each a "Larger Work" to which the Software is contributed
-// by such licensors),
-//
-// without restriction, including without limitation the rights to copy, create derivative works
-// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
-// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
-// foregoing rights on either these or other terms.
-//
-// This license is subject to the following condition: The above copyright notice and either this
-// complete permission notice or at a minimum a reference to the UPL must be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
 
 use std::marker::PhantomData;
 

--- a/cfgrammar/src/lib/yacc/follows.rs
+++ b/cfgrammar/src/lib/yacc/follows.rs
@@ -1,34 +1,11 @@
 // Copyright (c) 2018 King's College London
 // created by the Software Development Team <http://soft-dev.org/>
 //
-// The Universal Permissive License (UPL), Version 1.0
-//
-// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
-// copy of this software, associated documentation and/or data (collectively the "Software"), free
-// of charge and under any and all copyright rights in the Software, and any and all patent rights
-// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
-// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
-// below), to deal in both
-//
-// (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
-// if one is included with the Software (each a "Larger Work" to which the Software is contributed
-// by such licensors),
-//
-// without restriction, including without limitation the rights to copy, create derivative works
-// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
-// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
-// foregoing rights on either these or other terms.
-//
-// This license is subject to the following condition: The above copyright notice and either this
-// complete permission notice or at a minimum a reference to the UPL must be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
 
 use std::marker::PhantomData;
 

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -1,34 +1,11 @@
 // Copyright (c) 2017 King's College London
 // created by the Software Development Team <http://soft-dev.org/>
 //
-// The Universal Permissive License (UPL), Version 1.0
-//
-// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
-// copy of this software, associated documentation and/or data (collectively the "Software"), free
-// of charge and under any and all copyright rights in the Software, and any and all patent rights
-// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
-// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
-// below), to deal in both
-//
-// (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
-// if one is included with the Software (each a "Larger Work" to which the Software is contributed
-// by such licensors),
-//
-// without restriction, including without limitation the rights to copy, create derivative works
-// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
-// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
-// foregoing rights on either these or other terms.
-//
-// This license is subject to the following condition: The above copyright notice and either this
-// complete permission notice or at a minimum a reference to the UPL must be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
 
 use std::{cell::RefCell, collections::HashMap, error::Error, fmt};
 

--- a/cfgrammar/src/lib/yacc/mod.rs
+++ b/cfgrammar/src/lib/yacc/mod.rs
@@ -1,34 +1,11 @@
 // Copyright (c) 2017 King's College London
 // created by the Software Development Team <http://soft-dev.org/>
 //
-// The Universal Permissive License (UPL), Version 1.0
-//
-// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
-// copy of this software, associated documentation and/or data (collectively the "Software"), free
-// of charge and under any and all copyright rights in the Software, and any and all patent rights
-// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
-// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
-// below), to deal in both
-//
-// (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
-// if one is included with the Software (each a "Larger Work" to which the Software is contributed
-// by such licensors),
-//
-// without restriction, including without limitation the rights to copy, create derivative works
-// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
-// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
-// foregoing rights on either these or other terms.
-//
-// This license is subject to the following condition: The above copyright notice and either this
-// complete permission notice or at a minimum a reference to the UPL must be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
 
 pub mod ast;
 pub mod firsts;

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -1,34 +1,11 @@
 // Copyright (c) 2017 King's College London
 // created by the Software Development Team <http://soft-dev.org/>
 //
-// The Universal Permissive License (UPL), Version 1.0
-//
-// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
-// copy of this software, associated documentation and/or data (collectively the "Software"), free
-// of charge and under any and all copyright rights in the Software, and any and all patent rights
-// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
-// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
-// below), to deal in both
-//
-// (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
-// if one is included with the Software (each a "Larger Work" to which the Software is contributed
-// by such licensors),
-//
-// without restriction, including without limitation the rights to copy, create derivative works
-// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
-// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
-// foregoing rights on either these or other terms.
-//
-// This license is subject to the following condition: The above copyright notice and either this
-// complete permission notice or at a minimum a reference to the UPL must be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
 
 // Note: this is the parser for both YaccKind::Original and YaccKind::Eco yacc kinds.
 

--- a/lrlex/Cargo.toml
+++ b/lrlex/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/lib/mod.rs"
 
 [dependencies]
 getopts = "0.2.15" # only needed for src/main.rs
-lrpar = { path = "../lrpar" }
+lrpar = { path = "../lrpar", version = "0.1.0" }
 regex = "1.0"
 num-traits = "0.2"
 try_from = "0.2"

--- a/lrlex/Cargo.toml
+++ b/lrlex/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
 name = "lrlex"
+description = "Simple lexer generator"
+repository = "https://github.com/softdevteam/grmtools"
 version = "0.1.0"
 authors = ["Laurence Tratt <http://tratt.net/laurie/>"]
+readme = "README.md"
+# This should be "Apache-2.0 OR MIT OR UPL-1.0" but crates.io doesn't know about
+# UPL-1.0.
+license = "Apache-2.0 OR MIT"
+categories = ["parsing"]
 
 [[bin]]
 doc = false

--- a/lrlex/examples/calclex/build.rs
+++ b/lrlex/examples/calclex/build.rs
@@ -1,3 +1,12 @@
+// Copyright (c) 2018 King's College London
+// created by the Software Development Team <http://soft-dev.org/>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
+
 extern crate lrlex;
 
 use lrlex::LexerBuilder;

--- a/lrlex/examples/calclex/src/main.rs
+++ b/lrlex/examples/calclex/src/main.rs
@@ -1,3 +1,12 @@
+// Copyright (c) 2018 King's College London
+// created by the Software Development Team <http://soft-dev.org/>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
+
 use std::io::{self, BufRead, Write};
 
 #[macro_use]

--- a/lrlex/src/lib/builder.rs
+++ b/lrlex/src/lib/builder.rs
@@ -1,34 +1,11 @@
 // Copyright (c) 2018 King's College London
 // created by the Software Development Team <http://soft-dev.org/>
 //
-// The Universal Permissive License (UPL), Version 1.0
-//
-// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
-// copy of this software, associated documentation and/or data (collectively the "Software"), free
-// of charge and under any and all copyright rights in the Software, and any and all patent rights
-// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
-// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
-// below), to deal in both
-//
-// (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
-// if one is included with the Software (each a "Larger Work" to which the Software is contributed
-// by such licensors),
-//
-// without restriction, including without limitation the rights to copy, create derivative works
-// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
-// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
-// foregoing rights on either these or other terms.
-//
-// This license is subject to the following condition: The above copyright notice and either this
-// complete permission notice or at a minimum a reference to the UPL must be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
 
 use std::{
     collections::{HashMap, HashSet},

--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -1,34 +1,11 @@
 // Copyright (c) 2017 King's College London
 // created by the Software Development Team <http://soft-dev.org/>
 //
-// The Universal Permissive License (UPL), Version 1.0
-//
-// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
-// copy of this software, associated documentation and/or data (collectively the "Software"), free
-// of charge and under any and all copyright rights in the Software, and any and all patent rights
-// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
-// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
-// below), to deal in both
-//
-// (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
-// if one is included with the Software (each a "Larger Work" to which the Software is contributed
-// by such licensors),
-//
-// without restriction, including without limitation the rights to copy, create derivative works
-// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
-// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
-// foregoing rights on either these or other terms.
-//
-// This license is subject to the following condition: The above copyright notice and either this
-// complete permission notice or at a minimum a reference to the UPL must be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
 
 use std::{
     collections::{HashMap, HashSet},

--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -1,34 +1,11 @@
 // Copyright (c) 2017 King's College London
 // created by the Software Development Team <http://soft-dev.org/>
 //
-// The Universal Permissive License (UPL), Version 1.0
-//
-// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
-// copy of this software, associated documentation and/or data (collectively the "Software"), free
-// of charge and under any and all copyright rights in the Software, and any and all patent rights
-// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
-// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
-// below), to deal in both
-//
-// (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
-// if one is included with the Software (each a "Larger Work" to which the Software is contributed
-// by such licensors),
-//
-// without restriction, including without limitation the rights to copy, create derivative works
-// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
-// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
-// foregoing rights on either these or other terms.
-//
-// This license is subject to the following condition: The above copyright notice and either this
-// complete permission notice or at a minimum a reference to the UPL must be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
 
 extern crate lrpar;
 extern crate num_traits;

--- a/lrlex/src/lib/parser.rs
+++ b/lrlex/src/lib/parser.rs
@@ -1,34 +1,11 @@
 // Copyright (c) 2017 King's College London
 // created by the Software Development Team <http://soft-dev.org/>
 //
-// The Universal Permissive License (UPL), Version 1.0
-//
-// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
-// copy of this software, associated documentation and/or data (collectively the "Software"), free
-// of charge and under any and all copyright rights in the Software, and any and all patent rights
-// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
-// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
-// below), to deal in both
-//
-// (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
-// if one is included with the Software (each a "Larger Work" to which the Software is contributed
-// by such licensors),
-//
-// without restriction, including without limitation the rights to copy, create derivative works
-// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
-// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
-// foregoing rights on either these or other terms.
-//
-// This license is subject to the following condition: The above copyright notice and either this
-// complete permission notice or at a minimum a reference to the UPL must be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
 
 use std::hash::Hash;
 

--- a/lrlex/src/main.rs
+++ b/lrlex/src/main.rs
@@ -1,34 +1,11 @@
 // Copyright (c) 2017 King's College London
 // created by the Software Development Team <http://soft-dev.org/>
 //
-// The Universal Permissive License (UPL), Version 1.0
-//
-// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
-// copy of this software, associated documentation and/or data (collectively the "Software"), free
-// of charge and under any and all copyright rights in the Software, and any and all patent rights
-// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
-// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
-// below), to deal in both
-//
-// (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
-// if one is included with the Software (each a "Larger Work" to which the Software is contributed
-// by such licensors),
-//
-// without restriction, including without limitation the rights to copy, create derivative works
-// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
-// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
-// foregoing rights on either these or other terms.
-//
-// This license is subject to the following condition: The above copyright notice and either this
-// complete permission notice or at a minimum a reference to the UPL must be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
 
 extern crate getopts;
 extern crate lrlex;

--- a/lrpar/Cargo.toml
+++ b/lrpar/Cargo.toml
@@ -1,8 +1,16 @@
 [package]
 name = "lrpar"
+description = "Yacc-compatible parser generator"
+repository = "https://github.com/softdevteam/grmtools"
 version = "0.1.0"
 authors = ["Lukas Diekmann <http://lukasdiekmann.com/>", "Laurence Tratt <http://tratt.net/laurie/>"]
+readme = "README.md"
+# This should be "Apache-2.0 OR MIT OR UPL-1.0" but crates.io doesn't know about
+# UPL-1.0.
+license = "Apache-2.0 OR MIT"
 build = "build.rs"
+categories = ["parsing"]
+keywords = ["parser", "LR", "yacc", "grammar"]
 
 [lib]
 name = "lrpar"

--- a/lrpar/Cargo.toml
+++ b/lrpar/Cargo.toml
@@ -22,12 +22,12 @@ vergen = "2"
 [dependencies]
 bincode = "1.0"
 cactus = "1.0"
-cfgrammar = { path="../cfgrammar", features=["serde"] }
+cfgrammar = { path="../cfgrammar", version = "0.1.0", features=["serde"] }
 filetime = "0.2"
 getopts = "0.2"
 indexmap = "1.0"
 lazy_static = "1.2"
-lrtable = { path="../lrtable", features=["serde"] }
+lrtable = { path="../lrtable", version = "0.1.0", features=["serde"] }
 num-traits = "0.2"
 packedvec = "1.0"
 rmp-serde = "0.13"

--- a/lrpar/build.rs
+++ b/lrpar/build.rs
@@ -1,34 +1,11 @@
 // Copyright (c) 2018 King's College London
 // created by the Software Development Team <http://soft-dev.org/>
 //
-// The Universal Permissive License (UPL), Version 1.0
-//
-// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
-// copy of this software, associated documentation and/or data (collectively the "Software"), free
-// of charge and under any and all copyright rights in the Software, and any and all patent rights
-// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
-// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
-// below), to deal in both
-//
-// (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
-// if one is included with the Software (each a "Larger Work" to which the Software is contributed
-// by such licensors),
-//
-// without restriction, including without limitation the rights to copy, create derivative works
-// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
-// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
-// foregoing rights on either these or other terms.
-//
-// This license is subject to the following condition: The above copyright notice and either this
-// complete permission notice or at a minimum a reference to the UPL must be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
 
 extern crate vergen;
 

--- a/lrpar/examples/calc_actions/build.rs
+++ b/lrpar/examples/calc_actions/build.rs
@@ -1,34 +1,11 @@
 // Copyright (c) 2018 King's College London
 // created by the Software Development Team <http://soft-dev.org/>
 //
-// The Universal Permissive License (UPL), Version 1.0
-//
-// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
-// copy of this software, associated documentation and/or data (collectively the "Software"), free
-// of charge and under any and all copyright rights in the Software, and any and all patent rights
-// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
-// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
-// below), to deal in both
-//
-// (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
-// if one is included with the Software (each a "Larger Work" to which the Software is contributed
-// by such licensors),
-//
-// without restriction, including without limitation the rights to copy, create derivative works
-// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
-// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
-// foregoing rights on either these or other terms.
-//
-// This license is subject to the following condition: The above copyright notice and either this
-// complete permission notice or at a minimum a reference to the UPL must be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
 
 extern crate lrlex;
 extern crate lrpar;

--- a/lrpar/examples/calc_actions/src/main.rs
+++ b/lrpar/examples/calc_actions/src/main.rs
@@ -1,3 +1,12 @@
+// Copyright (c) 2018 King's College London
+// created by the Software Development Team <http://soft-dev.org/>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
+
 use std::io::{self, BufRead, Write};
 
 extern crate cfgrammar;

--- a/lrpar/examples/calc_parsetree/build.rs
+++ b/lrpar/examples/calc_parsetree/build.rs
@@ -1,34 +1,11 @@
 // Copyright (c) 2018 King's College London
 // created by the Software Development Team <http://soft-dev.org/>
 //
-// The Universal Permissive License (UPL), Version 1.0
-//
-// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
-// copy of this software, associated documentation and/or data (collectively the "Software"), free
-// of charge and under any and all copyright rights in the Software, and any and all patent rights
-// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
-// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
-// below), to deal in both
-//
-// (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
-// if one is included with the Software (each a "Larger Work" to which the Software is contributed
-// by such licensors),
-//
-// without restriction, including without limitation the rights to copy, create derivative works
-// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
-// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
-// foregoing rights on either these or other terms.
-//
-// This license is subject to the following condition: The above copyright notice and either this
-// complete permission notice or at a minimum a reference to the UPL must be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
 
 extern crate lrlex;
 extern crate lrpar;

--- a/lrpar/examples/calc_parsetree/src/main.rs
+++ b/lrpar/examples/calc_parsetree/src/main.rs
@@ -1,3 +1,12 @@
+// Copyright (c) 2018 King's College London
+// created by the Software Development Team <http://soft-dev.org/>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
+
 use std::io::{self, BufRead, Write};
 
 extern crate cfgrammar;

--- a/lrpar/src/lib/astar.rs
+++ b/lrpar/src/lib/astar.rs
@@ -1,34 +1,11 @@
 // Copyright (c) 2018 King's College London
 // created by the Software Development Team <http://soft-dev.org/>
 //
-// The Universal Permissive License (UPL), Version 1.0
-//
-// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
-// copy of this software, associated documentation and/or data (collectively the "Software"), free
-// of charge and under any and all copyright rights in the Software, and any and all patent rights
-// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
-// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
-// below), to deal in both
-//
-// (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
-// if one is included with the Software (each a "Larger Work" to which the Software is contributed
-// by such licensors),
-//
-// without restriction, including without limitation the rights to copy, create derivative works
-// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
-// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
-// foregoing rights on either these or other terms.
-//
-// This license is subject to the following condition: The above copyright notice and either this
-// complete permission notice or at a minimum a reference to the UPL must be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
 
 use std::{fmt::Debug, hash::Hash};
 

--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -1,34 +1,11 @@
 // Copyright (c) 2017 King's College London
 // created by the Software Development Team <http://soft-dev.org/>
 //
-// The Universal Permissive License (UPL), Version 1.0
-//
-// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
-// copy of this software, associated documentation and/or data (collectively the "Software"), free
-// of charge and under any and all copyright rights in the Software, and any and all patent rights
-// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
-// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
-// below), to deal in both
-//
-// (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
-// if one is included with the Software (each a "Larger Work" to which the Software is contributed
-// by such licensors),
-//
-// without restriction, including without limitation the rights to copy, create derivative works
-// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
-// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
-// foregoing rights on either these or other terms.
-//
-// This license is subject to the following condition: The above copyright notice and either this
-// complete permission notice or at a minimum a reference to the UPL must be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
 
 use std::{
     fmt::Debug,

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -1,34 +1,11 @@
 // Copyright (c) 2018 King's College London
 // created by the Software Development Team <http://soft-dev.org/>
 //
-// The Universal Permissive License (UPL), Version 1.0
-//
-// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
-// copy of this software, associated documentation and/or data (collectively the "Software"), free
-// of charge and under any and all copyright rights in the Software, and any and all patent rights
-// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
-// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
-// below), to deal in both
-//
-// (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
-// if one is included with the Software (each a "Larger Work" to which the Software is contributed
-// by such licensors),
-//
-// without restriction, including without limitation the rights to copy, create derivative works
-// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
-// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
-// foregoing rights on either these or other terms.
-//
-// This license is subject to the following condition: The above copyright notice and either this
-// complete permission notice or at a minimum a reference to the UPL must be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
 
 use std::{
     collections::HashMap,

--- a/lrpar/src/lib/lex.rs
+++ b/lrpar/src/lib/lex.rs
@@ -1,3 +1,12 @@
+// Copyright (c) 2018 King's College London
+// created by the Software Development Team <http://soft-dev.org/>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
+
 use std::{error::Error, fmt, hash::Hash, mem::size_of};
 
 use num_traits::{PrimInt, Unsigned};

--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -1,34 +1,11 @@
 // Copyright (c) 2017 King's College London
 // created by the Software Development Team <http://soft-dev.org/>
 //
-// The Universal Permissive License (UPL), Version 1.0
-//
-// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
-// copy of this software, associated documentation and/or data (collectively the "Software"), free
-// of charge and under any and all copyright rights in the Software, and any and all patent rights
-// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
-// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
-// below), to deal in both
-//
-// (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
-// if one is included with the Software (each a "Larger Work" to which the Software is contributed
-// by such licensors),
-//
-// without restriction, including without limitation the rights to copy, create derivative works
-// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
-// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
-// foregoing rights on either these or other terms.
-//
-// This license is subject to the following condition: The above copyright notice and either this
-// complete permission notice or at a minimum a reference to the UPL must be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
 
 use std::{
     fmt::Debug,

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -1,34 +1,11 @@
 // Copyright (c) 2017 King's College London
 // created by the Software Development Team <http://soft-dev.org/>
 //
-// The Universal Permissive License (UPL), Version 1.0
-//
-// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
-// copy of this software, associated documentation and/or data (collectively the "Software"), free
-// of charge and under any and all copyright rights in the Software, and any and all patent rights
-// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
-// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
-// below), to deal in both
-//
-// (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
-// if one is included with the Software (each a "Larger Work" to which the Software is contributed
-// by such licensors),
-//
-// without restriction, including without limitation the rights to copy, create derivative works
-// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
-// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
-// foregoing rights on either these or other terms.
-//
-// This license is subject to the following condition: The above copyright notice and either this
-// complete permission notice or at a minimum a reference to the UPL must be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
 
 extern crate bincode;
 extern crate cactus;

--- a/lrpar/src/lib/panic.rs
+++ b/lrpar/src/lib/panic.rs
@@ -1,34 +1,11 @@
 // Copyright (c) 2018 King's College London
 // created by the Software Development Team <http://soft-dev.org/>
 //
-// The Universal Permissive License (UPL), Version 1.0
-//
-// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
-// copy of this software, associated documentation and/or data (collectively the "Software"), free
-// of charge and under any and all copyright rights in the Software, and any and all patent rights
-// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
-// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
-// below), to deal in both
-//
-// (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
-// if one is included with the Software (each a "Larger Work" to which the Software is contributed
-// by such licensors),
-//
-// without restriction, including without limitation the rights to copy, create derivative works
-// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
-// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
-// foregoing rights on either these or other terms.
-//
-// This license is subject to the following condition: The above copyright notice and either this
-// complete permission notice or at a minimum a reference to the UPL must be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
 
 use std::{fmt::Debug, hash::Hash, time::Instant};
 

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -1,34 +1,11 @@
 // Copyright (c) 2017 King's College London
 // created by the Software Development Team <http://soft-dev.org/>
 //
-// The Universal Permissive License (UPL), Version 1.0
-//
-// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
-// copy of this software, associated documentation and/or data (collectively the "Software"), free
-// of charge and under any and all copyright rights in the Software, and any and all patent rights
-// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
-// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
-// below), to deal in both
-//
-// (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
-// if one is included with the Software (each a "Larger Work" to which the Software is contributed
-// by such licensors),
-//
-// without restriction, including without limitation the rights to copy, create derivative works
-// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
-// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
-// foregoing rights on either these or other terms.
-//
-// This license is subject to the following condition: The above copyright notice and either this
-// complete permission notice or at a minimum a reference to the UPL must be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
 
 use std::{
     error::Error,

--- a/lrtable/Cargo.toml
+++ b/lrtable/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
 name = "lrtable"
+description = "LR grammar table generation"
+repository = "https://github.com/softdevteam/grmtools"
 version = "0.1.0"
 authors = ["Lukas Diekmann <http://lukasdiekmann.com/>", "Laurence Tratt <http://tratt.net/laurie/>"]
+readme = "README.md"
+# This should be "Apache-2.0 OR MIT OR UPL-1.0" but crates.io doesn't know about
+# UPL-1.0.
+license = "Apache-2.0 OR MIT"
+categories = ["parsing"]
 
 [lib]
 name = "lrtable"

--- a/lrtable/Cargo.toml
+++ b/lrtable/Cargo.toml
@@ -20,7 +20,7 @@ fnv = "1.0"
 macro-attr = "0.2.0"
 newtype_derive = "0.1.6"
 num-traits = "0.2"
-cfgrammar = { path="../cfgrammar", features=["serde"] }
+cfgrammar = { path="../cfgrammar", version = "0.1.0", features=["serde"] }
 serde = { version="1.0", features=["derive"], optional=true }
 vob = { version="2.0", features=["serde"] }
 sparsevec = { version="0.1", features=["serde"] }

--- a/lrtable/src/lib/itemset.rs
+++ b/lrtable/src/lib/itemset.rs
@@ -1,34 +1,11 @@
 // Copyright (c) 2017 King's College London
 // created by the Software Development Team <http://soft-dev.org/>
 //
-// The Universal Permissive License (UPL), Version 1.0
-//
-// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
-// copy of this software, associated documentation and/or data (collectively the "Software"), free
-// of charge and under any and all copyright rights in the Software, and any and all patent rights
-// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
-// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
-// below), to deal in both
-//
-// (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
-// if one is included with the Software (each a "Larger Work" to which the Software is contributed
-// by such licensors),
-//
-// without restriction, including without limitation the rights to copy, create derivative works
-// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
-// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
-// foregoing rights on either these or other terms.
-//
-// This license is subject to the following condition: The above copyright notice and either this
-// complete permission notice or at a minimum a reference to the UPL must be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
 
 use std::{
     collections::hash_map::{Entry, HashMap},

--- a/lrtable/src/lib/mod.rs
+++ b/lrtable/src/lib/mod.rs
@@ -1,34 +1,11 @@
 // Copyright (c) 2017 King's College London
 // created by the Software Development Team <http://soft-dev.org/>
 //
-// The Universal Permissive License (UPL), Version 1.0
-//
-// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
-// copy of this software, associated documentation and/or data (collectively the "Software"), free
-// of charge and under any and all copyright rights in the Software, and any and all patent rights
-// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
-// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
-// below), to deal in both
-//
-// (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
-// if one is included with the Software (each a "Larger Work" to which the Software is contributed
-// by such licensors),
-//
-// without restriction, including without limitation the rights to copy, create derivative works
-// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
-// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
-// foregoing rights on either these or other terms.
-//
-// This license is subject to the following condition: The above copyright notice and either this
-// complete permission notice or at a minimum a reference to the UPL must be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
 
 extern crate cfgrammar;
 extern crate fnv;

--- a/lrtable/src/lib/pager.rs
+++ b/lrtable/src/lib/pager.rs
@@ -1,34 +1,11 @@
 // Copyright (c) 2017 King's College London
 // created by the Software Development Team <http://soft-dev.org/>
 //
-// The Universal Permissive License (UPL), Version 1.0
-//
-// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
-// copy of this software, associated documentation and/or data (collectively the "Software"), free
-// of charge and under any and all copyright rights in the Software, and any and all patent rights
-// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
-// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
-// below), to deal in both
-//
-// (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
-// if one is included with the Software (each a "Larger Work" to which the Software is contributed
-// by such licensors),
-//
-// without restriction, including without limitation the rights to copy, create derivative works
-// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
-// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
-// foregoing rights on either these or other terms.
-//
-// This license is subject to the following condition: The above copyright notice and either this
-// complete permission notice or at a minimum a reference to the UPL must be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
 
 use std::{
     collections::{hash_map::HashMap, HashSet},

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -1,34 +1,11 @@
 // Copyright (c) 2017 King's College London
 // created by the Software Development Team <http://soft-dev.org/>
 //
-// The Universal Permissive License (UPL), Version 1.0
-//
-// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
-// copy of this software, associated documentation and/or data (collectively the "Software"), free
-// of charge and under any and all copyright rights in the Software, and any and all patent rights
-// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
-// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
-// below), to deal in both
-//
-// (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
-// if one is included with the Software (each a "Larger Work" to which the Software is contributed
-// by such licensors),
-//
-// without restriction, including without limitation the rights to copy, create derivative works
-// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
-// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
-// foregoing rights on either these or other terms.
-//
-// This license is subject to the following condition: The above copyright notice and either this
-// complete permission notice or at a minimum a reference to the UPL must be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
 
 use std::{collections::hash_map::HashMap, hash::Hash};
 

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -1,34 +1,11 @@
 // Copyright (c) 2017 King's College London
 // created by the Software Development Team <http://soft-dev.org/>
 //
-// The Universal Permissive License (UPL), Version 1.0
-//
-// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
-// copy of this software, associated documentation and/or data (collectively the "Software"), free
-// of charge and under any and all copyright rights in the Software, and any and all patent rights
-// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
-// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
-// below), to deal in both
-//
-// (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
-// if one is included with the Software (each a "Larger Work" to which the Software is contributed
-// by such licensors),
-//
-// without restriction, including without limitation the rights to copy, create derivative works
-// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
-// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
-// foregoing rights on either these or other terms.
-//
-// This license is subject to the following condition: The above copyright notice and either this
-// complete permission notice or at a minimum a reference to the UPL must be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
 
 use std::{
     collections::hash_map::HashMap,

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -1,34 +1,11 @@
 // Copyright (c) 2017 King's College London
 // created by the Software Development Team <http://soft-dev.org/>
 //
-// The Universal Permissive License (UPL), Version 1.0
-//
-// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
-// copy of this software, associated documentation and/or data (collectively the "Software"), free
-// of charge and under any and all copyright rights in the Software, and any and all patent rights
-// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
-// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
-// below), to deal in both
-//
-// (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
-// if one is included with the Software (each a "Larger Work" to which the Software is contributed
-// by such licensors),
-//
-// without restriction, including without limitation the rights to copy, create derivative works
-// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
-// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
-// foregoing rights on either these or other terms.
-//
-// This license is subject to the following condition: The above copyright notice and either this
-// complete permission notice or at a minimum a reference to the UPL must be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
 
 extern crate cfgrammar;
 extern crate getopts;


### PR DESCRIPTION
This PR aims to get the grmtools into a point where its 4 constituent libraries can be made packages on `crates.io`. https://github.com/softdevteam/grmtools/commit/b81376c5249ddca3d1d537427719b2a99737f722 sorts the licensing situation out (moving us from UPL to triple licence MIT/Apache-2.0/UPL-1.0, as with our other Rust libraries), including adding licenses to some files that weren't licensed. https://github.com/softdevteam/grmtools/commit/1cea65778948de25705a082796e1cf2d146ce58c adds the bits and bobs that crates.io needs and https://github.com/softdevteam/grmtools/commit/038150e26d3434c1e49d49e408bc5ee02768b463 hopefully makes the packages work both on crates.io and for local development.