### PR TITLE
Make process_file consistent between LexerBuilder and CTParserBuilder

### DIFF
--- a/lrlex/src/lib/builder.rs
+++ b/lrlex/src/lib/builder.rs
@@ -113,8 +113,8 @@ where
         self.process_file(inp, outp)
     }
 
-    /// Statically compile the `.l` file `inp` into Rust, placing the output into `outp`. The
-    /// latter defines a module with a function `lexerdef()`, which returns a
+    /// Statically compile the `.l` file `inp` into Rust, placing the output into the file `outp`.
+    /// The latter defines a module with a function `lexerdef()`, which returns a
     /// [`LexerDef`](struct.LexerDef.html) that can then be used as normal.
     pub fn process_file<P, Q>(
         self,

--- a/lrpar/tests/build.rs
+++ b/lrpar/tests/build.rs
@@ -44,16 +44,19 @@ fn main() -> Result<(), Box<std::error::Error>> {
             fs::write(&pl, &lex).unwrap();
 
             // Build parser and lexer
+            let mut outp = PathBuf::from(&out_dir);
+            outp.push(format!("{}_y", base));
+            outp.set_extension("rs");
             let lex_rule_ids_map = CTParserBuilder::new()
                 .yacckind(yacckind)
-                .process_file(pg.to_str().unwrap(), &out_dir)?;
+                .process_file(pg.to_str().unwrap(), &outp)?;
 
-            let mut outpl = PathBuf::from(&out_dir);
-            outpl.push(format!("{}_l", base));
-            outpl.set_extension("rs");
+            let mut outl = PathBuf::from(&out_dir);
+            outl.push(format!("{}_l", base));
+            outl.set_extension("rs");
             LexerBuilder::new()
                 .rule_ids_map(lex_rule_ids_map)
-                .process_file(pl.to_str().unwrap(), &outpl)?;
+                .process_file(pl.to_str().unwrap(), &outl)?;
         }
     }
     Ok(())


### PR DESCRIPTION
Previously, `process_file` in LexerBuilder expected a filename, while
CTParserBuilder's `process_file` expects a directory. This commit adjusts
LexerBuilder to generate the filename from a given directory similar to
CTParserBuilder, which makes the function a bit easier to use as can be
seen in lrpar/tests/build.rs where we the change saves a few lines of code.