### PR TITLE
Add surrounding_line_str functions.

### DIFF
--- a/lrpar/src/lib/lex.rs
+++ b/lrpar/src/lib/lex.rs
@@ -40,6 +40,10 @@ pub trait Lexer<StorageT: Hash + PrimInt + Unsigned> {
     /// input.
     fn offset_line_col(&self, off: usize) -> (usize, usize);
 
+    /// Return the line containing the byte at position `off`. Panics if the offset exceeds the
+    /// known input.
+    fn surrounding_line_str(&self, off: usize) -> &str;
+
     /// Return all this lexer's remaining lexemes or a `LexError` if there was a problem when lexing.
     fn all_lexemes(&mut self) -> Result<Vec<Lexeme<StorageT>>, LexError> {
         let mut lxs = Vec::new();

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -896,6 +896,10 @@ pub(crate) mod test {
             unreachable!();
         }
 
+        fn surrounding_line_str(&self, _: usize) -> &str {
+            unreachable!();
+        }
+
         fn lexeme_str(&self, _: &Lexeme<StorageT>) -> &str {
             unreachable!();
         }
@@ -975,7 +979,7 @@ L: 'ID'
         check_parse_output(
             &lexs, &grms, "", "S
  L
-",
+"
         );
 
         check_parse_output(


### PR DESCRIPTION
When e.g. printing out error messages, it's often useful to get hold of the entire line that a lexeme is contained on.

The tests are probably the easiest way of seeing what this does.