### PR TITLE
2018 edition

### DIFF
--- a/cfgrammar/Cargo.toml
+++ b/cfgrammar/Cargo.toml
@@ -4,6 +4,7 @@ description = "Grammar manipulation"
 repository = "https://github.com/softdevteam/grmtools"
 version = "0.1.1"
 authors = ["Laurence Tratt <http://tratt.net/laurie/>"]
+edition = "2018"
 readme = "README.md"
 # This should be "Apache-2.0 OR MIT OR UPL-1.0" but crates.io doesn't know about
 # UPL-1.0.

--- a/cfgrammar/src/lib/idxnewtype.rs
+++ b/cfgrammar/src/lib/idxnewtype.rs
@@ -13,6 +13,8 @@
 use std::mem::size_of;
 
 use num_traits::{self, PrimInt, Unsigned};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 macro_rules! IdxNewtype {
     ($(#[$attr:meta])* $n: ident) => {

--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -65,7 +65,7 @@ mod idxnewtype;
 pub mod yacc;
 
 /// A type specifically for rule indices.
-pub use idxnewtype::{PIdx, RIdx, SIdx, TIdx};
+pub use crate::idxnewtype::{PIdx, RIdx, SIdx, TIdx};
 
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -52,14 +52,8 @@
 //! [`YaccGrammar::new_with_storaget()`](yacc/grammar/struct.YaccGrammar.html#method.new_with_storaget)
 //! which take as input a Yacc grammar.
 
-#[macro_use]
-extern crate lazy_static;
-extern crate indexmap;
-extern crate num_traits;
 #[cfg(feature = "serde")]
-#[macro_use]
-extern crate serde;
-extern crate vob;
+use serde::{Deserialize, Serialize};
 
 mod idxnewtype;
 pub mod yacc;

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -15,7 +15,7 @@ use std::{
 
 use indexmap::{IndexMap, IndexSet};
 
-use yacc::Precedence;
+use super::Precedence;
 
 /// An AST representing a grammar. This is built up gradually: when it is finished, the
 /// `complete_and_validate` must be called exactly once in order to finish the set-up. At that
@@ -252,8 +252,10 @@ impl GrammarAST {
 
 #[cfg(test)]
 mod test {
-    use super::{GrammarAST, GrammarValidationError, GrammarValidationErrorKind, Symbol};
-    use yacc::{AssocKind, Precedence};
+    use super::{
+        super::{AssocKind, Precedence},
+        GrammarAST, GrammarValidationError, GrammarValidationErrorKind, Symbol
+    };
 
     fn rule(n: &str) -> Symbol {
         Symbol::Rule(n.to_string())

--- a/cfgrammar/src/lib/yacc/firsts.rs
+++ b/cfgrammar/src/lib/yacc/firsts.rs
@@ -12,10 +12,8 @@ use std::marker::PhantomData;
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 use vob::Vob;
 
-use yacc::YaccGrammar;
-use RIdx;
-use Symbol;
-use TIdx;
+use super::YaccGrammar;
+use crate::{RIdx, Symbol, TIdx};
 
 /// `Firsts` stores all the first sets for a given grammar. For example, given this code and
 /// grammar:
@@ -154,9 +152,11 @@ where
 
 #[cfg(test)]
 mod test {
-    use super::YaccFirsts;
+    use super::{
+        super::{YaccGrammar, YaccKind, YaccOriginalActionKind},
+        YaccFirsts
+    };
     use num_traits::{AsPrimitive, PrimInt, Unsigned};
-    use yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind};
 
     fn has<StorageT: 'static + PrimInt + Unsigned>(
         grm: &YaccGrammar<StorageT>,

--- a/cfgrammar/src/lib/yacc/follows.rs
+++ b/cfgrammar/src/lib/yacc/follows.rs
@@ -12,10 +12,8 @@ use std::marker::PhantomData;
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 use vob::Vob;
 
-use yacc::YaccGrammar;
-use RIdx;
-use Symbol;
-use TIdx;
+use super::YaccGrammar;
+use crate::{RIdx, Symbol, TIdx};
 
 /// `Follows` stores all the Follow sets for a given grammar. For example, given this code and
 /// grammar:
@@ -125,9 +123,11 @@ where
 
 #[cfg(test)]
 mod test {
-    use super::YaccFollows;
+    use super::{
+        super::{YaccGrammar, YaccKind, YaccOriginalActionKind},
+        YaccFollows
+    };
     use num_traits::{AsPrimitive, PrimInt, Unsigned};
-    use yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind};
 
     fn has<StorageT: 'static + PrimInt + Unsigned>(
         grm: &YaccGrammar<StorageT>,

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -10,6 +10,8 @@
 use std::{cell::RefCell, collections::HashMap, error::Error, fmt};
 
 use num_traits::{self, AsPrimitive, PrimInt, Unsigned};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use vob::Vob;
 
 use super::{

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -616,7 +616,7 @@ where
 /// C: [x]
 /// D: [y, x] or [y, z]
 /// ```
-pub struct SentenceGenerator<'a, StorageT: 'a> {
+pub struct SentenceGenerator<'a, StorageT> {
     grm: &'a YaccGrammar<StorageT>,
     rule_min_costs: RefCell<Option<Vec<u16>>>,
     rule_max_costs: RefCell<Option<Vec<u16>>>,

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -12,22 +12,18 @@ use std::{cell::RefCell, collections::HashMap, error::Error, fmt};
 use num_traits::{self, AsPrimitive, PrimInt, Unsigned};
 use vob::Vob;
 
-use super::YaccKind;
-use yacc::{firsts::YaccFirsts, follows::YaccFollows, parser::YaccParser};
-use PIdx;
-use RIdx;
-use SIdx;
-use Symbol;
-use TIdx;
+use super::{
+    ast::{self, GrammarValidationError},
+    firsts::YaccFirsts,
+    follows::YaccFollows,
+    parser::{YaccParser, YaccParserError},
+    YaccKind
+};
+use crate::{PIdx, RIdx, SIdx, Symbol, TIdx};
 
 const START_RULE: &str = "^";
 const IMPLICIT_RULE: &str = "~";
 const IMPLICIT_START_RULE: &str = "^~";
-
-use yacc::{
-    ast::{self, GrammarValidationError},
-    parser::YaccParserError
-};
 
 pub type PrecedenceLevel = u64;
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1016,13 +1012,12 @@ impl fmt::Display for YaccGrammarError {
 
 #[cfg(test)]
 mod test {
-    use super::{rule_max_costs, rule_min_costs, IMPLICIT_RULE, IMPLICIT_START_RULE};
+    use super::{
+        super::{AssocKind, Precedence, YaccGrammar, YaccKind, YaccOriginalActionKind},
+        rule_max_costs, rule_min_costs, IMPLICIT_RULE, IMPLICIT_START_RULE
+    };
+    use crate::{PIdx, RIdx, Symbol, TIdx};
     use std::collections::HashMap;
-    use yacc::{AssocKind, Precedence, YaccGrammar, YaccKind, YaccOriginalActionKind};
-    use PIdx;
-    use RIdx;
-    use Symbol;
-    use TIdx;
 
     #[test]
     fn test_minimal() {

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -11,6 +11,7 @@
 
 use std::{collections::HashSet, error::Error, fmt};
 
+use lazy_static::lazy_static;
 use regex::Regex;
 
 type YaccResult<T> = Result<T, YaccParserError>;

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -11,12 +11,11 @@
 
 use std::{collections::HashSet, error::Error, fmt};
 
-extern crate regex;
-use self::regex::Regex;
+use regex::Regex;
 
 type YaccResult<T> = Result<T, YaccParserError>;
 
-use yacc::{
+use super::{
     ast::{GrammarAST, Symbol},
     AssocKind, Precedence, YaccKind
 };
@@ -619,10 +618,12 @@ impl YaccParser {
 
 #[cfg(test)]
 mod test {
-    use super::{YaccParser, YaccParserError, YaccParserErrorKind};
-    use yacc::{
-        ast::{GrammarAST, Production, Symbol},
-        AssocKind, Precedence, YaccKind, YaccOriginalActionKind
+    use super::{
+        super::{
+            ast::{GrammarAST, Production, Symbol},
+            AssocKind, Precedence, YaccKind, YaccOriginalActionKind
+        },
+        YaccParser, YaccParserError, YaccParserErrorKind
     };
 
     fn parse(yacc_kind: YaccKind, s: &str) -> Result<GrammarAST, YaccParserError> {

--- a/doc/src/quickstart.md
+++ b/doc/src/quickstart.md
@@ -45,10 +45,6 @@ into Rust code. We thus need to create a
 file which can process the lexer and grammar.  Our `build.rs` file thus looks as follows:
 
 ```rust
-extern crate cfgrammar;
-extern crate lrlex;
-extern crate lrpar;
-
 use cfgrammar::yacc::YaccKind;
 use lrlex::LexerBuilder;
 use lrpar::{CTParserBuilder, ActionKind};
@@ -186,19 +182,15 @@ that we can then call. The `src/main.rs` file below provides a simple
 Python-esque REPL to the user into which they can write calculator expressions:
 
 ```rust
-// The cfgrammar import will not be needed once the 2018 edition is stable.
-extern crate cfgrammar;
-// We import lrpar and lrlex with macros so that lrlex_mod! and lrpar_mod! are in scope.
-#[macro_use] extern crate lrpar;
-#[macro_use] extern crate lrlex;
-
 use std::io::{self, BufRead, Write};
+
+use lrlex::lrlex_mod;
+use lrpar::lrpar_mod;
 
 // Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
 lrlex_mod!(calc_l);
 // Using `lrpar_mod!` brings the lexer for `calc.l` into scope.
 lrpar_mod!(calc_y);
-
 
 fn main() {
     // We need to get a `LexerDef` for the `calc` language in order that we can lex input.

--- a/lrlex/Cargo.toml
+++ b/lrlex/Cargo.toml
@@ -4,6 +4,7 @@ description = "Simple lexer generator"
 repository = "https://github.com/softdevteam/grmtools"
 version = "0.1.1"
 authors = ["Laurence Tratt <http://tratt.net/laurie/>"]
+edition = "2018"
 readme = "README.md"
 # This should be "Apache-2.0 OR MIT OR UPL-1.0" but crates.io doesn't know about
 # UPL-1.0.

--- a/lrlex/examples/calclex/Cargo.toml
+++ b/lrlex/examples/calclex/Cargo.toml
@@ -2,6 +2,7 @@
 name = "calclex"
 version = "0.1.0"
 authors = ["Laurence Tratt <http://tratt.net/laurie/>"]
+edition = "2018"
 
 [[bin]]
 doc = false

--- a/lrlex/examples/calclex/build.rs
+++ b/lrlex/examples/calclex/build.rs
@@ -7,8 +7,6 @@
 // at your option. This file may not be copied, modified, or distributed except according to those
 // terms.
 
-extern crate lrlex;
-
 use lrlex::LexerBuilder;
 
 fn main() {

--- a/lrlex/examples/calclex/src/main.rs
+++ b/lrlex/examples/calclex/src/main.rs
@@ -9,10 +9,7 @@
 
 use std::io::{self, BufRead, Write};
 
-#[macro_use]
-extern crate lrlex;
-extern crate lrpar;
-
+use lrlex::lrlex_mod;
 use lrpar::Lexer;
 
 // Using `lrlex_mod!` brings the lexer for `calc.l` into scope.

--- a/lrlex/src/lib/builder.rs
+++ b/lrlex/src/lib/builder.rs
@@ -19,6 +19,7 @@ use std::{
     path::{Path, PathBuf}
 };
 
+use lazy_static::lazy_static;
 use num_traits::{PrimInt, Unsigned};
 use regex::Regex;
 use try_from::TryFrom;

--- a/lrlex/src/lib/builder.rs
+++ b/lrlex/src/lib/builder.rs
@@ -24,8 +24,7 @@ use regex::Regex;
 use try_from::TryFrom;
 use typename::TypeName;
 
-use lexer::LexerDef;
-use parser::parse_lex;
+use crate::{lexer::LexerDef, parser::parse_lex};
 
 const LEX_SUFFIX: &str = "_l";
 const LEX_FILE_EXT: &str = "l";

--- a/lrlex/src/lib/builder.rs
+++ b/lrlex/src/lib/builder.rs
@@ -94,7 +94,7 @@ where
     pub fn process_file_in_src(
         self,
         srcp: &str
-    ) -> Result<(Option<HashSet<String>>, Option<HashSet<String>>), Box<Error>> {
+    ) -> Result<(Option<HashSet<String>>, Option<HashSet<String>>), Box<dyn Error>> {
         let mut inp = current_dir()?;
         inp.push("src");
         inp.push(srcp);
@@ -120,7 +120,7 @@ where
         self,
         inp: P,
         outp: Q
-    ) -> Result<(Option<HashSet<String>>, Option<HashSet<String>>), Box<Error>>
+    ) -> Result<(Option<HashSet<String>>, Option<HashSet<String>>), Box<dyn Error>>
     where
         P: AsRef<Path>,
         Q: AsRef<Path>

--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -268,7 +268,7 @@ impl<'a, StorageT: Copy + Eq + Hash + PrimInt + Unsigned> Lexer<StorageT>
 #[cfg(test)]
 mod test {
     use super::*;
-    use parser::parse_lex;
+    use crate::parser::parse_lex;
     use std::collections::HashMap;
 
     #[test]

--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -172,7 +172,7 @@ impl<StorageT: Copy + Eq + Hash + PrimInt + Unsigned> LexerDef<StorageT> {
 
 /// A lexer holds a reference to a string and can lex it into `Lexeme`s. Although the struct is
 /// tied to a single string, no guarantees are made about whether the lexemes are cached or not.
-pub struct LRLexer<'a, StorageT: 'a> {
+pub struct LRLexer<'a, StorageT> {
     lexerdef: &'a LexerDef<StorageT>,
     s: &'a str,
     i: usize,

--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -24,9 +24,11 @@ mod builder;
 mod lexer;
 mod parser;
 
-pub use builder::LexerBuilder;
-pub use lexer::{LexerDef, Rule};
-use parser::parse_lex;
+use crate::parser::parse_lex;
+pub use crate::{
+    builder::LexerBuilder,
+    lexer::{LexerDef, Rule}
+};
 
 pub type LexBuildResult<T> = Result<T, LexBuildError>;
 

--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -7,14 +7,6 @@
 // at your option. This file may not be copied, modified, or distributed except according to those
 // terms.
 
-#[macro_use]
-extern crate lazy_static;
-extern crate lrpar;
-extern crate num_traits;
-extern crate regex;
-extern crate try_from;
-extern crate typename;
-
 use std::{error::Error, fmt, hash::Hash};
 
 use num_traits::{PrimInt, Unsigned};

--- a/lrlex/src/lib/parser.rs
+++ b/lrlex/src/lib/parser.rs
@@ -110,7 +110,7 @@ impl<StorageT: TryFrom<usize>> LexParser<StorageT> {
         let line_len = self.src[i..]
             .find(|c| c == '\n')
             .unwrap_or(self.src.len() - i);
-        let line = self.src[i..i + line_len].trim_right();
+        let line = self.src[i..i + line_len].trim_end();
         let rspace = match line.rfind(' ') {
             Some(j) => j,
             None => return Err(self.mk_error(LexErrorKind::MissingSpace, i))
@@ -137,7 +137,7 @@ impl<StorageT: TryFrom<usize>> LexParser<StorageT> {
             }
         }
 
-        let re_str = line[..rspace].trim_right().to_string();
+        let re_str = line[..rspace].trim_end().to_string();
         let rules_len = self.rules.len();
         let tok_id = StorageT::try_from(rules_len)
                            .unwrap_or_else(|_| panic!("StorageT::try_from failed on {} (if StorageT is an unsigned integer type, this probably means that {} exceeds the type's maximum value)", rules_len, rules_len));

--- a/lrlex/src/lib/parser.rs
+++ b/lrlex/src/lib/parser.rs
@@ -12,10 +12,10 @@ use std::hash::Hash;
 use num_traits::{PrimInt, Unsigned};
 use try_from::TryFrom;
 
-use lexer::{LexerDef, Rule};
-use LexBuildError;
-use LexBuildResult;
-use LexErrorKind;
+use crate::{
+    lexer::{LexerDef, Rule},
+    LexBuildError, LexBuildResult, LexErrorKind
+};
 
 pub struct LexParser<StorageT> {
     src: String,
@@ -179,8 +179,6 @@ pub fn parse_lex<StorageT: Copy + Eq + Hash + PrimInt + TryFrom<usize> + Unsigne
 #[cfg(test)]
 mod test {
     use super::*;
-    use LexBuildError;
-    use LexErrorKind;
 
     #[test]
     fn test_nooptions() {

--- a/lrlex/src/main.rs
+++ b/lrlex/src/main.rs
@@ -7,10 +7,6 @@
 // at your option. This file may not be copied, modified, or distributed except according to those
 // terms.
 
-extern crate getopts;
-extern crate lrlex;
-extern crate lrpar;
-
 use getopts::Options;
 use std::{
     env,

--- a/lrpar/Cargo.toml
+++ b/lrpar/Cargo.toml
@@ -4,6 +4,7 @@ description = "Yacc-compatible parser generator"
 repository = "https://github.com/softdevteam/grmtools"
 version = "0.1.1"
 authors = ["Lukas Diekmann <http://lukasdiekmann.com/>", "Laurence Tratt <http://tratt.net/laurie/>"]
+edition = "2018"
 readme = "README.md"
 # This should be "Apache-2.0 OR MIT OR UPL-1.0" but crates.io doesn't know about
 # UPL-1.0.

--- a/lrpar/README.md
+++ b/lrpar/README.md
@@ -16,10 +16,6 @@ lexer). We need to add a `build.rs` file to our project which tells `lrpar` to
 statically compile the lexer and parser files:
 
 ```rust
-extern crate cfgrammar;
-extern crate lrlex;
-extern crate lrpar;
-
 use lrlex::LexerBuilder;
 use lrpar::{CTParserBuilder, ActionKind};
 
@@ -78,11 +74,9 @@ fn parse_int(s: &str) -> u64 {
 A simple `src/main.rs` is as follows:
 
 ```rust
-// The cfgrammar import will not be needed once the 2018 edition is stable.
-extern crate cfgrammar;
 // We import lrpar and lrlex with macros so that lrlex_mod! and lrpar_mod! are in scope.
-#[macro_use] extern crate lrpar;
-#[macro_use] extern crate lrlex;
+use lrlex::lrlex_mod;
+use lrpar::lrpar_mod;
 
 use std::io::{self, BufRead, Write};
 

--- a/lrpar/build.rs
+++ b/lrpar/build.rs
@@ -7,8 +7,6 @@
 // at your option. This file may not be copied, modified, or distributed except according to those
 // terms.
 
-extern crate vergen;
-
 use vergen::{ConstantsFlags, Vergen};
 
 fn main() {

--- a/lrpar/examples/calc_actions/Cargo.toml
+++ b/lrpar/examples/calc_actions/Cargo.toml
@@ -2,6 +2,7 @@
 name = "actions"
 version = "0.1.0"
 authors = ["Laurence Tratt <http://tratt.net/laurie/>"]
+edition = "2018"
 
 [[bin]]
 doc = false

--- a/lrpar/examples/calc_actions/build.rs
+++ b/lrpar/examples/calc_actions/build.rs
@@ -7,10 +7,6 @@
 // at your option. This file may not be copied, modified, or distributed except according to those
 // terms.
 
-extern crate cfgrammar;
-extern crate lrlex;
-extern crate lrpar;
-
 use cfgrammar::yacc::YaccKind;
 use lrlex::LexerBuilder;
 use lrpar::CTParserBuilder;

--- a/lrpar/examples/calc_actions/build.rs
+++ b/lrpar/examples/calc_actions/build.rs
@@ -11,7 +11,7 @@ use cfgrammar::yacc::YaccKind;
 use lrlex::LexerBuilder;
 use lrpar::CTParserBuilder;
 
-fn main() -> Result<(), Box<std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     // First we create the parser, which returns a HashMap of all the tokens used, then we pass
     // that HashMap to the lexer.
     //

--- a/lrpar/examples/calc_actions/src/main.rs
+++ b/lrpar/examples/calc_actions/src/main.rs
@@ -9,11 +9,8 @@
 
 use std::io::{self, BufRead, Write};
 
-extern crate cfgrammar;
-#[macro_use]
-extern crate lrlex;
-#[macro_use]
-extern crate lrpar;
+use lrlex::lrlex_mod;
+use lrpar::lrpar_mod;
 
 // Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
 lrlex_mod!(calc_l);

--- a/lrpar/examples/calc_parsetree/Cargo.toml
+++ b/lrpar/examples/calc_parsetree/Cargo.toml
@@ -2,6 +2,7 @@
 name = "calcparse"
 version = "0.1.0"
 authors = ["Laurence Tratt <http://tratt.net/laurie/>"]
+edition = "2018"
 
 [[bin]]
 doc = false

--- a/lrpar/examples/calc_parsetree/build.rs
+++ b/lrpar/examples/calc_parsetree/build.rs
@@ -11,7 +11,7 @@ use cfgrammar::yacc::{YaccKind, YaccOriginalActionKind};
 use lrlex::LexerBuilder;
 use lrpar::CTParserBuilder;
 
-fn main() -> Result<(), Box<std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     // First we create the parser, which returns a HashMap of all the tokens used, then we pass
     // that HashMap to the lexer.
     //

--- a/lrpar/examples/calc_parsetree/build.rs
+++ b/lrpar/examples/calc_parsetree/build.rs
@@ -7,10 +7,6 @@
 // at your option. This file may not be copied, modified, or distributed except according to those
 // terms.
 
-extern crate cfgrammar;
-extern crate lrlex;
-extern crate lrpar;
-
 use cfgrammar::yacc::{YaccKind, YaccOriginalActionKind};
 use lrlex::LexerBuilder;
 use lrpar::CTParserBuilder;

--- a/lrpar/examples/calc_parsetree/src/main.rs
+++ b/lrpar/examples/calc_parsetree/src/main.rs
@@ -9,14 +9,9 @@
 
 use std::io::{self, BufRead, Write};
 
-extern crate cfgrammar;
-#[macro_use]
-extern crate lrlex;
-#[macro_use]
-extern crate lrpar;
-
 use cfgrammar::RIdx;
-use lrpar::Node;
+use lrlex::lrlex_mod;
+use lrpar::{lrpar_mod, Node};
 
 // Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
 lrlex_mod!(calc_l);

--- a/lrpar/src/lib/astar.rs
+++ b/lrpar/src/lib/astar.rs
@@ -9,7 +9,10 @@
 
 use std::{fmt::Debug, hash::Hash};
 
-use indexmap::map::{Entry, IndexMap};
+use indexmap::{
+    indexmap,
+    map::{Entry, IndexMap}
+};
 
 /// Starting at `start_node`, return, in arbitrary order, all least-cost success nodes.
 ///

--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -116,7 +116,7 @@ pub(crate) fn recoverer<
     ActionT: 'static
 >(
     parser: &'a Parser<StorageT, ActionT>
-) -> Box<Recoverer<StorageT, ActionT> + 'a>
+) -> Box<dyn Recoverer<StorageT, ActionT> + 'a>
 where
     usize: AsPrimitive<StorageT>,
     u32: AsPrimitive<StorageT>
@@ -387,7 +387,7 @@ where
                         }
                     }
                     for c in vc.vals() {
-                        for mut pc in traverse(c) {
+                        for pc in traverse(c) {
                             out.push(pc);
                         }
                     }

--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -18,10 +18,12 @@ use cfgrammar::TIdx;
 use lrtable::{Action, StIdx};
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 
-use astar::dijkstra;
-use lex::Lexeme;
-use mf::{apply_repairs, rank_cnds, simplify_repairs};
-use parser::{AStackType, ParseRepair, Parser, Recoverer};
+use super::{
+    astar::dijkstra,
+    lex::Lexeme,
+    mf::{apply_repairs, rank_cnds, simplify_repairs},
+    parser::{AStackType, ParseRepair, Parser, Recoverer}
+};
 
 const PARSE_AT_LEAST: usize = 3; // N in Corchuelo et al.
 
@@ -452,8 +454,10 @@ mod test {
     use cfgrammar::yacc::YaccGrammar;
     use num_traits::{AsPrimitive, PrimInt, ToPrimitive, Unsigned};
 
-    use lex::Lexeme;
-    use parser::{test::do_parse, LexParseError, ParseRepair, RecoveryKind};
+    use crate::{
+        lex::Lexeme,
+        parser::{test::do_parse, LexParseError, ParseRepair, RecoveryKind}
+    };
 
     fn pp_repairs<StorageT: 'static + Hash + PrimInt + Unsigned>(
         grm: &YaccGrammar<StorageT>,

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -26,6 +26,7 @@ use cfgrammar::{
     RIdx, Symbol
 };
 use filetime::FileTime;
+use lazy_static::lazy_static;
 use lrtable::{from_yacc, statetable::Conflicts, Minimiser, StateGraph, StateTable};
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 use regex::Regex;
@@ -793,12 +794,11 @@ pub fn _reconstitute<'a, StorageT: Deserialize<'a> + Hash + PrimInt + Unsigned>(
 
 #[cfg(test)]
 mod test {
-    extern crate tempfile;
     use std::{fs::File, io::Write, path::PathBuf};
 
-    use self::tempfile::TempDir;
     use super::{CTConflictsError, CTParserBuilder};
     use cfgrammar::yacc::{YaccKind, YaccOriginalActionKind};
+    use tempfile::TempDir;
 
     #[test]
     fn test_conflicts() {

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -32,7 +32,7 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use typename::TypeName;
 
-use RecoveryKind;
+use crate::RecoveryKind;
 
 const YACC_SUFFIX: &str = "_y";
 const ACTION_PREFIX: &str = "__gt_";

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -190,7 +190,7 @@ where
     pub fn process_file_in_src(
         &mut self,
         srcp: &str
-    ) -> Result<HashMap<String, StorageT>, Box<Error>> {
+    ) -> Result<HashMap<String, StorageT>, Box<dyn Error>> {
         let mut inp = current_dir()?;
         inp.push("src");
         inp.push(srcp);
@@ -253,7 +253,7 @@ where
         &mut self,
         inp: P,
         outd: Q
-    ) -> Result<HashMap<String, StorageT>, Box<Error>>
+    ) -> Result<HashMap<String, StorageT>, Box<dyn Error>>
     where
         P: AsRef<Path>,
         Q: AsRef<Path>
@@ -343,7 +343,7 @@ where
         outp_base: PathBuf,
         outp_rs: PathBuf,
         cache: &str
-    ) -> Result<(), Box<Error>> {
+    ) -> Result<(), Box<dyn Error>> {
         let mut outs = String::new();
         // Header
         outs.push_str(&format!("mod {}_y {{\n", mod_name));
@@ -416,7 +416,7 @@ where
         sgraph: &StateGraph<StorageT>,
         stable: &StateTable<StorageT>,
         outp_base: PathBuf
-    ) -> Result<String, Box<Error>> {
+    ) -> Result<String, Box<dyn Error>> {
         let mut outs = String::new();
         match self.yacckind.unwrap() {
             YaccKind::Original(YaccOriginalActionKind::UserAction) | YaccKind::Grmtools => {
@@ -749,7 +749,7 @@ where
         outp_base: P,
         ext: &str,
         d: &T
-    ) -> Result<PathBuf, Box<Error>> {
+    ) -> Result<PathBuf, Box<dyn Error>> {
         let mut outp = outp_base.as_ref().to_path_buf();
         outp.set_extension(ext);
         let f = File::create(&outp)?;

--- a/lrpar/src/lib/lex.rs
+++ b/lrpar/src/lib/lex.rs
@@ -34,11 +34,11 @@ pub trait Lexer<StorageT: Hash + PrimInt + Unsigned> {
 
     /// Return the user input associated with a lexeme. Panics if the lexeme is invalid (i.e. was
     /// not produced by next()).
-    fn lexeme_str(&self, &Lexeme<StorageT>) -> &str;
+    fn lexeme_str(&self, lexeme: &Lexeme<StorageT>) -> &str;
 
     /// Return the line and column number of a given offset. Panics if the offset exceeds the known
     /// input.
-    fn offset_line_col(&self, usize) -> (usize, usize);
+    fn offset_line_col(&self, off: usize) -> (usize, usize);
 
     /// Return all this lexer's remaining lexemes or a `LexError` if there was a problem when lexing.
     fn all_lexemes(&mut self) -> Result<Vec<Lexeme<StorageT>>, LexError> {

--- a/lrpar/src/lib/lex.rs
+++ b/lrpar/src/lib/lex.rs
@@ -113,4 +113,9 @@ impl<StorageT: Copy> Lexeme<StorageT> {
             Some(self.len as usize)
         }
     }
+
+    /// Returns `true` if this lexeme is the result of error recovery, or `false` otherwise.
+    pub fn is_empty(&self) -> bool {
+        self.len == u32::max_value()
+    }
 }

--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -125,7 +125,7 @@ pub(crate) fn recoverer<
     ActionT: 'static
 >(
     parser: &'a Parser<StorageT, ActionT>
-) -> Box<Recoverer<StorageT, ActionT> + 'a>
+) -> Box<dyn Recoverer<StorageT, ActionT> + 'a>
 where
     usize: AsPrimitive<StorageT>,
     u32: AsPrimitive<StorageT>
@@ -413,7 +413,7 @@ where
                         }
                     }
                     for c in vc.vals() {
-                        for mut pc in traverse(c) {
+                        for pc in traverse(c) {
                             out.push(pc);
                         }
                     }

--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -25,9 +25,11 @@ use num_traits::{AsPrimitive, PrimInt, Unsigned};
 use packedvec::PackedVec;
 use vob::Vob;
 
-use astar::astar_all;
-use lex::Lexeme;
-use parser::{AStackType, ParseRepair, Parser, Recoverer};
+use crate::{
+    astar::astar_all,
+    lex::Lexeme,
+    parser::{AStackType, ParseRepair, Parser, Recoverer}
+};
 
 const PARSE_AT_LEAST: usize = 3; // N in Corchuelo et al.
 const TRY_PARSE_AT_MOST: usize = 250;
@@ -864,19 +866,20 @@ where
 mod test {
     use std::{collections::HashMap, fmt::Debug, hash::Hash};
 
-    use num_traits::{AsPrimitive, PrimInt, ToPrimitive, Unsigned, Zero};
-
     use cactus::Cactus;
     use cfgrammar::{
         yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
         Symbol
     };
     use lrtable::{from_yacc, Minimiser, StIdx, StIdxStorageT};
+    use num_traits::{AsPrimitive, PrimInt, ToPrimitive, Unsigned, Zero};
 
-    use lex::Lexeme;
-    use parser::{
-        test::{do_parse, do_parse_with_costs},
-        LexParseError, ParseRepair, RecoveryKind
+    use crate::{
+        lex::Lexeme,
+        parser::{
+            test::{do_parse, do_parse_with_costs},
+            LexParseError, ParseRepair, RecoveryKind
+        }
     };
 
     use super::{ends_with_parse_at_least_shifts, Dist, Repair, RepairMerge, PARSE_AT_LEAST};

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -7,23 +7,6 @@
 // at your option. This file may not be copied, modified, or distributed except according to those
 // terms.
 
-extern crate bincode;
-extern crate cactus;
-extern crate cfgrammar;
-extern crate filetime;
-#[macro_use]
-extern crate indexmap;
-#[macro_use]
-extern crate lazy_static;
-extern crate lrtable;
-extern crate num_traits;
-extern crate packedvec;
-extern crate regex;
-extern crate rmp_serde as rmps;
-extern crate serde;
-extern crate typename;
-extern crate vob;
-
 mod astar;
 mod cpctplus;
 pub mod ctbuilder;

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -28,13 +28,15 @@ mod astar;
 mod cpctplus;
 pub mod ctbuilder;
 pub mod lex;
-pub use lex::{LexError, Lexeme, Lexer};
+pub use crate::lex::{LexError, Lexeme, Lexer};
 mod panic;
 pub mod parser;
-pub use parser::{LexParseError, Node, ParseError, ParseRepair, RTParserBuilder, RecoveryKind};
+pub use crate::parser::{
+    LexParseError, Node, ParseError, ParseRepair, RTParserBuilder, RecoveryKind
+};
 mod mf;
 
-pub use ctbuilder::CTParserBuilder;
+pub use crate::ctbuilder::CTParserBuilder;
 
 /// A convenience macro for including statically compiled `.y` files. A file `src/x.y` which is
 /// statically compiled by lrpar can then be used in a crate with `lrpar_mod!(x)`.

--- a/lrpar/src/lib/panic.rs
+++ b/lrpar/src/lib/panic.rs
@@ -22,7 +22,7 @@ pub(crate) fn recoverer<
     ActionT: 'static
 >(
     _: &'a Parser<StorageT, ActionT>
-) -> Box<Recoverer<StorageT, ActionT> + 'a>
+) -> Box<dyn Recoverer<StorageT, ActionT> + 'a>
 where
     usize: AsPrimitive<StorageT>,
     u32: AsPrimitive<StorageT>

--- a/lrpar/src/lib/panic.rs
+++ b/lrpar/src/lib/panic.rs
@@ -12,7 +12,7 @@ use std::{fmt::Debug, hash::Hash, time::Instant};
 use lrtable::{Action, StIdx};
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 
-use parser::{AStackType, ParseRepair, Parser, Recoverer};
+use crate::parser::{AStackType, ParseRepair, Parser, Recoverer};
 
 struct Panic;
 

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -21,10 +21,11 @@ use cfgrammar::{yacc::YaccGrammar, RIdx, TIdx};
 use lrtable::{Action, StIdx, StIdxStorageT, StateGraph, StateTable};
 use num_traits::{AsPrimitive, PrimInt, Unsigned, Zero};
 
-use cpctplus;
-use lex::{LexError, Lexeme, Lexer};
-use mf;
-use panic;
+use crate::{
+    cpctplus,
+    lex::{LexError, Lexeme, Lexer},
+    mf, panic
+};
 
 const RECOVERY_TIME_BUDGET: u64 = 500; // milliseconds
 
@@ -526,11 +527,11 @@ where
 pub trait Recoverer<StorageT: Hash + PrimInt + Unsigned, ActionT> {
     fn recover(
         &self,
-        Instant,
-        &Parser<StorageT, ActionT>,
-        usize,
-        &mut PStack,
-        &mut Vec<AStackType<ActionT, StorageT>>
+        finish_by: Instant,
+        parser: &Parser<StorageT, ActionT>,
+        in_laidx: usize,
+        in_pstack: &mut PStack,
+        astack: &mut Vec<AStackType<ActionT, StorageT>>
     ) -> (usize, Vec<Vec<ParseRepair<StorageT>>>);
 }
 
@@ -808,7 +809,7 @@ pub(crate) mod test {
     use regex::Regex;
 
     use super::*;
-    use lex::Lexeme;
+    use crate::lex::Lexeme;
 
     pub(crate) fn do_parse(
         rcvry_kind: RecoveryKind,

--- a/lrpar/tests/ct.rs
+++ b/lrpar/tests/ct.rs
@@ -7,9 +7,6 @@
 // at your option. This file may not be copied, modified, or distributed except according to those
 // terms.
 
-extern crate lrpar;
-extern crate tempfile;
-
 use std::{
     fs::{self, create_dir, read_dir, remove_dir_all, remove_file},
     panic::{catch_unwind, resume_unwind, UnwindSafe},
@@ -20,7 +17,7 @@ use std::{
     time::Duration
 };
 
-use self::tempfile::TempDir;
+use tempfile::TempDir;
 
 // How long to wait, in ms, when spinning for DUMMY_SPINLOCK to become false?
 const SPIN_WAIT: u64 = 250;
@@ -113,6 +110,7 @@ fn reset_dummy(tdir: &TempDir) {
 name = \"dummytest\"
 version = \"0.1.0\"
 authors = [\"test\"]
+edition = \"2018\"
 
 [build-dependencies]
 cfgrammar = {{ path = \"{repop}/cfgrammar\" }}
@@ -137,10 +135,6 @@ fn init_simple(tdir: &TempDir) {
     fs::write(
         p,
         "
-extern crate cfgrammar;
-extern crate lrlex;
-extern crate lrpar;
-
 use cfgrammar::yacc::{YaccKind, YaccOriginalActionKind};
 use lrpar::CTParserBuilder;
 
@@ -160,8 +154,7 @@ fn main() -> Result<(), Box<std::error::Error>> {
     fs::write(
         p,
         "
-extern crate cfgrammar;
-#[macro_use] extern crate lrpar;
+use lrpar::lrpar_mod;
 
 lrpar_mod!(grm_y);
 
@@ -180,10 +173,6 @@ fn init_generic(tdir: &TempDir, yacckind: &str, grm: &str, lex: &str, main: &str
         p,
         &format!(
             "
-extern crate cfgrammar;
-extern crate lrlex;
-extern crate lrpar;
-
 use cfgrammar::yacc::{{YaccKind, YaccOriginalActionKind}};
 use lrlex::LexerBuilder;
 use lrpar::CTParserBuilder;
@@ -221,9 +210,9 @@ fn main() -> Result<(), Box<std::error::Error>> {{
     fs::write(
         p,
         &format!(
-            "extern crate cfgrammar;
-#[macro_use] extern crate lrpar;
-#[macro_use] extern crate lrlex;
+            "
+use lrlex::lrlex_mod;
+use lrpar::lrpar_mod;
 
 lrlex_mod!(lex_l);
 lrpar_mod!(grm_y);

--- a/lrtable/Cargo.toml
+++ b/lrtable/Cargo.toml
@@ -4,6 +4,7 @@ description = "LR grammar table generation"
 repository = "https://github.com/softdevteam/grmtools"
 version = "0.1.1"
 authors = ["Lukas Diekmann <http://lukasdiekmann.com/>", "Laurence Tratt <http://tratt.net/laurie/>"]
+edition = "2018"
 readme = "README.md"
 # This should be "Apache-2.0 OR MIT OR UPL-1.0" but crates.io doesn't know about
 # UPL-1.0.

--- a/lrtable/src/lib/itemset.rs
+++ b/lrtable/src/lib/itemset.rs
@@ -15,6 +15,8 @@ use std::{
 use cfgrammar::{yacc::YaccGrammar, PIdx, SIdx, Symbol};
 use fnv::FnvHasher;
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use vob::Vob;
 
 use cfgrammar::yacc::firsts::YaccFirsts;

--- a/lrtable/src/lib/itemset.rs
+++ b/lrtable/src/lib/itemset.rs
@@ -164,13 +164,14 @@ where
 
 #[cfg(test)]
 mod test {
-    use super::Itemset;
     use cfgrammar::{
         yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
         SIdx, Symbol
     };
-    use stategraph::state_exists;
     use vob::Vob;
+
+    use super::Itemset;
+    use crate::stategraph::state_exists;
 
     #[test]
     #[rustfmt::skip]

--- a/lrtable/src/lib/mod.rs
+++ b/lrtable/src/lib/mod.rs
@@ -26,9 +26,11 @@ mod pager;
 mod stategraph;
 pub mod statetable;
 
+pub use crate::{
+    stategraph::StateGraph,
+    statetable::{Action, StateTable, StateTableError, StateTableErrorKind}
+};
 use cfgrammar::yacc::YaccGrammar;
-pub use stategraph::StateGraph;
-pub use statetable::{Action, StateTable, StateTableError, StateTableErrorKind};
 
 /// The type of the inner value of an StIdx.
 pub type StIdxStorageT = u16;

--- a/lrtable/src/lib/mod.rs
+++ b/lrtable/src/lib/mod.rs
@@ -7,19 +7,11 @@
 // at your option. This file may not be copied, modified, or distributed except according to those
 // terms.
 
-extern crate cfgrammar;
-extern crate fnv;
-extern crate num_traits;
-#[cfg(feature = "serde")]
-#[macro_use]
-extern crate serde;
-extern crate sparsevec;
-extern crate try_from;
-extern crate vob;
-
 use std::{hash::Hash, mem::size_of};
 
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 mod itemset;
 mod pager;

--- a/lrtable/src/lib/pager.rs
+++ b/lrtable/src/lib/pager.rs
@@ -16,10 +16,7 @@ use cfgrammar::{yacc::YaccGrammar, SIdx, Symbol};
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 use vob::Vob;
 
-use itemset::Itemset;
-use stategraph::StateGraph;
-use StIdx;
-use StIdxStorageT;
+use crate::{itemset::Itemset, stategraph::StateGraph, StIdx, StIdxStorageT};
 
 // This file creates stategraphs from grammars. Unfortunately there is no perfect guide to how to
 // do this that I know of -- certainly not one that talks about sensible ways to arrange data and
@@ -397,15 +394,13 @@ fn gc<StorageT: Eq + Hash + PrimInt>(
 mod test {
     use vob::Vob;
 
+    use crate::{pager::pager_stategraph, stategraph::state_exists, StIdx};
     use cfgrammar::{
         yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
         SIdx, Symbol
     };
-    use pager::pager_stategraph;
-    use stategraph::state_exists;
 
     use super::vob_intersect;
-    use StIdx;
 
     #[test]
     fn test_vob_intersect() {

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -54,7 +54,9 @@ where
     }
 
     /// Return an iterator over all closed states in this `StateGraph`.
-    pub fn iter_closed_states<'a>(&'a self) -> Box<Iterator<Item = &'a Itemset<StorageT>> + 'a> {
+    pub fn iter_closed_states<'a>(
+        &'a self
+    ) -> Box<dyn Iterator<Item = &'a Itemset<StorageT>> + 'a> {
         Box::new(self.states.iter().map(|x| &x.1))
     }
 
@@ -64,7 +66,7 @@ where
     }
 
     /// Return an iterator over all core states in this `StateGraph`.
-    pub fn iter_core_states<'a>(&'a self) -> Box<Iterator<Item = &'a Itemset<StorageT>> + 'a> {
+    pub fn iter_core_states<'a>(&'a self) -> Box<dyn Iterator<Item = &'a Itemset<StorageT>> + 'a> {
         Box::new(self.states.iter().map(|x| &x.0))
     }
 

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -11,6 +11,8 @@ use std::{collections::hash_map::HashMap, hash::Hash};
 
 use cfgrammar::{yacc::YaccGrammar, Symbol, TIdx};
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use try_from::TryFrom;
 
 use crate::{itemset::Itemset, StIdx, StIdxStorageT};

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -13,9 +13,7 @@ use cfgrammar::{yacc::YaccGrammar, Symbol, TIdx};
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 use try_from::TryFrom;
 
-use itemset::Itemset;
-use StIdx;
-use StIdxStorageT;
+use crate::{itemset::Itemset, StIdx, StIdxStorageT};
 
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -243,12 +241,11 @@ pub fn state_exists<StorageT: 'static + Hash + PrimInt + Unsigned>(
 
 #[cfg(test)]
 mod test {
+    use crate::{pager::pager_stategraph, StIdx};
     use cfgrammar::{
         yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
         Symbol
     };
-    use pager::pager_stategraph;
-    use StIdx;
 
     #[test]
     #[rustfmt::skip]

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -20,6 +20,8 @@ use cfgrammar::{
     PIdx, RIdx, Symbol, TIdx
 };
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use sparsevec::SparseVec;
 use vob::{IterSetBits, Vob};
 

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -23,9 +23,7 @@ use num_traits::{AsPrimitive, PrimInt, Unsigned};
 use sparsevec::SparseVec;
 use vob::{IterSetBits, Vob};
 
-use stategraph::StateGraph;
-use StIdx;
-use StIdxStorageT;
+use crate::{stategraph::StateGraph, StIdx, StIdxStorageT};
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
@@ -580,14 +578,14 @@ fn resolve_shift_reduce<StorageT: 'static + Hash + PrimInt + Unsigned>(
 
 #[cfg(test)]
 mod test {
-    use super::{Action, StateTable, StateTableError, StateTableErrorKind};
     use cfgrammar::{
         yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
         PIdx, Symbol, TIdx
     };
-    use pager::pager_stategraph;
     use std::collections::HashSet;
-    use StIdx;
+
+    use super::{Action, StateTable, StateTableError, StateTableErrorKind};
+    use crate::{pager::pager_stategraph, StIdx};
 
     #[test]
     #[rustfmt::skip]

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -176,14 +176,12 @@ where
         // We only have usize-2 bits to store state IDs and rule indexes
         assert!(usize::from(sg.all_states_len()) < (usize::max_value() - 4));
         assert!(usize::from(grm.rules_len()) < (usize::max_value() - 4));
-        let mut actions: Vec<usize> = Vec::with_capacity(maxa);
-        actions.resize(maxa, 0);
-        let mut gotos: Vec<usize> = Vec::with_capacity(maxg);
+        let mut actions: Vec<usize> = vec![0; maxa];
 
         // Since 0 is reserved for the error type, and states are encoded by adding 1, we can only
         // store max_value - 1 states within the goto table
         assert!(usize::from(sg.all_states_len()) < (usize::from(StIdx::max_value()) - 1));
-        gotos.resize(maxg, 0);
+        let mut gotos: Vec<usize> = vec![0; maxg];
 
         // Store automatically resolved conflicts, so we can print them out later
         let mut reduce_reduce = Vec::new();

--- a/nimbleparse/Cargo.toml
+++ b/nimbleparse/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nimbleparse"
 version = "0.1.0"
 authors = ["Laurence Tratt <http://tratt.net/laurie/>"]
+edition = "2018"
 
 [[bin]]
 doc = false

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -7,13 +7,6 @@
 // at your option. This file may not be copied, modified, or distributed except according to those
 // terms.
 
-extern crate cfgrammar;
-extern crate getopts;
-extern crate lrlex;
-extern crate lrpar;
-extern crate lrtable;
-extern crate num_traits;
-
 use std::{
     env,
     fs::File,


### PR DESCRIPTION
Upgrade to Rust 2018. Since we're about to release 0.2, it seems like a reasonable time to upgrade to the 2018 edition. The major changes for us are mostly around module imports. This does mean we can only compile on rustc-1.31 and later, but I don't think that's a major issue.

None of these commits is fully automated (though https://github.com/softdevteam/grmtools/commit/5a69c044ddcc8da2f6d1be66e2ec05a2746dbdc4 comes close), but they're often (but not always) semi-mechanical.