### PR TITLE
Make a 0.2.1 release.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,3 +54,8 @@ First stable release.
 * `lrlex` no longer tries to create Rust-level identifiers for tokens whose
   names can't be valid Rust identifiers (which led to compile-time syntax
   errors in the generated Rust code).
+
+
+# grmtools 0.2.1 (2019-01-16)
+
+* Documentation fixes.

--- a/cfgrammar/Cargo.toml
+++ b/cfgrammar/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cfgrammar"
 description = "Grammar manipulation"
 repository = "https://github.com/softdevteam/grmtools"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Laurence Tratt <http://tratt.net/laurie/>"]
 edition = "2018"
 readme = "README.md"

--- a/lrlex/Cargo.toml
+++ b/lrlex/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lrlex"
 description = "Simple lexer generator"
 repository = "https://github.com/softdevteam/grmtools"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Laurence Tratt <http://tratt.net/laurie/>"]
 edition = "2018"
 readme = "README.md"

--- a/lrpar/Cargo.toml
+++ b/lrpar/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lrpar"
 description = "Yacc-compatible parser generator"
 repository = "https://github.com/softdevteam/grmtools"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Lukas Diekmann <http://lukasdiekmann.com/>", "Laurence Tratt <http://tratt.net/laurie/>"]
 edition = "2018"
 readme = "README.md"

--- a/lrtable/Cargo.toml
+++ b/lrtable/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lrtable"
 description = "LR grammar table generation"
 repository = "https://github.com/softdevteam/grmtools"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Lukas Diekmann <http://lukasdiekmann.com/>", "Laurence Tratt <http://tratt.net/laurie/>"]
 edition = "2018"
 readme = "README.md"


### PR DESCRIPTION
In one way this is a bit annoying, but since our documentation is sufficiently wrong that it makes using things hard, probably the right thing to do.