### PR TITLE
Add a %avoid_insert directive.

### DIFF
--- a/cfgrammar/Cargo.toml
+++ b/cfgrammar/Cargo.toml
@@ -22,4 +22,4 @@ indexmap = "1.0"
 num-traits = "0.2"
 regex = "1.0"
 serde = { version="1.0", features=["derive"], optional=true }
-vob = "2.0"
+vob = { version="2.0", features=["serde"] }

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -27,6 +27,7 @@ pub struct GrammarAST {
     pub prods: Vec<Production>,
     pub tokens: IndexSet<String>,
     pub precs: HashMap<String, Precedence>,
+    pub avoid_insert: Option<HashSet<String>>,
     pub implicit_tokens: Option<HashSet<String>>,
     // Error pretty-printers
     pub epp: HashMap<String, String>,
@@ -122,6 +123,7 @@ impl GrammarAST {
             prods: Vec::new(),
             tokens: IndexSet::new(),
             precs: HashMap::new(),
+            avoid_insert: None,
             implicit_tokens: None,
             epp: HashMap::new(),
             programs: None,

--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -236,7 +236,7 @@ where
         if rnk_rprs.is_empty() {
             return (in_laidx, vec![]);
         }
-        simplify_repairs(&mut rnk_rprs);
+        simplify_repairs(parser, &mut rnk_rprs);
         let laidx = apply_repairs(
             parser,
             in_laidx,

--- a/lrpar/tests/ct.rs
+++ b/lrpar/tests/ct.rs
@@ -204,6 +204,7 @@ fn main() -> Result<(), Box<std::error::Error>> {{
         p,
         "%start Expr
 %type Result<u64, ()>
+%avoid_insert 'INT'
 %%
 Expr: Term 'PLUS' Expr { Ok($1? + $3?) }
     | Term { $1 }
@@ -361,7 +362,7 @@ fn test_error_recovery_and_actions() {
     let mut lexer = lexerdef.lexer(\"2++3\");
     let (r, errs) = calc_y::parse(&mut lexer);
     match r {
-        Some(Ok(5)) | Some(Err(())) => (),
+        Some(Ok(5)) => (),
         _ => unreachable!()
     }
     match errs[0] {


### PR DESCRIPTION
**THIS IS A REQUEST FOR COMMENTS: PLEASE DON'T MERGE YET**

With the calc grammar and the input "2++3" there are two possible repair sequences:

```
  Insert Int
  Delete +
```

If you're building a parse tree, both are equally reasonable. However, if you're executing actions, "Insert Int" isn't great, because there is no value we can insert, so we stop execution. In contrast, "Delete" allows us to continue execution as normal. Since our current ranking is non-deterministic, that means that we end up with this surprising outcome (from a real calc_actions session):

```
  >>> 2++3
  Parsing error at line 1 column 3. Repair sequences found:
     1: Insert INT
     2: Delete +
  Unable to evaluate expression.
  >>> 2++3
  Parsing error at line 1 column 3. Repair sequences found:
     1: Delete +
     2: Insert INT
  Result: 5
```

The problem is that, in general, we probably prefer to Insert new content than delete content, on the basis that there is more value in what the user entered than what they didn't enter. However, as the above example shows, tokens whose value we care about are not ideal when recovering from errors. Unfortunately, we have no idea which tokens have important values or not.

This commit adds a new grammar-level directive `%avoid_insert` which takes one or more token names. When ranking repairs, repair sequences which contain an Insert that references a token in `%avoid_insert` are penalised. If we add `%avoid_insert 'INT'` to the calc grammar, then it is guaranteed that the repair sequences above are always returned in the following order:

```
  Delete +
  Insert Int
```