### PR TITLE
Add the rule name to the generated Rust file.

### DIFF
--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -718,11 +718,13 @@ where
             // element from the argument vector (e.g. $1 is replaced by args[0]). At
             // the same time extract &str from tokens and actiontype from nonterminals.
             outs.push_str(&format!(
-                "    fn {prefix}action_{}({prefix}ridx: RIdx<{storaget}>,
+                "    // {rulename}
+    fn {prefix}action_{}({prefix}ridx: RIdx<{storaget}>,
                      {prefix}lexer: &Lexer<{storaget}>,
                      {args})
                   -> {actiont} {{\n",
                 usize::from(pidx),
+                rulename = grm.rule_name(grm.prod_to_rule(pidx)),
                 storaget = StorageT::type_name(),
                 prefix = ACTION_PREFIX,
                 actiont = grm.actiontype(grm.prod_to_rule(pidx)).as_ref().unwrap(),


### PR DESCRIPTION
This is a very simple way of helping debugging. Instead of getting a message such as "error in gen_y.rs at line 2121" and then having to spend ages working out which action that line of code relates to, this at least narrows it down to a particular rule's productions.

In other words instead of:

```rust
    fn __gt_action_45(__gt_ridx: RIdx<u32>,
                     __gt_lexer: &Lexer<u32>,
    ...
```

one now gets:

```rust
    // DotOpt
    fn __gt_action_45(__gt_ridx: RIdx<u32>,
                     __gt_lexer: &Lexer<u32>,
    ...
```

where "DotOpt" is the rule name. It's a small difference, but it really helps. It would probably be nicer to do something more here, perhaps even adding the full production text to the output. That's quite a bit of work though.