### PR TITLE
Stop lrlex from creating identifiers from tokens that are invalid in Rust

### DIFF
--- a/lrlex/Cargo.toml
+++ b/lrlex/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/lib/mod.rs"
 
 [dependencies]
 getopts = "0.2.15" # only needed for src/main.rs
+lazy_static = "1.2"
 lrpar = { path = "../lrpar", version = "0.1" }
 regex = "1.0"
 num-traits = "0.2"

--- a/lrlex/src/lib/builder.rs
+++ b/lrlex/src/lib/builder.rs
@@ -20,6 +20,7 @@ use std::{
 };
 
 use num_traits::{PrimInt, Unsigned};
+use regex::Regex;
 use try_from::TryFrom;
 use typename::TypeName;
 
@@ -29,6 +30,10 @@ use parser::parse_lex;
 const LEX_SUFFIX: &str = "_l";
 const LEX_FILE_EXT: &str = "l";
 const RUST_FILE_EXT: &str = "rs";
+
+lazy_static! {
+    static ref RE_TOKEN_ID: Regex = Regex::new(r"^[a-zA-Z_][a-zA-Z_0-9]*$").unwrap();
+}
 
 /// A `LexerBuilder` allows one to specify the criteria for building a statically generated
 /// lexer.
@@ -169,12 +174,14 @@ where
         // Token IDs
         if let Some(ref rim) = self.rule_ids_map {
             for (n, id) in rim {
-                outs.push_str(&format!(
-                    "#[allow(dead_code)]\npub const T_{}: {} = {:?};\n",
-                    n.to_ascii_uppercase(),
-                    StorageT::type_name(),
-                    *id
-                ));
+                if RE_TOKEN_ID.is_match(n) {
+                    outs.push_str(&format!(
+                        "#[allow(dead_code)]\npub const T_{}: {} = {:?};\n",
+                        n.to_ascii_uppercase(),
+                        StorageT::type_name(),
+                        *id
+                    ));
+                }
             }
         }
 

--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -7,6 +7,8 @@
 // at your option. This file may not be copied, modified, or distributed except according to those
 // terms.
 
+#[macro_use]
+extern crate lazy_static;
 extern crate lrpar;
 extern crate num_traits;
 extern crate regex;

--- a/lrpar/tests/ct.rs
+++ b/lrpar/tests/ct.rs
@@ -206,15 +206,15 @@ fn main() -> Result<(), Box<std::error::Error>> {{
 %type Result<u64, ()>
 %avoid_insert 'INT'
 %%
-Expr: Term 'PLUS' Expr { Ok($1? + $3?) }
+Expr: Term '+' Expr { Ok($1? + $3?) }
     | Term { $1 }
     ;
 
-Term: Factor 'MUL' Term { Ok($1? * $3?) }
+Term: Factor '*' Term { Ok($1? * $3?) }
     | Factor { $1 }
     ;
 
-Factor: 'LBRACK' Expr 'RBRACK' { $2 }
+Factor: '(' Expr ')' { $2 }
       | 'INT' {
             let l = $1.map_err(|_| ())?;
             match $lexer.lexeme_str(&l).parse::<u64>() {
@@ -240,10 +240,10 @@ Factor: 'LBRACK' Expr 'RBRACK' { $2 }
         p,
         " %%
 [0-9]+ \"INT\"
-\\+ \"PLUS\"
-\\* \"MUL\"
-\\( \"LBRACK\"
-\\) \"RBRACK\"
+\\+ \"+\"
+\\* \"*\"
+\\( \"(\"
+\\) \")\"
 [\\t ]+ ;"
     )
     .unwrap();


### PR DESCRIPTION
A simple lex rule such as:

```
  = "="
```

would lead to the following Rust code being generated:

```
  pub const T_= = <some int>;
```

which, of course, is completely invalid.

This commit doesn't generate `T_` variables for token names that can't be Rust identifiers. Many users won't use these variables so will never notice the difference: and those who do want to use this feature will have to use Rust identifier-friendly token names!