### PR TITLE
Having offset_line_col return the byte offset of columns is annoying to use.

### DIFF
--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -369,6 +369,34 @@ if 'IF'
     }
 
     #[test]
+    fn test_multibyte() {
+        let src = "%%
+[a❤]+ 'ID'
+[ ] ;"
+            .to_string();
+        let mut lexerdef = parse_lex(&src).unwrap();
+        let mut map = HashMap::new();
+        map.insert("ID", 0u8);
+        assert_eq!(lexerdef.set_rule_ids(&map), (None, None));
+
+        let mut lexer = lexerdef.lexer("a ❤ a");
+        let lexemes = lexer.all_lexemes().unwrap();
+        assert_eq!(lexemes.len(), 3);
+        let lex1 = lexemes[0];
+        assert_eq!(lex1.start(), 0);
+        assert_eq!(lex1.len(), Some(1));
+        assert_eq!(lexer.lexeme_str(&lex1), "a");
+        let lex2 = lexemes[1];
+        assert_eq!(lex2.start(), 2);
+        assert_eq!(lex2.len(), Some(3));
+        assert_eq!(lexer.lexeme_str(&lex2), "❤");
+        let lex3 = lexemes[2];
+        assert_eq!(lex3.start(), 6);
+        assert_eq!(lex3.len(), Some(1));
+        assert_eq!(lexer.lexeme_str(&lex3), "a");
+    }
+
+    #[test]
     fn test_line_col() {
         let src = "%%
 [a-z]+ 'ID'

--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -239,24 +239,30 @@ impl<'a, StorageT: Copy + Eq + Hash + PrimInt + Unsigned> Lexer<StorageT>
         None
     }
 
