### PR TITLE
Tidyup YaccKinds and co.

### DIFF
--- a/cfgrammar/src/lib/yacc/firsts.rs
+++ b/cfgrammar/src/lib/yacc/firsts.rs
@@ -20,7 +20,7 @@ use TIdx;
 /// `Firsts` stores all the first sets for a given grammar. For example, given this code and
 /// grammar:
 /// ```text
-///   let grm = YaccGrammar::new(YaccKind::Original, "
+///   let grm = YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), "
 ///     S: A 'b';
 ///     A: 'a'
 ///      | ;").unwrap();
@@ -156,7 +156,7 @@ where
 mod test {
     use super::YaccFirsts;
     use num_traits::{AsPrimitive, PrimInt, Unsigned};
-    use yacc::{YaccGrammar, YaccKind};
+    use yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind};
 
     fn has<StorageT: 'static + PrimInt + Unsigned>(
         grm: &YaccGrammar<StorageT>,
@@ -193,7 +193,7 @@ mod test {
     #[test]
     fn test_first() {
         let grm = YaccGrammar::new(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
           %start C
           %token c d
@@ -215,7 +215,7 @@ mod test {
     #[test]
     fn test_first_no_subsequent_rules() {
         let grm = YaccGrammar::new(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
           %start C
           %token c d
@@ -233,7 +233,7 @@ mod test {
     #[test]
     fn test_first_epsilon() {
         let grm = YaccGrammar::new(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
           %start A
           %token a b c
@@ -254,7 +254,7 @@ mod test {
     #[test]
     fn test_last_epsilon() {
         let grm = YaccGrammar::new(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
           %start A
           %token b c
@@ -274,7 +274,7 @@ mod test {
     #[test]
     fn test_first_no_multiples() {
         let grm = YaccGrammar::new(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
           %start A
           %token b c
@@ -290,7 +290,7 @@ mod test {
 
     fn eco_grammar() -> YaccGrammar {
         YaccGrammar::new(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
           %start S
           %token a b c d f
@@ -321,7 +321,7 @@ mod test {
     #[test]
     fn test_first_from_eco_bug() {
         let grm = YaccGrammar::new(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
           %start E
           %token a b c d e f

--- a/cfgrammar/src/lib/yacc/follows.rs
+++ b/cfgrammar/src/lib/yacc/follows.rs
@@ -20,7 +20,7 @@ use TIdx;
 /// `Follows` stores all the Follow sets for a given grammar. For example, given this code and
 /// grammar:
 /// ```text
-///   let grm = YaccGrammar::new(YaccKind::Original, "
+///   let grm = YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), "
 ///       S: A 'b';
 ///       A: 'a' | ;
 ///     ").unwrap();
@@ -127,7 +127,7 @@ where
 mod test {
     use super::YaccFollows;
     use num_traits::{AsPrimitive, PrimInt, Unsigned};
-    use yacc::{YaccGrammar, YaccKind};
+    use yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind};
 
     fn has<StorageT: 'static + PrimInt + Unsigned>(
         grm: &YaccGrammar<StorageT>,
@@ -160,7 +160,7 @@ mod test {
     fn test_follow() {
         // Adapted from p2 of https://www.cs.uaf.edu/~cs331/notes/FirstFollow.pdf
         let grm = YaccGrammar::new(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
                 %start E
                 %%
@@ -184,7 +184,7 @@ mod test {
     fn test_follow2() {
         // Adapted from https://www.l2f.inesc-id.pt/~david/w/pt/Top-Down_Parsing/Exercise_5:_Test_2010/07/01
         let grm = YaccGrammar::new(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
                 %start A
                 %%
@@ -207,7 +207,7 @@ mod test {
     #[test]
     fn test_follow3() {
         let grm = YaccGrammar::new(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
                 %start S
                 %%
@@ -224,7 +224,7 @@ mod test {
     #[test]
     fn test_follow_corchuelo() {
         let grm = YaccGrammar::new(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
                 %start E
                 %%

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -117,7 +117,7 @@ where
     /// user defined start rule.
     pub fn new_with_storaget(yacc_kind: YaccKind, s: &str) -> Result<Self, YaccGrammarError> {
         let ast = match yacc_kind {
-            YaccKind::Original | YaccKind::Eco => {
+            YaccKind::Original(_) | YaccKind::Eco => {
                 let mut yp = YaccParser::new(yacc_kind, s.to_string());
                 yp.parse()?;
                 let mut ast = yp.ast();
@@ -158,7 +158,7 @@ where
         let implicit_rule;
         let implicit_start_rule;
         match yacc_kind {
-            YaccKind::Original => {
+            YaccKind::Original(_) => {
                 implicit_rule = None;
                 implicit_start_rule = None;
             }
@@ -1015,7 +1015,7 @@ impl fmt::Display for YaccGrammarError {
 mod test {
     use super::{rule_max_costs, rule_min_costs, IMPLICIT_RULE, IMPLICIT_START_RULE};
     use std::collections::HashMap;
-    use yacc::{AssocKind, Precedence, YaccGrammar, YaccKind};
+    use yacc::{AssocKind, Precedence, YaccGrammar, YaccKind, YaccOriginalActionKind};
     use PIdx;
     use RIdx;
     use Symbol;
@@ -1023,7 +1023,11 @@ mod test {
 
     #[test]
     fn test_minimal() {
-        let grm = YaccGrammar::new(YaccKind::Original, "%start R %token T %% R: 'T';").unwrap();
+        let grm = YaccGrammar::new(
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            "%start R %token T %% R: 'T';"
+        )
+        .unwrap();
 
         assert_eq!(grm.start_prod, PIdx(1));
         assert_eq!(grm.implicit_rule(), None);
@@ -1050,8 +1054,11 @@ mod test {
 
     #[test]
     fn test_rule_ref() {
-        let grm =
-            YaccGrammar::new(YaccKind::Original, "%start R %token T %% R : S; S: 'T';").unwrap();
+        let grm = YaccGrammar::new(
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            "%start R %token T %% R : S; S: 'T';"
+        )
+        .unwrap();
 
         grm.rule_idx("^").unwrap();
         grm.rule_idx("R").unwrap();
@@ -1077,7 +1084,7 @@ mod test {
     #[rustfmt::skip]
     fn test_long_prod() {
         let grm = YaccGrammar::new(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             "%start R %token T1 T2 %% R : S 'T1' S; S: 'T2';"
         ).unwrap();
 
@@ -1108,7 +1115,7 @@ mod test {
     #[test]
     fn test_prods_rules() {
         let grm = YaccGrammar::new(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             "
             %start A
             %%
@@ -1131,7 +1138,7 @@ mod test {
     #[rustfmt::skip]
     fn test_left_right_nonassoc_precs() {
         let grm = YaccGrammar::new(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             "
             %start Expr
             %right '='
@@ -1164,7 +1171,7 @@ mod test {
     #[rustfmt::skip]
     fn test_prec_override() {
         let grm = YaccGrammar::new(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             "
             %start expr
             %left '+' '-'
@@ -1268,7 +1275,7 @@ mod test {
     #[rustfmt::skip]
     fn test_has_path() {
         let grm = YaccGrammar::new(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             "
             %start A
             %%
@@ -1295,7 +1302,7 @@ mod test {
     #[rustfmt::skip]
     fn test_rule_min_costs() {
         let grm = YaccGrammar::new(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             "
             %start A
             %%
@@ -1318,7 +1325,7 @@ mod test {
     #[test]
     fn test_min_sentences() {
         let grm = YaccGrammar::new(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             "
             %start A
             %%
@@ -1366,7 +1373,7 @@ mod test {
     #[rustfmt::skip]
     fn test_rule_max_costs1() {
         let grm = YaccGrammar::new(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             "
             %start A
             %%
@@ -1390,7 +1397,7 @@ mod test {
     #[rustfmt::skip]
     fn test_rule_max_costs2() {
         let grm = YaccGrammar::new(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             "
             %start A
             %%
@@ -1412,7 +1419,7 @@ mod test {
     fn test_out_of_order_productions() {
         // Example taken from p54 of Locally least-cost error repair in LR parsers, Carl Cerecke
         let grm = YaccGrammar::new(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             "
             %start S
             %%

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -276,8 +276,8 @@ where
             }
 
             let rule = &mut rules_prods[usize::from(ridx)];
-            for &prod_idx in &ast.rules[astrulename] {
-                let astprod = &ast.prods[prod_idx];
+            for &pidx in &ast.rules[astrulename].pidxs {
+                let astprod = &ast.prods[pidx];
                 let mut prod = Vec::with_capacity(astprod.symbols.len());
                 for astsym in &astprod.symbols {
                     match *astsym {
@@ -305,12 +305,12 @@ where
                         }
                     }
                 }
-                (*rule).push(PIdx(prod_idx.as_()));
-                prods[prod_idx] = Some(prod);
-                prod_precs[prod_idx] = Some(prec);
-                prods_rules[prod_idx] = Some(ridx);
+                (*rule).push(PIdx(pidx.as_()));
+                prods[pidx] = Some(prod);
+                prod_precs[pidx] = Some(prec);
+                prods_rules[pidx] = Some(ridx);
                 if let Some(ref s) = astprod.action {
-                    actions[prod_idx] = Some(s.clone());
+                    actions[pidx] = Some(s.clone());
                 }
             }
         }

--- a/cfgrammar/src/lib/yacc/mod.rs
+++ b/cfgrammar/src/lib/yacc/mod.rs
@@ -23,8 +23,19 @@ pub use self::{
 #[derive(Clone, Copy)]
 pub enum YaccKind {
     /// The original Yacc style as documented by
-    /// [Johnson](http://dinosaur.compilertools.net/yacc/index.html)
-    Original,
+    /// [Johnson](http://dinosaur.compilertools.net/yacc/index.html),
+    Original(YaccOriginalActionKind),
     /// The variant used in the [Eco language composition editor](http://soft-dev.org/src/eco/)
     Eco
+}
+
+#[derive(Clone, Copy)]
+pub enum YaccOriginalActionKind {
+    /// Execute user-specified actions attached to each production; also requires a %actiontype
+    /// declaration.
+    UserAction,
+    /// Automatically create a parse tree instead of user-specified actions.
+    GenericParseTree,
+    /// Do not do execute actions of any sort.
+    NoAction
 }

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -7,7 +7,7 @@
 // at your option. This file may not be copied, modified, or distributed except according to those
 // terms.
 
-// Note: this is the parser for both YaccKind::Original and YaccKind::Eco yacc kinds.
+// Note: this is the parser for both YaccKind::Original(YaccOriginalActionKind::GenericParseTree) and YaccKind::Eco yacc kinds.
 
 use std::{collections::HashSet, error::Error, fmt};
 
@@ -574,7 +574,7 @@ mod test {
     use super::{YaccParser, YaccParserError, YaccParserErrorKind};
     use yacc::{
         ast::{GrammarAST, Production, Symbol},
-        AssocKind, Precedence, YaccKind
+        AssocKind, Precedence, YaccKind, YaccOriginalActionKind
     };
 
     fn parse(yacc_kind: YaccKind, s: &str) -> Result<GrammarAST, YaccParserError> {
@@ -610,7 +610,11 @@ mod test {
             A : 'a';
         "
         .to_string();
-        let grm = parse(YaccKind::Original, &src).unwrap();
+        let grm = parse(
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            &src
+        )
+        .unwrap();
         assert_eq!(grm.get_rule("A").unwrap().pidxs, vec![0]);
         assert_eq!(
             grm.prods[grm.get_rule("A").unwrap().pidxs[0]],
@@ -630,7 +634,11 @@ mod test {
             A : 'b';
         "
         .to_string();
-        let grm = parse(YaccKind::Original, &src).unwrap();
+        let grm = parse(
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            &src
+        )
+        .unwrap();
         assert_eq!(
             grm.prods[grm.get_rule("A").unwrap().pidxs[0]],
             Production {
@@ -658,7 +666,11 @@ mod test {
             C : | 'c';
         "
         .to_string();
-        let grm = parse(YaccKind::Original, &src).unwrap();
+        let grm = parse(
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            &src
+        )
+        .unwrap();
 
         assert_eq!(
             grm.prods[grm.get_rule("A").unwrap().pidxs[0]],
@@ -707,13 +719,21 @@ mod test {
     #[test]
     fn test_empty_program() {
         let src = "%%\nA : 'a';\n%%".to_string();
-        parse(YaccKind::Original, &src).unwrap();
+        parse(
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            &src
+        )
+        .unwrap();
     }
 
     #[test]
     fn test_multiple_symbols() {
         let src = "%%\nA : 'a' B;".to_string();
-        let grm = parse(YaccKind::Original, &src).unwrap();
+        let grm = parse(
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            &src
+        )
+        .unwrap();
         assert_eq!(
             grm.prods[grm.get_rule("A").unwrap().pidxs[0]],
             Production {
@@ -727,7 +747,11 @@ mod test {
     #[test]
     fn test_token_types() {
         let src = "%%\nA : 'a' \"b\";".to_string();
-        let grm = parse(YaccKind::Original, &src).unwrap();
+        let grm = parse(
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            &src
+        )
+        .unwrap();
         assert_eq!(
             grm.prods[grm.get_rule("A").unwrap().pidxs[0]],
             Production {
@@ -741,28 +765,44 @@ mod test {
     #[test]
     fn test_declaration_start() {
         let src = "%start   A\n%%\nA : a;".to_string();
-        let grm = parse(YaccKind::Original, &src).unwrap();
+        let grm = parse(
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            &src
+        )
+        .unwrap();
         assert_eq!(grm.start.unwrap(), "A");
     }
 
     #[test]
     fn test_declaration_token() {
         let src = "%token   a\n%%\nA : a;".to_string();
-        let grm = parse(YaccKind::Original, &src).unwrap();
+        let grm = parse(
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            &src
+        )
+        .unwrap();
         assert!(grm.has_token("a"));
     }
 
     #[test]
     fn test_declaration_token_literal() {
         let src = "%token   'a'\n%%\nA : 'a';".to_string();
-        let grm = parse(YaccKind::Original, &src).unwrap();
+        let grm = parse(
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            &src
+        )
+        .unwrap();
         assert!(grm.has_token("a"));
     }
 
     #[test]
     fn test_declaration_tokens() {
         let src = "%token   a b c 'd'\n%%\nA : a;".to_string();
-        let grm = parse(YaccKind::Original, &src).unwrap();
+        let grm = parse(
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            &src
+        )
+        .unwrap();
         assert!(grm.has_token("a"));
         assert!(grm.has_token("b"));
         assert!(grm.has_token("c"));
@@ -771,14 +811,22 @@ mod test {
     #[test]
     fn test_auto_add_tokens() {
         let src = "%%\nA : 'a';".to_string();
-        let grm = parse(YaccKind::Original, &src).unwrap();
+        let grm = parse(
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            &src
+        )
+        .unwrap();
         assert!(grm.has_token("a"));
     }
 
     #[test]
     fn test_token_non_literal() {
         let src = "%token T %%\nA : T;".to_string();
-        let grm = parse(YaccKind::Original, &src).unwrap();
+        let grm = parse(
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            &src
+        )
+        .unwrap();
         assert!(grm.has_token("T"));
         assert_eq!(
             grm.prods[grm.get_rule("A").unwrap().pidxs[0]],
@@ -793,14 +841,21 @@ mod test {
     #[test]
     fn test_token_unicode() {
         let src = "%token '❤' %%\nA : '❤';".to_string();
-        let grm = parse(YaccKind::Original, &src).unwrap();
+        let grm = parse(
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            &src
+        )
+        .unwrap();
         assert!(grm.has_token("❤"));
     }
 
     #[test]
     fn test_unicode_err1() {
         let src = "%token '❤' ❤;".to_string();
-        match parse(YaccKind::Original, &src) {
+        match parse(
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            &src
+        ) {
             Ok(_) => panic!("Incorrect token parsed"),
             Err(YaccParserError {
                 kind: YaccParserErrorKind::IllegalString,
@@ -814,7 +869,10 @@ mod test {
     #[test]
     fn test_unicode_err2() {
         let src = "%token '❤'\n%%\nA : '❤' | ❤;".to_string();
-        match parse(YaccKind::Original, &src) {
+        match parse(
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            &src
+        ) {
             Ok(_) => panic!("Incorrect token parsed"),
             Err(YaccParserError {
                 kind: YaccParserErrorKind::IllegalString,
@@ -829,20 +887,31 @@ mod test {
     #[should_panic]
     fn test_simple_decl_fail() {
         let src = "%fail x\n%%\nA : a".to_string();
-        parse(YaccKind::Original, &src).unwrap();
+        parse(
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            &src
+        )
+        .unwrap();
     }
 
     #[test]
     #[should_panic]
     fn test_empty() {
         let src = "".to_string();
-        parse(YaccKind::Original, &src).unwrap();
+        parse(
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            &src
+        )
+        .unwrap();
     }
 
     #[test]
     fn test_incomplete_rule1() {
         let src = "%%A:".to_string();
-        match parse(YaccKind::Original, &src) {
+        match parse(
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            &src
+        ) {
             Ok(_) => panic!("Incomplete rule parsed"),
             Err(YaccParserError {
                 kind: YaccParserErrorKind::IncompleteRule,
@@ -858,7 +927,10 @@ mod test {
         let src = "%%
 A:"
         .to_string();
-        match parse(YaccKind::Original, &src) {
+        match parse(
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            &src
+        ) {
             Ok(_) => panic!("Incomplete rule parsed"),
             Err(YaccParserError {
                 kind: YaccParserErrorKind::IncompleteRule,
@@ -875,7 +947,10 @@ A:"
 A:
 "
         .to_string();
-        match parse(YaccKind::Original, &src) {
+        match parse(
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            &src
+        ) {
             Ok(_) => panic!("Incomplete rule parsed"),
             Err(YaccParserError {
                 kind: YaccParserErrorKind::IncompleteRule,
@@ -892,7 +967,10 @@ A:
 
         %woo"
             .to_string();
-        match parse(YaccKind::Original, &src) {
+        match parse(
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            &src
+        ) {
             Ok(_) => panic!("Incomplete rule parsed"),
             Err(YaccParserError {
                 kind: YaccParserErrorKind::UnknownDeclaration,
@@ -906,7 +984,10 @@ A:
     #[test]
     fn test_missing_colon() {
         let src = "%%A x;".to_string();
-        match parse(YaccKind::Original, &src) {
+        match parse(
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            &src
+        ) {
             Ok(_) => panic!("Missing colon parsed"),
             Err(YaccParserError {
                 kind: YaccParserErrorKind::MissingColon,
@@ -920,7 +1001,10 @@ A:
     #[test]
     fn test_premature_end() {
         let src = "%token x".to_string();
-        match parse(YaccKind::Original, &src) {
+        match parse(
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            &src
+        ) {
             Ok(_) => panic!("Incomplete rule parsed"),
             Err(YaccParserError {
                 kind: YaccParserErrorKind::PrematureEnd,
@@ -936,7 +1020,10 @@ A:
         let src = "%token
 x"
         .to_string();
-        match parse(YaccKind::Original, &src) {
+        match parse(
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            &src
+        ) {
             Ok(_) => panic!("Incomplete rule parsed"),
             Err(YaccParserError {
                 kind: YaccParserErrorKind::ReachedEOL,
@@ -951,7 +1038,7 @@ x"
     #[rustfmt::skip]
     fn test_unknown_declaration() {
         let src = "%woo".to_string();
-        match parse(YaccKind::Original, &src) {
+        match parse(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), &src) {
             Ok(_) => panic!("Unknown declaration parsed"),
             Err(YaccParserError {
                 kind: YaccParserErrorKind::UnknownDeclaration,
@@ -973,7 +1060,7 @@ x"
           %nonassoc '~'
           %%
           ".to_string();
-        let grm = parse(YaccKind::Original, &src).unwrap();
+        let grm = parse(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), &src).unwrap();
         assert_eq!(grm.precs.len(), 6);
         assert_eq!(grm.precs["+"], Precedence{level: 0, kind: AssocKind::Left});
         assert_eq!(grm.precs["-"], Precedence{level: 0, kind: AssocKind::Left});
@@ -1018,7 +1105,10 @@ x"
           ",
         ];
         for src in srcs.iter() {
-            match parse(YaccKind::Original, &src.to_string()) {
+            match parse(
+                YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+                &src.to_string()
+            ) {
                 Ok(_) => panic!("Duplicate precedence parsed"),
                 Err(YaccParserError {
                     kind: YaccParserErrorKind::DuplicatePrecedence,
@@ -1045,7 +1135,7 @@ x"
                  | '-'  expr %prec '*'
                  | NAME ;
         ";
-        let grm = parse(YaccKind::Original, &src).unwrap();
+        let grm = parse(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), &src).unwrap();
         assert_eq!(grm.precs.len(), 4);
         assert_eq!(grm.prods[grm.rules["expr"].pidxs[0]].precedence, None);
         assert_eq!(grm.prods[grm.rules["expr"].pidxs[3]].symbols.len(), 3);
@@ -1056,7 +1146,7 @@ x"
     #[test]
     fn test_bad_prec_overrides() {
         match parse(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
           %%
           S: 'A' %prec ;
@@ -1072,7 +1162,7 @@ x"
         }
 
         match parse(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
           %%
           S: 'A' %prec B;
@@ -1174,7 +1264,7 @@ x"
     #[test]
     fn test_no_implicit_tokens_in_original_yacc() {
         match parse(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
           %implicit_tokens X
           %%
@@ -1390,7 +1480,7 @@ x"
     #[test]
     fn test_action() {
         let grm = parse(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
           %%
           A: 'a' B { println!(\"test\"); }
@@ -1415,7 +1505,7 @@ x"
     #[test]
     fn test_programs() {
         let grm = parse(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
          %%
          A: 'a';
@@ -1429,7 +1519,7 @@ x"
     #[test]
     fn test_actions_with_newlines() {
         match parse(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
          %%
          A: 'a' { foo();
@@ -1451,11 +1541,15 @@ x"
             /* Another valid comment */
             %%\n
             A : a;";
-        let grm = parse(YaccKind::Original, src).unwrap();
+        let grm = parse(
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            src
+        )
+        .unwrap();
         assert!(grm.has_token("a"));
 
         match parse(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
             /* An invalid comment * /
             %token   a
@@ -1472,7 +1566,7 @@ x"
         }
 
         match parse(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
             %token   a
             %%
@@ -1492,7 +1586,7 @@ x"
         }
 
         match parse(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
             %token   a
             %%
@@ -1512,7 +1606,7 @@ x"
     #[test]
     fn test_type() {
         let grm = parse(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
          %type T
          %%
@@ -1527,7 +1621,7 @@ x"
     #[test]
     fn test_only_one_type() {
         match parse(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
          %type T1
          %type T2

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -75,7 +75,7 @@ impl fmt::Display for YaccParserError {
                 "Duplicate %implicit_tokens declaration"
             }
             YaccParserErrorKind::DuplicateStartDeclaration => "Duplicate %start declaration",
-            YaccParserErrorKind::DuplicateTypeDeclaration => "Duplicate %type declaration",
+            YaccParserErrorKind::DuplicateTypeDeclaration => "Duplicate %actiontype declaration",
             YaccParserErrorKind::DuplicateEPP => "Duplicate %epp declaration for this token",
             YaccParserErrorKind::ReachedEOL => {
                 "Reached end of line without finding expected content"
@@ -142,7 +142,7 @@ impl YaccParser {
                 }
                 continue;
             }
-            if let Some(j) = self.lookahead_is("%type", i) {
+            if let Some(j) = self.lookahead_is("%actiontype", i) {
                 if self.ast.actiontype.is_some() {
                     return Err(self.mk_error(YaccParserErrorKind::DuplicateTypeDeclaration, i));
                 }
@@ -1608,7 +1608,7 @@ x"
         let grm = parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
-         %type T
+         %actiontype T
          %%
          A: 'a';
          %%
@@ -1623,8 +1623,8 @@ x"
         match parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
-         %type T1
-         %type T2
+         %actiontype T1
+         %actiontype T2
          %%
          A: 'a';"
         ) {

--- a/doc/src/errorrecovery.md
+++ b/doc/src/errorrecovery.md
@@ -52,7 +52,7 @@ Consider the `calc` grammar from the [quickstart guide](quickstart.html):
 %start Expr
 // Define the Rust type that is to be returned by each
 // productions' action.
-%type u64
+%actiontype u64
 %%
 Expr: Term 'PLUS' Expr { $1 + $3 }
     | Term { $1 }
@@ -78,9 +78,9 @@ fn parse_int(s: &str) -> u64 {
 ```
 
 In this grammar, every production has an action: each action *must* evaluate to
-an instance of the `%type` type (in this case `u64`). The `$x` variables refer
+an instance of the `%actiontype` type (in this case `u64`). The `$x` variables refer
 to the respective symbol in the production (i.e. `$1` refers to the first symbol
-in the production). If the symbol is a rule then an instance of `%type` is
+in the production). If the symbol is a rule then an instance of `%actiontype` is
 stored in the `$x` variable; if the symbol is a lexeme then an `Option<Lexeme>`
 instance is returned. A special `$lexer` variable allows access to the lexer.
 This allows us to turn `Lexeme`s into strings with the `lexeme_str` function,
@@ -159,9 +159,9 @@ simpler than it sounds with only a slight rethink in the way that we tend to
 write a grammar's actions.
 
 
-## A rule of thumb: make `%type` return a `Result` type
+## A rule of thumb: make `%actiontype` return a `Result` type
 
-Although you can use whatever type you use for `%type`, using a `Result` type
+Although you can use whatever type you use for `%actiontype`, using a `Result` type
 allows a (deliberately) simple interaction with the effects of error recovery.
 The basic idea is simple: in actions, we ignore lexemes whose value we don't
 care about (e.g. brackets); for lexemes whose value we care about, we either
@@ -175,7 +175,7 @@ occurring:
 
 ```yacc
 %start Expr
-%type Result<u64, ()>
+%actiontype Result<u64, ()>
 %%
 Expr: Term 'PLUS' Expr { Ok($1? + $3?) }
     | Term { $1 }
@@ -251,11 +251,11 @@ Unable to evaluate expression.
 
 Using a `Result` type allows the user arbitrary control over the classes of
 syntax errors they are prepared to deal with or not. For example, we could
-remove the `panic` from `parse_int` by having `%type` be `Result<u64, String>`
+remove the `panic` from `parse_int` by having `%actiontype` be `Result<u64, String>`
 where the `Err` case would report a string such as “18446744073709551616 cannot
 be represented as a u64” for the first unrepresentable `u64` in the user's
 input. If we wanted to report *all* unrepresentable `u64`s, we could have
-`%type` by `Result<u64, Vec<String>>`, though merging together the errors found
+`%actiontype` by `Result<u64, Vec<String>>`, though merging together the errors found
 on the left and right hand sides of the `+` and `*` operators requires adding a
 few lines of code.
 

--- a/doc/src/errorrecovery.md
+++ b/doc/src/errorrecovery.md
@@ -426,7 +426,7 @@ the first parsing error, with the `recoverer` method in `CTParserBuilder` or
 
 ```rust,ignore
     let lex_rule_ids_map = CTParserBuilder::new()
-        .action_kind(ActionKind::CustomAction)
+        .yacckind(YaccKind::Original(YaccOriginalActionKind::UserAction))
         .recoverer(lrpar::RecoveryKind::None)
         .process_file_in_src("calc.y")?;
 ```

--- a/doc/src/quickstart.md
+++ b/doc/src/quickstart.md
@@ -29,6 +29,7 @@ doc = false
 name = "calc"
 
 [build-dependencies]
+cfgrammar = "0.1"
 lrlex = "0.1"
 lrpar = "0.1"
 
@@ -44,15 +45,17 @@ into Rust code. We thus need to create a
 file which can process the lexer and grammar.  Our `build.rs` file thus looks as follows:
 
 ```rust
+extern crate cfgrammar;
 extern crate lrlex;
 extern crate lrpar;
 
+use cfgrammar::yacc::{{YaccKind, YaccOriginalActionKind}};
 use lrlex::LexerBuilder;
 use lrpar::{CTParserBuilder, ActionKind};
 
 fn main() -> Result<(), Box<std::error::Error>> {
     let lex_rule_ids_map = CTParserBuilder::new()
-        .action_kind(ActionKind::CustomAction)
+        .yacckind(YaccKind::Original(YaccOriginalActionKind::UserAction))
         .process_file_in_src("calc.y")?;
     LexerBuilder::new()
         .rule_ids_map(lex_rule_ids_map)
@@ -63,7 +66,8 @@ fn main() -> Result<(), Box<std::error::Error>> {
 
 In our case, we want to specify Rust code which is run as the input is parsed
 (rather than creating a generic parse tree which we traverse later), so we
-specified that the `action_kind` is `ActionKind::CustomAction`. The grammar file
+specified that the `yacckind` (i.e. what variant of Yacc file we're using)
+is `YaccKind::Original(YaccOriginalActionKind::UserAction)`. The grammar file
 is stored in `src/calc.y`, but we only specify `calc.y` as the filename to
 `lrpar`, since it searches relative to `src/` automatically.
 

--- a/doc/src/quickstart.md
+++ b/doc/src/quickstart.md
@@ -107,7 +107,7 @@ Our initial version of calc.y looks as follows:
 ```yacc
 %start Expr
 // Define the Rust type that is to be returned by the actions.
-%type u64
+%actiontype u64
 %%
 Expr: Term 'PLUS' Expr { $1 + $3 }
     | Term { $1 }
@@ -135,7 +135,7 @@ The grammar is in 3 parts, separated by the `%%` lines.
 
 The first part specifies general settings for the grammar: its start rule
 (`%start Expr`) and the Rust type that actions in the grammar must produce
-(`%type u64`).
+(`%actiontype u64`).
 
 The second part is the [Yacc
 grammar](http://dinosaur.compilertools.net/yacc/index.html). It consists of 3
@@ -147,7 +147,7 @@ the end of the production) is executed.
 
 `lrpar`'s actions are somewhat different to Yacc. The `$x` variables refer to
 the respective symbol in the production (i.e. `$1` refers to the first symbol in
-the production). If the symbol is a rule then an instance of `%type` is stored
+the production). If the symbol is a rule then an instance of `%actiontype` is stored
 in the `$x` variable; if the symbol is a lexeme then an `Option<Lexeme>`
 instance is returned. A special `$lexer` variable allows access to the lexer.
 This allows us to turn `Lexeme`s into strings with the `lexeme_str` function,

--- a/lrpar/README.md
+++ b/lrpar/README.md
@@ -51,7 +51,7 @@ and `src/calc.y` is as follows:
 ```
 %start Expr
 // Define the Rust type that is to be returned by the actions.
-%type u64
+%actiontype u64
 %%
 Expr: Term 'PLUS' Expr { $1 + $3 }
     | Term { $1 }

--- a/lrpar/README.md
+++ b/lrpar/README.md
@@ -16,6 +16,7 @@ lexer). We need to add a `build.rs` file to our project which tells `lrpar` to
 statically compile the lexer and parser files:
 
 ```rust
+extern crate cfgrammar;
 extern crate lrlex;
 extern crate lrpar;
 
@@ -24,7 +25,7 @@ use lrpar::{CTParserBuilder, ActionKind};
 
 fn main() -> Result<(), Box<std::error::Error>> {
     let lex_rule_ids_map = CTParserBuilder::new()
-        .action_kind(ActionKind::CustomAction)
+        .yacckind(YaccKind::Original(YaccOriginalActionKind::UserAction))
         .process_file_in_src("calc.y")?;
     LexerBuilder::new()
         .rule_ids_map(lex_rule_ids_map)

--- a/lrpar/examples/calc_actions/Cargo.toml
+++ b/lrpar/examples/calc_actions/Cargo.toml
@@ -8,6 +8,7 @@ doc = false
 name = "actions"
 
 [build-dependencies]
+cfgrammar = { path="../../../cfgrammar" }
 lrlex = { path="../../../lrlex" }
 lrpar = { path="../.." }
 

--- a/lrpar/examples/calc_actions/build.rs
+++ b/lrpar/examples/calc_actions/build.rs
@@ -7,11 +7,13 @@
 // at your option. This file may not be copied, modified, or distributed except according to those
 // terms.
 
+extern crate cfgrammar;
 extern crate lrlex;
 extern crate lrpar;
 
+use cfgrammar::yacc::{YaccKind, YaccOriginalActionKind};
 use lrlex::LexerBuilder;
-use lrpar::{ActionKind, CTParserBuilder};
+use lrpar::CTParserBuilder;
 
 fn main() -> Result<(), Box<std::error::Error>> {
     // First we create the parser, which returns a HashMap of all the tokens used, then we pass
@@ -21,7 +23,7 @@ fn main() -> Result<(), Box<std::error::Error>> {
     // enough to fit all IDs in) as well as the input file (which must end in ".y" for lrpar, and
     // ".l" for lrlex).
     let lex_rule_ids_map = CTParserBuilder::new()
-        .action_kind(ActionKind::CustomAction)
+        .yacckind(YaccKind::Original(YaccOriginalActionKind::UserAction))
         .process_file_in_src("calc.y")?;
     LexerBuilder::new()
         .rule_ids_map(lex_rule_ids_map)

--- a/lrpar/examples/calc_actions/src/calc.y
+++ b/lrpar/examples/calc_actions/src/calc.y
@@ -1,5 +1,5 @@
 %start Expr
-%type Result<u64, ()>
+%actiontype Result<u64, ()>
 %%
 Expr: Term 'PLUS' Expr { Ok($1? + $3?) }
     | Term { $1 }

--- a/lrpar/examples/calc_parsetree/Cargo.toml
+++ b/lrpar/examples/calc_parsetree/Cargo.toml
@@ -8,6 +8,7 @@ doc = false
 name = "calcparse"
 
 [build-dependencies]
+cfgrammar = { path="../../../cfgrammar" }
 lrlex = { path="../../../lrlex" }
 lrpar = { path="../.." }
 

--- a/lrpar/examples/calc_parsetree/build.rs
+++ b/lrpar/examples/calc_parsetree/build.rs
@@ -7,9 +7,11 @@
 // at your option. This file may not be copied, modified, or distributed except according to those
 // terms.
 
+extern crate cfgrammar;
 extern crate lrlex;
 extern crate lrpar;
 
+use cfgrammar::yacc::{YaccKind, YaccOriginalActionKind};
 use lrlex::LexerBuilder;
 use lrpar::CTParserBuilder;
 
@@ -20,8 +22,9 @@ fn main() -> Result<(), Box<std::error::Error>> {
     // Note that we specify the integer type (u8) we'll use for token IDs (this type *must* be big
     // enough to fit all IDs in) as well as the input file (which must end in ".y" for lrpar, and
     // ".l" for lrlex).
-    let lex_rule_ids_map =
-        CTParserBuilder::<u8>::new_with_storaget().process_file_in_src("calc.y")?;
+    let lex_rule_ids_map = CTParserBuilder::<u8>::new_with_storaget()
+        .yacckind(YaccKind::Original(YaccOriginalActionKind::GenericParseTree))
+        .process_file_in_src("calc.y")?;
     LexerBuilder::new()
         .rule_ids_map(lex_rule_ids_map)
         .process_file_in_src("calc.l")?;

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -48,9 +48,6 @@ lazy_static! {
     static ref RE_DOL_LEXER: Regex = Regex::new(r"\$lexer").unwrap();
 }
 
-/// By default `CTParserBuilder` generates a parse tree which is returned after a successful parse.
-/// If the user wants to supply custom actions to be executed during reductions and return their
-/// results, they may change `ActionKind` to `CustomAction` instead.
 pub enum ActionKind {
     /// Execute user-specified actions attached to each production
     CustomAction,

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -238,7 +238,7 @@ where
     ///
     /// Where `ActionT` is either:
     ///
-    ///   * the `%type` value given to the grammar
+    ///   * the `%actiontype` value given to the grammar
     ///   * or, if the `yacckind` was set YaccKind::Original(YaccOriginalActionKind::UserAction),
     ///     it is [`Node<StorageT>`](../parser/enum.Node.html)
     ///

--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -868,7 +868,7 @@ mod test {
 
     use cactus::Cactus;
     use cfgrammar::{
-        yacc::{YaccGrammar, YaccKind},
+        yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
         Symbol
     };
     use lrtable::{from_yacc, Minimiser, StIdx, StIdxStorageT};
@@ -912,7 +912,7 @@ A: '(' A ')'
  ;
 ";
 
-        let grm = YaccGrammar::new(YaccKind::Original, grms).unwrap();
+        let grm = YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), grms).unwrap();
         let (sgraph, stable) = from_yacc(&grm, Minimiser::Pager).unwrap();
         let d = Dist::new(&grm, &sgraph, &stable, |_| 1);
         let s0 = StIdx::from(StIdxStorageT::zero());
@@ -975,7 +975,7 @@ T: 'A';
 U: 'B';
 ";
 
-        let grm = YaccGrammar::new(YaccKind::Original, grms).unwrap();
+        let grm = YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), grms).unwrap();
         let (sgraph, stable) = from_yacc(&grm, Minimiser::Pager).unwrap();
         let d = Dist::new(&grm, &sgraph, &stable, |_| 1);
 
@@ -1033,7 +1033,7 @@ Factor: '(' Expr ')'
       | 'INT' ;
 ";
 
-        let grm = YaccGrammar::new(YaccKind::Original, grms).unwrap();
+        let grm = YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), grms).unwrap();
         let (sgraph, stable) = from_yacc(&grm, Minimiser::Pager).unwrap();
         let d = Dist::new(&grm, &sgraph, &stable, |_| 1);
 
@@ -1098,7 +1098,7 @@ W: 'b' ;
         // 6: [U -> V W ., {'a', '$'}]
         // 7: [W -> 'b' ., {'a', '$'}]
 
-        let grm = YaccGrammar::new(YaccKind::Original, grms).unwrap();
+        let grm = YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), grms).unwrap();
         let (sgraph, stable) = from_yacc(&grm, Minimiser::Pager).unwrap();
         let d = Dist::new(&grm, &sgraph, &stable, |_| 1);
 

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -34,7 +34,7 @@ pub mod parser;
 pub use parser::{LexParseError, Node, ParseError, ParseRepair, RTParserBuilder, RecoveryKind};
 mod mf;
 
-pub use ctbuilder::{ActionKind, CTParserBuilder};
+pub use ctbuilder::CTParserBuilder;
 
 /// A convenience macro for including statically compiled `.y` files. A file `src/x.y` which is
 /// statically compiled by lrpar can then be used in a crate with `lrpar_mod!(x)`.

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -802,7 +802,7 @@ impl<StorageT: Hash + PrimInt + Unsigned> ParseError<StorageT> {
 pub(crate) mod test {
     use std::collections::HashMap;
 
-    use cfgrammar::yacc::{YaccGrammar, YaccKind};
+    use cfgrammar::yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind};
     use lrtable::{from_yacc, Minimiser};
     use num_traits::ToPrimitive;
     use regex::Regex;
@@ -832,7 +832,11 @@ pub(crate) mod test {
         YaccGrammar<u16>,
         Result<Node<u16>, (Option<Node<u16>>, Vec<LexParseError<u16>>)>
     ) {
-        let grm = YaccGrammar::<u16>::new_with_storaget(YaccKind::Original, grms).unwrap();
+        let grm = YaccGrammar::<u16>::new_with_storaget(
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            grms
+        )
+        .unwrap();
         let (sgraph, stable) = from_yacc(&grm, Minimiser::Pager).unwrap();
         let rule_ids = grm
             .tokens_map()

--- a/lrpar/tests/ct.rs
+++ b/lrpar/tests/ct.rs
@@ -209,7 +209,7 @@ fn main() -> Result<(), Box<std::error::Error>> {{
     fs::write(
         p,
         "%start Expr
-%type Result<u64, ()>
+%actiontype Result<u64, ()>
 %avoid_insert 'INT'
 %%
 Expr: Term '+' Expr { Ok($1? + $3?) }

--- a/lrpar/tests/ct.rs
+++ b/lrpar/tests/ct.rs
@@ -115,6 +115,7 @@ version = \"0.1.0\"
 authors = [\"test\"]
 
 [build-dependencies]
+cfgrammar = {{ path = \"{repop}/cfgrammar\" }}
 lrlex = {{ path = \"{repop}/lrlex\" }}
 lrpar = {{ path = \"{repop}/lrpar\" }}
 
@@ -136,13 +137,16 @@ fn init_simple(tdir: &TempDir) {
     fs::write(
         p,
         "
+extern crate cfgrammar;
 extern crate lrlex;
 extern crate lrpar;
 
+use cfgrammar::yacc::{YaccKind, YaccOriginalActionKind};
 use lrpar::CTParserBuilder;
 
 fn main() -> Result<(), Box<std::error::Error>> {
     CTParserBuilder::new()
+        .yacckind(YaccKind::Original(YaccOriginalActionKind::GenericParseTree))
         .process_file_in_src(\"grm.y\")?;
     Ok(())
 }"
@@ -168,7 +172,7 @@ fn main() {{
     .unwrap();
 }
 
-fn init_calc(tdir: &TempDir, actionkind: &str, main: &str) {
+fn init_calc(tdir: &TempDir, yacckind: &str, main: &str) {
     // Write build.rs
     let mut p = PathBuf::from(tdir.as_ref());
     p.push("build.rs");
@@ -176,22 +180,24 @@ fn init_calc(tdir: &TempDir, actionkind: &str, main: &str) {
         p,
         &format!(
             "
+extern crate cfgrammar;
 extern crate lrlex;
 extern crate lrpar;
 
+use cfgrammar::yacc::{{YaccKind, YaccOriginalActionKind}};
 use lrlex::LexerBuilder;
-use lrpar::{{CTParserBuilder, ActionKind}};
+use lrpar::CTParserBuilder;
 
 fn main() -> Result<(), Box<std::error::Error>> {{
     let lex_rule_ids_map = CTParserBuilder::new()
-        .action_kind({})
+        .yacckind({})
         .process_file_in_src(\"calc.y\")?;
     LexerBuilder::new()
         .rule_ids_map(lex_rule_ids_map)
         .process_file_in_src(\"calc.l\")?;
     Ok(())
 }}",
-            actionkind
+            yacckind
         )
     )
     .unwrap();
@@ -311,7 +317,7 @@ fn test_no_actions() {
     run_in_dummy(|tdir| {
         init_calc(
             &tdir,
-            "ActionKind::NoAction",
+            "YaccKind::Original(YaccOriginalActionKind::NoAction)",
             "
     let lexerdef = calc_l::lexerdef();
     let mut lexer = lexerdef.lexer(\"2+3\");
@@ -334,7 +340,7 @@ fn test_basic_actions() {
     run_in_dummy(|tdir| {
         init_calc(
             &tdir,
-            "ActionKind::CustomAction",
+            "YaccKind::Original(YaccOriginalActionKind::UserAction)",
             "
     let lexerdef = calc_l::lexerdef();
     let mut lexer = lexerdef.lexer(\"2+3\");
@@ -353,7 +359,7 @@ fn test_error_recovery_and_actions() {
     run_in_dummy(|tdir| {
         init_calc(
             &tdir,
-            "ActionKind::CustomAction",
+            "YaccKind::Original(YaccOriginalActionKind::UserAction)",
             "
     use lrpar::LexParseError;
 

--- a/lrtable/src/lib/itemset.rs
+++ b/lrtable/src/lib/itemset.rs
@@ -166,7 +166,7 @@ where
 mod test {
     use super::Itemset;
     use cfgrammar::{
-        yacc::{YaccGrammar, YaccKind},
+        yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
         SIdx, Symbol
     };
     use stategraph::state_exists;
@@ -177,7 +177,7 @@ mod test {
     fn test_dragon_grammar() {
         // From http://binarysculpting.com/2012/02/04/computing-lr1-closure/
         let grm = &YaccGrammar::new(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
           %start S
           %%
@@ -205,7 +205,7 @@ mod test {
 
     fn eco_grammar() -> YaccGrammar {
         YaccGrammar::new(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
           %start S
           %token a b c d f
@@ -256,7 +256,7 @@ mod test {
     //     aSb
     fn grammar3() -> YaccGrammar {
         YaccGrammar::new(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
           %start S
           %token a b c d

--- a/lrtable/src/lib/pager.rs
+++ b/lrtable/src/lib/pager.rs
@@ -398,7 +398,7 @@ mod test {
     use vob::Vob;
 
     use cfgrammar::{
-        yacc::{YaccGrammar, YaccKind},
+        yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
         SIdx, Symbol
     };
     use pager::pager_stategraph;
@@ -441,7 +441,7 @@ mod test {
     //     aSb
     fn grammar3() -> YaccGrammar {
         YaccGrammar::new(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
           %start S
           %token a b c d
@@ -520,7 +520,7 @@ mod test {
     // Pager grammar
     fn grammar_pager() -> YaccGrammar {
         YaccGrammar::new(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
             %start X
             %%

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -244,7 +244,7 @@ pub fn state_exists<StorageT: 'static + Hash + PrimInt + Unsigned>(
 #[cfg(test)]
 mod test {
     use cfgrammar::{
-        yacc::{YaccGrammar, YaccKind},
+        yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
         Symbol
     };
     use pager::pager_stategraph;
@@ -255,7 +255,7 @@ mod test {
     fn test_statetable_core() {
         // Taken from p13 of https://link.springer.com/article/10.1007/s00236-010-0115-6
         let grm = YaccGrammar::new(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
             %start A
             %%

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -582,7 +582,7 @@ fn resolve_shift_reduce<StorageT: 'static + Hash + PrimInt + Unsigned>(
 mod test {
     use super::{Action, StateTable, StateTableError, StateTableErrorKind};
     use cfgrammar::{
-        yacc::{YaccGrammar, YaccKind},
+        yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
         PIdx, Symbol, TIdx
     };
     use pager::pager_stategraph;
@@ -594,7 +594,7 @@ mod test {
     fn test_statetable() {
         // Taken from p19 of www.cs.umd.edu/~mvz/cmsc430-s07/M10lr.pdf
         let grm = YaccGrammar::new(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
             %start Expr
             %%
@@ -675,7 +675,7 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_default_reduce_reduce() {
-        let grm = YaccGrammar::new(YaccKind::Original, &"
+        let grm = YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), &"
             %start A
             %%
             A : B 'x' | C 'x' 'x';
@@ -699,7 +699,7 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_default_shift_reduce() {
-        let grm = YaccGrammar::new(YaccKind::Original, &"
+        let grm = YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), &"
             %start Expr
             %%
             Expr : Expr '+' Expr
@@ -729,7 +729,7 @@ mod test {
     #[rustfmt::skip]
     fn test_conflict_resolution() {
         // Example taken from p54 of Locally least-cost error repair in LR parsers, Carl Cerecke
-        let grm = YaccGrammar::new(YaccKind::Original, &"
+        let grm = YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), &"
             %start S
             %%
             S: A 'c' 'd'
@@ -754,7 +754,7 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_left_associativity() {
-        let grm = YaccGrammar::new(YaccKind::Original, &"
+        let grm = YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), &"
             %start Expr
             %left '+'
             %left '*'
@@ -793,7 +793,7 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_left_right_associativity() {
-        let grm = &YaccGrammar::new(YaccKind::Original, &"
+        let grm = &YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), &"
             %start Expr
             %right '='
             %left '+'
@@ -849,7 +849,7 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_left_right_nonassoc_associativity() {
-        let grm = YaccGrammar::new(YaccKind::Original, &"
+        let grm = YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), &"
             %start Expr
             %right '='
             %left '+'
@@ -924,7 +924,7 @@ mod test {
     #[test]
     fn conflicts() {
         let grm = YaccGrammar::new(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
 %start A
 %%
@@ -960,7 +960,7 @@ C : 'a';
     #[test]
     fn accept_reduce_conflict() {
         let grm = YaccGrammar::new(
-            YaccKind::Original,
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &"
 %start D
 %%

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -22,7 +22,7 @@ use std::{
     process
 };
 
-use cfgrammar::yacc::{YaccGrammar, YaccKind};
+use cfgrammar::yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind};
 use getopts::Options;
 use lrlex::build_lex;
 use lrpar::parser::{RTParserBuilder, RecoveryKind};
@@ -102,9 +102,9 @@ fn main() {
     };
 
     let yacckind = match matches.opt_str("y") {
-        None => YaccKind::Original,
+        None => YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
         Some(s) => match &*s.to_lowercase() {
-            "original" => YaccKind::Original,
+            "original" => YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             "eco" => YaccKind::Eco,
             _ => usage(prog, &format!("Unknown Yacc variant '{}'.", s))
         }


### PR DESCRIPTION
This is very much a "PR that will make later PRs easier", but it's probably big enough to make it worth considering individually.

The main aim of the PR is to solve the weird dichotomy we had between YaccKind (Original or Eco?) and ActionKind (parse tree, user action, no action?). This felt like some sort of weird feature matrix, except sometimes you could specify YaccKind and not ActionKind (or vice versa), making it simply confusing. https://github.com/softdevteam/grmtools/commit/6238a48deb1ac918595c38440e8a9c3961a285b6 is thus the most important commit, though https://github.com/softdevteam/grmtools/commit/6ec897526bfd8fe137b2ec1db247592e65acad4d is a useful follow-up (I kept these two commits separate to make reviewing easier: both commits pass all tests in their own right). This indirectly fixes https://github.com/softdevteam/grmtools/issues/75 by virtue of removing `action_kind` entirely! [I should add that I'm not sure `YaccOriginalActionKind` is a great name due to its verbosity. However, it does have the virtue of being accurate. Thoughts welcome!]

There are then a couple of secondary aspects to the PR.

https://github.com/softdevteam/grmtools/commit/1b6fe62214cbedd9e0588a09cf41d933f5ad5603 does a proper job of a hack in Yacc ASTs which will prove useful to us soon.

Finally, https://github.com/softdevteam/grmtools/commit/c34676293a47800fb3e8042c8ccc8d259a854a3d makes the compile-time generation code slightly less unreadable. 