### PR TITLE
Allow different rules to have different action types.

### DIFF
--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -31,14 +31,14 @@ pub struct GrammarAST {
     pub implicit_tokens: Option<HashSet<String>>,
     // Error pretty-printers
     pub epp: HashMap<String, String>,
-    pub programs: Option<String>,
-    pub actiontype: Option<String>
+    pub programs: Option<String>
 }
 
 #[derive(Debug)]
 pub struct Rule {
     pub name: String,
-    pub pidxs: Vec<usize> // index into GrammarAST.prod
+    pub pidxs: Vec<usize>, // index into GrammarAST.prod
+    pub actiont: Option<String>
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -126,17 +126,17 @@ impl GrammarAST {
             avoid_insert: None,
             implicit_tokens: None,
             epp: HashMap::new(),
-            programs: None,
-            actiontype: None
+            programs: None
         }
     }
 
-    pub fn add_rule(&mut self, name: String) {
+    pub fn add_rule(&mut self, name: String, actiont: Option<String>) {
         self.rules.insert(
             name.clone(),
             Rule {
                 name,
-                pidxs: Vec::new()
+                pidxs: Vec::new(),
+                actiont
             }
         );
     }
@@ -279,7 +279,7 @@ mod test {
     fn test_invalid_start_rule() {
         let mut grm = GrammarAST::new();
         grm.start = Some("A".to_string());
-        grm.add_rule("B".to_string());
+        grm.add_rule("B".to_string(), None);
         grm.add_prod("B".to_string(), vec![], None, None);
         match grm.complete_and_validate() {
             Err(GrammarValidationError {
@@ -294,7 +294,7 @@ mod test {
     fn test_valid_start_rule() {
         let mut grm = GrammarAST::new();
         grm.start = Some("A".to_string());
-        grm.add_rule("A".to_string());
+        grm.add_rule("A".to_string(), None);
         grm.add_prod("A".to_string(), vec![], None, None);
         assert!(grm.complete_and_validate().is_ok());
     }
@@ -303,8 +303,8 @@ mod test {
     fn test_valid_rule_ref() {
         let mut grm = GrammarAST::new();
         grm.start = Some("A".to_string());
-        grm.add_rule("A".to_string());
-        grm.add_rule("B".to_string());
+        grm.add_rule("A".to_string(), None);
+        grm.add_rule("B".to_string(), None);
         grm.add_prod("A".to_string(), vec![rule("B")], None, None);
         grm.add_prod("B".to_string(), vec![], None, None);
         assert!(grm.complete_and_validate().is_ok());
@@ -314,7 +314,7 @@ mod test {
     fn test_invalid_rule_ref() {
         let mut grm = GrammarAST::new();
         grm.start = Some("A".to_string());
-        grm.add_rule("A".to_string());
+        grm.add_rule("A".to_string(), None);
         grm.add_prod("A".to_string(), vec![rule("B")], None, None);
         match grm.complete_and_validate() {
             Err(GrammarValidationError {
@@ -330,7 +330,7 @@ mod test {
         let mut grm = GrammarAST::new();
         grm.tokens.insert("b".to_string());
         grm.start = Some("A".to_string());
-        grm.add_rule("A".to_string());
+        grm.add_rule("A".to_string(), None);
         grm.add_prod("A".to_string(), vec![token("b")], None, None);
         assert!(grm.complete_and_validate().is_ok());
     }
@@ -342,7 +342,7 @@ mod test {
         let mut grm = GrammarAST::new();
         grm.tokens.insert("b".to_string());
         grm.start = Some("A".to_string());
-        grm.add_rule("A".to_string());
+        grm.add_rule("A".to_string(), None);
         grm.add_prod("A".to_string(), vec![rule("b")], None, None);
         assert!(grm.complete_and_validate().is_err());
     }
@@ -351,7 +351,7 @@ mod test {
     fn test_invalid_token_ref() {
         let mut grm = GrammarAST::new();
         grm.start = Some("A".to_string());
-        grm.add_rule("A".to_string());
+        grm.add_rule("A".to_string(), None);
         grm.add_prod("A".to_string(), vec![token("b")], None, None);
         match grm.complete_and_validate() {
             Err(GrammarValidationError {
@@ -366,7 +366,7 @@ mod test {
     fn test_invalid_rule_forgotten_token() {
         let mut grm = GrammarAST::new();
         grm.start = Some("A".to_string());
-        grm.add_rule("A".to_string());
+        grm.add_rule("A".to_string(), None);
         grm.add_prod("A".to_string(), vec![rule("b"), token("b")], None, None);
         match grm.complete_and_validate() {
             Err(GrammarValidationError {
@@ -381,7 +381,7 @@ mod test {
     fn test_invalid_epp() {
         let mut grm = GrammarAST::new();
         grm.start = Some("A".to_string());
-        grm.add_rule("A".to_string());
+        grm.add_rule("A".to_string(), None);
         grm.add_prod("A".to_string(), vec![], None, None);
         grm.epp.insert("k".to_owned(), "v".to_owned());
         match grm.complete_and_validate() {
@@ -405,7 +405,7 @@ mod test {
         );
         grm.start = Some("A".to_string());
         grm.tokens.insert("b".to_string());
-        grm.add_rule("A".to_string());
+        grm.add_rule("A".to_string(), None);
         grm.add_prod(
             "A".to_string(),
             vec![token("b")],
@@ -419,7 +419,7 @@ mod test {
     fn test_invalid_precedence_override() {
         let mut grm = GrammarAST::new();
         grm.start = Some("A".to_string());
-        grm.add_rule("A".to_string());
+        grm.add_rule("A".to_string(), None);
         grm.add_prod(
             "A".to_string(),
             vec![token("b")],

--- a/cfgrammar/src/lib/yacc/mod.rs
+++ b/cfgrammar/src/lib/yacc/mod.rs
@@ -25,6 +25,9 @@ pub enum YaccKind {
     /// The original Yacc style as documented by
     /// [Johnson](http://dinosaur.compilertools.net/yacc/index.html),
     Original(YaccOriginalActionKind),
+    /// Similar to the original Yacc style, but allowing individual rules' actions to have their
+    /// own return type.
+    Grmtools,
     /// The variant used in the [Eco language composition editor](http://soft-dev.org/src/eco/)
     Eco
 }

--- a/doc/src/cfgrammar.md
+++ b/doc/src/cfgrammar.md
@@ -1,5 +1,12 @@
 # `cfgrammar`
 
 `cfgrammar` reads in grammar files, processes them, and provides a convenient
-API for operating with them. It may be of interest to those manipulating
-grammars directly, or who wish to use custom types of parsers.
+API for operating with them. Most users only need to think about `cfgrammar` to the
+extent that they are required to use it to specify what Yacc variant they wish
+to use.
+
+`cfgrammar` may also be of interest to those manipulating grammars directly, or
+who wish to use custom types of parsers. Note that `cfgrammar`'s API should be
+considered semi-stable at best. As the needs of other parts of grmtools change,
+`cfgrammar` tends to have to change too. Since it is unlikely to have few direct
+users, the consequences of changing the API are relatively slight.

--- a/doc/src/parsing.md
+++ b/doc/src/parsing.md
@@ -12,17 +12,50 @@ speaking, the core parts of grammars work identically in Yacc and `lrpar`, but
 some other parts of the system have been modernised (e.g. to avoid the use of
 global variables) and given a more idiomatic Rust feel. Notably, `lrpar` is
 built from the ground-up to have a powerful, flexible approach to [error
-recovery](errorrecovery.md). 
+recovery](errorrecovery.md).
 
 
-## Actions
+## Yacc variants
 
-Users can specify what sort of actions they want performed when parsing occurs.
-The default is `ActionKind::GenericParseTree` which, as its name probably
-suggests, creates a generic parse tree, where elements are instances of
-the `lrpar::parser::Node` enum.
+grmtools can deal with several different variants of Yacc input.
 
-Most users will probably want to specify `ActionKind::CustomAction`, where each
-production can be annotated with an action. A brief example of this is shown in
-the [quickstart guide](quickstart.md); a more detailed explanation can be found
-in the [error recovery](errorrecovery.md) section.
+### Grmtools
+
+`YaccKind::Grmtools` is grmtools own variant of Yacc syntax. The sole difference
+is that rules have a Rust type to which all their production's actions must adhere
+to. Consider the following snippet:
+
+```
+R -> Result<i32, ()>:
+     'a' { Ok(5) }
+   | 'b' { Err(()) }
+```
+
+Here the rule `R` has a Rust return type of `Result<X, ()>` (between `->` and
+`:`). Both of its productions adhere to this type, the first by instantiating
+`Ok(5)` and the second `Err(())`.
+
+### “Original” Yacc
+
+Although the name is not fully accurate (grmtools supports a slightly disjoint
+subset of original Yacc's input), this mode allows users to most easily test
+externally created Yacc files. Several sub-variants are allowed:
+
+* `YaccKind::Original(YaccOriginalActionKind::GenericParseTree)` does not
+  execute user actions, but instead creates a generic parse tree, where elements
+  are instances of the `lrpar::parser::Node` enum. This is useful for quickly
+  testing whether a parser is accepting the intended language.
+
+* `YaccKind::Original(YaccOriginalActionKind::NoActions)` parses input and
+  reports errors but does not execute any user actions. This is useful if you
+  are trying to test a large corpus of input for correctness.
+
+* `YaccKind::Original(YaccOriginalActionKind::UserAction)` models original Yacc
+  most closely but, in a Rust setting, is probably of little use beyond simple
+  calculator like languages. Instead of Yacc's `%union` directive, users can
+  specify `%actiontype` which is a Rust type which all production actions must
+  return an instance of. Unless all actions happen to naturally return the same
+  type, this quickly becomes cumbersome to use. For most use cases,
+  `YaccKind::Grmtools` is a superior alternative.
+
+

--- a/lrpar/examples/calc_actions/build.rs
+++ b/lrpar/examples/calc_actions/build.rs
@@ -11,7 +11,7 @@ extern crate cfgrammar;
 extern crate lrlex;
 extern crate lrpar;
 
-use cfgrammar::yacc::{YaccKind, YaccOriginalActionKind};
+use cfgrammar::yacc::YaccKind;
 use lrlex::LexerBuilder;
 use lrpar::CTParserBuilder;
 
@@ -23,7 +23,7 @@ fn main() -> Result<(), Box<std::error::Error>> {
     // enough to fit all IDs in) as well as the input file (which must end in ".y" for lrpar, and
     // ".l" for lrlex).
     let lex_rule_ids_map = CTParserBuilder::new()
-        .yacckind(YaccKind::Original(YaccOriginalActionKind::UserAction))
+        .yacckind(YaccKind::Grmtools)
         .process_file_in_src("calc.y")?;
     LexerBuilder::new()
         .rule_ids_map(lex_rule_ids_map)

--- a/lrpar/examples/calc_actions/src/calc.y
+++ b/lrpar/examples/calc_actions/src/calc.y
@@ -1,26 +1,30 @@
 %start Expr
-%actiontype Result<u64, ()>
+%avoid_insert "INT"
 %%
-Expr: Term 'PLUS' Expr { Ok($1? + $3?) }
+Expr -> Result<u64, ()>:
+      Term 'PLUS' Expr { Ok($1? + $3?) }
     | Term { $1 }
     ;
 
-Term: Factor 'MUL' Term { Ok($1? * $3?) }
+Term -> Result<u64, ()>:
+      Factor 'MUL' Term { Ok($1? * $3?) }
     | Factor { $1 }
     ;
 
-Factor: 'LBRACK' Expr 'RBRACK' { $2 }
-      | 'INT' {
-            let l = $1.map_err(|_| ())?;
-            match $lexer.lexeme_str(&l).parse::<u64>() {
-                Ok(v) => Ok(v),
-                Err(_) => {
-                    let (_, col) = $lexer.offset_line_col(l.start());
-                    eprintln!("Error at column {}: '{}' cannot be represented as a u64",
-                              col,
-                              $lexer.lexeme_str(&l));
-                    Err(())
-                }
-            }
-        }
-      ;
+Factor -> Result<u64, ()>:
+      'LBRACK' Expr 'RBRACK' { $2 }
+    | 'INT'
+      {
+          let l = $1.map_err(|_| ())?;
+          match $lexer.lexeme_str(&l).parse::<u64>() {
+              Ok(v) => Ok(v),
+              Err(_) => {
+                  let (_, col) = $lexer.offset_line_col(l.start());
+                  eprintln!("Error at column {}: '{}' cannot be represented as a u64",
+                            col,
+                            $lexer.lexeme_str(&l));
+                  Err(())
+              }
+          }
+      }
+    ;

--- a/lrpar/examples/calc_actions/src/calc.y
+++ b/lrpar/examples/calc_actions/src/calc.y
@@ -15,16 +15,19 @@ Factor -> Result<u64, ()>:
       'LBRACK' Expr 'RBRACK' { $2 }
     | 'INT'
       {
-          let l = $1.map_err(|_| ())?;
-          match $lexer.lexeme_str(&l).parse::<u64>() {
-              Ok(v) => Ok(v),
-              Err(_) => {
-                  let (_, col) = $lexer.offset_line_col(l.start());
-                  eprintln!("Error at column {}: '{}' cannot be represented as a u64",
-                            col,
-                            $lexer.lexeme_str(&l));
-                  Err(())
-              }
-          }
+          let v = $1.map_err(|_| ())?;
+          parse_int($lexer.lexeme_str(&v))
       }
     ;
+%%
+// Any functions here are in scope for all the grammar actions above.
+
+fn parse_int(s: &str) -> Result<u64, ()> {
+    match s.parse::<u64>() {
+        Ok(val) => Ok(val as u64),
+        Err(_) => {
+            eprintln!("{} cannot be represented as a u64", s);
+            Err(())
+        }
+    }
+}

--- a/lrpar/examples/calc_parsetree/src/calc.y
+++ b/lrpar/examples/calc_parsetree/src/calc.y
@@ -1,4 +1,5 @@
 %start Expr
+%avoid_insert "INT"
 %%
 Expr: Term 'PLUS' Expr
     | Term ;

--- a/lrpar/examples/calc_parsetree/src/main.rs
+++ b/lrpar/examples/calc_parsetree/src/main.rs
@@ -16,7 +16,7 @@ extern crate lrlex;
 extern crate lrpar;
 
 use cfgrammar::RIdx;
-use lrpar::{LexParseError, Lexer, Node};
+use lrpar::Node;
 
 // Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
 lrlex_mod!(calc_l);
@@ -39,21 +39,12 @@ fn main() {
                 let mut lexer = lexerdef.lexer(l);
                 // Pass the lexer to the parser and lex and parse the input.
                 let (pt, errs) = calc_y::parse(&mut lexer);
+                for e in errs {
+                    println!("{}", e.pp(&lexer, &calc_y::token_epp));
+                }
                 if let Some(pt) = pt {
                     // Success! We parsed the input and created a parse tree.
-                    println!("{}", Eval::new(l).eval(&pt));
-                }
-                for e in errs {
-                    match e {
-                        LexParseError::LexError(e) => {
-                            eprintln!("Lexing error at column {:?}", e.idx);
-                        }
-                        LexParseError::ParseError(e) => {
-                            let (line, col) = lexer.offset_line_col(e.lexeme().start());
-                            assert_eq!(line, 1);
-                            println!("Parsing error at column {}.", col);
-                        }
-                    }
+                    println!("Result: {}", Eval::new(l).eval(&pt));
                 }
             }
             _ => break


### PR DESCRIPTION
This falls under the "why didn't this occur to me earlier?" heading.

Our previous %actiontype solution is, more-or-less, useless in practise. It works in C because the union type that's created allows C programmers to treat chunks of memory as dynamically typed (happily seg-faulting if the programmer fished the wrong thing out of the union). Consider this (highly contrived) grammar:

```
  %start S
  %%
  S: A | S A;
  A: 'a';
```

i.e. match one or more "a" characters. Let's assume that, for each "a" we match we want to produce some value. How should we write this? Our only option is "%actiontype Vec<...>" because "S" must return a Vec, even though "A" only sensibly returns a singular value. In this case, this feels inelegant, but it works.

However, what happens if you've got a real programming language building up an AST? Consider a simple language which allow assignments and expressions:

```
  Assignments: Assignment | Assignments Assignment;
  Assignment: "ID" "=" Expr
  Expr: "INT" "+" Expr | "INT"
```

"Assignments" should return "Vec<Assign>" and "Expr" should return an "Expr". What should our %actiontype be now? Well, we can make an enum:

```rust
  enum AssignsOrExprs {
    Assigns(Vec<Assign>),
    Expr(Expr)
  }
```

and then we can have "%actiontype AssignsOrExprs". But we now have to scale this up to every AST type in our entire program which is horrible, and also turns our seemingly statically typed Rust into dynamically typed code: the number of "match" statements doesn't bear thinking about!

How do other grammar generators deal with this? Well they do the obvious (in retrospect) thing of allowing each different rule's actions to return different types (note: each production in a rule must return the same type!). That's what this commit does. Interestingly, this requires a simple tweak to cfgrammar; a big change to ctbuilder.rs; and not much else.

First we add `YaccKind::Grmtools`, a new variant on Yacc syntax. `%actiontype` is not valid in this grammar type. Instead, each rule in this grammar type *must* have a type after its name:

```
  %start S
  %%
  S::Vec<A>: A { vec![$1] }
    | S A {
        $1.push($2);
        $1
    }
    ;
  A::A: 'a' { A } ;
  %%
  pub struct A;
```

How does this work? Before we translated each production's action into a rule which (for the first production in the grammar above) looked roughly like this:

```rust
  fn action_prod0(..., args: Drain<...>) -> Vec<A> {
     let arg1 = match args.next().unwrap() {
        AStackType::ActionType(x) => x,
        _ => unreachable!()
     };
     vec![arg1]
  }
```

The crucial detail now is that we know the types of all rules in advance. So we generate an enum of all action types, and translate each action into a wrapper and an action:

```rust
  enum ActionsKind {
    AKS(Vec<A>),
    AKA(A)
  }

  fn wrapper_prod0(..., args: Drain<...>) -> Vec<A> {
    let arg1 = match args.next().unwrap() {
      AStackType::ActionType(x) => x,
      _ => unreachable!()
    };
    action_prod0(arg1)
  }

  fn action_prod0(..., mut arg1: A) -> Vec<A> {
    vec![arg1]
  }

  fn wrapper_prod1(..., args: Drain<...>) -> Vec<A> {
    let arg1 = match args.next().unwrap() {
      AStackType::ActionType(x) => x,
      _ => unreachable!()
    };
    let arg2 = match args.next().unwrap() {
      AStackType::ActionType(x) => x,
      _ => unreachable!()
    };
    action_prod0(arg1, arg2)
  }

  fn action_prod1(..., mut arg1: Vec<A>, mut arg2: A) -> Vec<A> {
    arg1.push(arg2);
    arg1
  }

  fn wrapper_prod2(..., args: Drain<...>) -> Vec<A> {
    action_prod2()
  }

  fn action_prod2(...) -> A {
    A
  }
```

The cunning thing about this is that we don't have to change the way the parser works: it receives "action" functions that are wrappers, all of which have the same function signature (i.e. from the parser's perspective it's a bit like we wrote `%actiontype ActionsKind`). The wrapper functions then unpack the Drain, and call the "actual" action functions which contain user code. The actual action functions have their function's arguments and return types statically typed, so Rust statically guarantees that you can't, for example, mix your Classes and Imports. This does incur a mild additional overhead because of the ActionsKind enum (one extra machine word, at worst, per ActionType we're holding), but not enough to hugely worry us. And now we can write grammars which
generate ASTs with ease!

As a happy bonus, I realised that we can make arguments to action functions be mutable (hence the `mut arg1: Vec<A>` above), which makes doing thing like flattening lists a lot more ergonomic.