-    fn offset_line_col(&self, i: usize) -> (usize, usize) {
+    fn line_col(&self, i: usize) -> (usize, usize) {
         if i > self.s.len() {
             panic!("Offset {} exceeds known input length {}", i, self.s.len());
         }
 
-        if self.newlines.is_empty() || i < self.newlines[0] {
-            return (1, i + 1);
+        fn line_col_off<StorageT>(lexer: &LRLexer<StorageT>, i: usize) -> (usize, usize) {
+            if lexer.newlines.is_empty() || i < lexer.newlines[0] {
+                return (1, i);
+            }
+
+            for j in 0..lexer.newlines.len() - 1 {
+                if lexer.newlines[j + 1] > i {
+                    return (j + 2, i - lexer.newlines[j]);
+                }
+            }
+            (
+                lexer.newlines.len() + 1,
+                i - lexer.newlines[lexer.newlines.len() - 1]
+            )
         }
 
-        for j in 0..self.newlines.len() - 1 {
-            if self.newlines[j + 1] > i {
-                return (j + 2, i - self.newlines[j] + 1);
-            }
-        }
-        (
-            self.newlines.len() + 1,
-            i - self.newlines[self.newlines.len() - 1] + 1
-        )
+        let (line_idx, col_byte) = line_col_off(self, i);
+        let line = self.surrounding_line_str(i);
+        (line_idx, line[..col_byte].chars().count() + 1)
     }
 
     fn surrounding_line_str(&self, i: usize) -> &str {
@@ -363,7 +369,7 @@ if 'IF'
     }
 
     #[test]
-    fn test_offset_line_col() {
+    fn test_line_col() {
         let src = "%%
 [a-z]+ 'ID'
 [ \\n] ;"
@@ -376,22 +382,22 @@ if 'IF'
         let mut lexer = lexerdef.lexer("a b c");
         let lexemes = lexer.all_lexemes().unwrap();
         assert_eq!(lexemes.len(), 3);
-        assert_eq!(lexer.offset_line_col(lexemes[1].start()), (1, 3));
+        assert_eq!(lexer.line_col(lexemes[1].start()), (1, 3));
         assert_eq!(lexer.surrounding_line_str(lexemes[1].start()), "a b c");
 
         let mut lexer = lexerdef.lexer("a b c\n");
         let lexemes = lexer.all_lexemes().unwrap();
         assert_eq!(lexemes.len(), 3);
-        assert_eq!(lexer.offset_line_col(lexemes[1].start()), (1, 3));
+        assert_eq!(lexer.line_col(lexemes[1].start()), (1, 3));
         assert_eq!(lexer.surrounding_line_str(lexemes[1].start()), "a b c");
 
         let mut lexer = lexerdef.lexer(" a\nb\n  c d");
         let lexemes = lexer.all_lexemes().unwrap();
         assert_eq!(lexemes.len(), 4);
-        assert_eq!(lexer.offset_line_col(lexemes[0].start()), (1, 2));
-        assert_eq!(lexer.offset_line_col(lexemes[1].start()), (2, 1));
-        assert_eq!(lexer.offset_line_col(lexemes[2].start()), (3, 3));
-        assert_eq!(lexer.offset_line_col(lexemes[3].start()), (3, 5));
+        assert_eq!(lexer.line_col(lexemes[0].start()), (1, 2));
+        assert_eq!(lexer.line_col(lexemes[1].start()), (2, 1));
+        assert_eq!(lexer.line_col(lexemes[2].start()), (3, 3));
+        assert_eq!(lexer.line_col(lexemes[3].start()), (3, 5));
         assert_eq!(lexer.surrounding_line_str(lexemes[0].start()), " a");
         assert_eq!(lexer.surrounding_line_str(lexemes[1].start()), "b");
         assert_eq!(lexer.surrounding_line_str(lexemes[2].start()), "  c d");
@@ -399,8 +405,30 @@ if 'IF'
     }
 
     #[test]
+    fn test_line_col_multibyte() {
+        let src = "%%
+[a-z❤]+ 'ID'
+[ \\n] ;"
+            .to_string();
+        let mut lexerdef = parse_lex(&src).unwrap();
+        let mut map = HashMap::new();
+        map.insert("ID", 0u8);
+        assert_eq!(lexerdef.set_rule_ids(&map), (None, None));
+
+        let mut lexer = lexerdef.lexer(" a\n❤ b");
+        let lexemes = lexer.all_lexemes().unwrap();
+        assert_eq!(lexemes.len(), 3);
+        assert_eq!(lexer.line_col(lexemes[0].start()), (1, 2));
+        assert_eq!(lexer.line_col(lexemes[1].start()), (2, 1));
+        assert_eq!(lexer.line_col(lexemes[2].start()), (2, 3));
+        assert_eq!(lexer.surrounding_line_str(lexemes[0].start()), " a");
+        assert_eq!(lexer.surrounding_line_str(lexemes[1].start()), "❤ b");
+        assert_eq!(lexer.surrounding_line_str(lexemes[2].start()), "❤ b");
+    }
+
+    #[test]
     #[should_panic]
-    fn test_bad_offset_line_col() {
+    fn test_bad_line_col() {
         let src = "%%
 [a-z]+ 'ID'
 [ \\n] ;"
@@ -412,7 +440,7 @@ if 'IF'
 
         let lexer = lexerdef.lexer("a b c");
 
-        lexer.offset_line_col(100);
+        lexer.line_col(100);
     }
 
     #[test]

--- a/lrpar/src/lib/lex.rs
+++ b/lrpar/src/lib/lex.rs
@@ -36,9 +36,10 @@ pub trait Lexer<StorageT: Hash + PrimInt + Unsigned> {
     /// not produced by next()).
     fn lexeme_str(&self, lexeme: &Lexeme<StorageT>) -> &str;
 
-    /// Return the line and column number of a given offset. Panics if the offset exceeds the known
-    /// input.
-    fn offset_line_col(&self, off: usize) -> (usize, usize);
+    /// Return the line and column number of the byte at position `off`. Note that the column
+    /// number is a character -- not a byte! -- offset, relative to the beginning of the line.
+    /// Panics if the offset exceeds the known input.
+    fn line_col(&self, off: usize) -> (usize, usize);
 
     /// Return the line containing the byte at position `off`. Panics if the offset exceeds the
     /// known input.

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -580,11 +580,11 @@ impl<StorageT: Hash + PrimInt + Unsigned> LexParseError<StorageT> {
     ) -> String {
         match self {
             LexParseError::LexError(e) => {
-                let (line, col) = lexer.offset_line_col(e.idx);
+                let (line, col) = lexer.line_col(e.idx);
                 format!("Lexing error at line {} column {}.", line, col)
             }
             LexParseError::ParseError(e) => {
-                let (line, col) = lexer.offset_line_col(e.lexeme().start());
+                let (line, col) = lexer.line_col(e.lexeme().start());
                 let mut out = format!("Parsing error at line {} column {}.", line, col);
                 let repairs_len = e.repairs().len();
                 if repairs_len == 0 {
@@ -892,7 +892,7 @@ pub(crate) mod test {
             None
         }
 
-        fn offset_line_col(&self, _: usize) -> (usize, usize) {
+        fn line_col(&self, _: usize) -> (usize, usize) {
             unreachable!();
         }
 

--- a/lrpar/tests/src/calc_actiontype.test
+++ b/lrpar/tests/src/calc_actiontype.test
@@ -19,7 +19,7 @@ grammar: |
                 match $lexer.lexeme_str(&l).parse::<u64>() {
                     Ok(v) => Ok(v),
                     Err(_) => {
-                        let (_, col) = $lexer.offset_line_col(l.start());
+                        let (_, col) = $lexer.line_col(l.start());
                         eprintln!("Error at column {}: '{}' cannot be represented as a u64",
                                   col,
                                   $lexer.lexeme_str(&l));


### PR DESCRIPTION
Byte offsets are efficient ways of indexing UTF-8 strings, but are confusing to users, since bytes and characters aren't always the same thing. In other words, in the face of multi-byte characters, offset_line_col gave confusing results.

This commit fixes this, returning the character offset for the column which is nearly always what users want. To make this clear, this commit also renames `offset_line_col` to `line_col`. This is a breaking change, but probably the right thing to do.

[I'm not sure why this didn't occur to me earlier -- probably I made the classic mistake of forgetting that byte and character offsets aren't the same thing in UTF-8. Besides, before the `surrounding_line` function was added, there wasn't really an easy way to perform the necessary calculation.]