### PR TITLE
Add various rustdoc comments for lrpar.

### DIFF
--- a/lrlex/src/lib/builder.rs
+++ b/lrlex/src/lib/builder.rs
@@ -7,6 +7,8 @@
 // at your option. This file may not be copied, modified, or distributed except according to those
 // terms.
 
+//! Build grammars at run-time.
+
 use std::{
     collections::{HashMap, HashSet},
     convert::AsRef,

--- a/lrpar/README.md
+++ b/lrpar/README.md
@@ -82,7 +82,7 @@ fn parse_int(s: &str) -> Result<u64, ()> {
 }
 ```
 
-Because we specified that our Yacc file is in `Grmtools` format, each Rule has a
+Because we specified that our Yacc file is in `Grmtools` format, each rule has a
 separate Rust type to which all its functions conform (in this case, all the
 rules have the same type, but that's not a requirement).
 
@@ -130,7 +130,7 @@ fn main() {
 }
 ```
 
-We can now cargo run our project and evaluate simple expressions:
+We can now `cargo run` our project and evaluate simple expressions:
 
 ```
 >>> 2 + 3

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -7,6 +7,8 @@
 // at your option. This file may not be copied, modified, or distributed except according to those
 // terms.
 
+//! Build grammars at compile-time so that they can be statically included into a binary.
+
 use std::{
     collections::HashMap,
     convert::AsRef,

--- a/lrpar/src/lib/lex.rs
+++ b/lrpar/src/lib/lex.rs
@@ -11,6 +11,7 @@ use std::{error::Error, fmt, hash::Hash, mem::size_of};
 
 use num_traits::{PrimInt, Unsigned};
 
+/// A Lexing error.
 #[derive(Copy, Clone, Debug)]
 pub struct LexError {
     pub idx: usize

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -7,19 +7,190 @@
 // at your option. This file may not be copied, modified, or distributed except according to those
 // terms.
 
+//! `lrpar` provides a Yacc-compatible parser (where grammars can be generated at
+//! compile-time or run-time). It can take in traditional `.y` files and convert
+//! them into an idiomatic Rust parser. More details can be found in the [grmtools
+//! book](https://softdevteam.github.io/grmtools/master/book); the
+//! [quickstart guide](https://softdevteam.github.io/grmtools/master/book/quickstart.html)
+//! is a good place to start.
+//!
+//!
+//! ## Example
+//!
+//! Let's assume we want to statically generate a parser for a simple calculator
+//! language (and let's also assume we are able to use
+//! [`lrlex`](https://softdevteam.github.io/grmtools/master/book/lrlex.html) for the
+//! lexer). We need to add a `build.rs` file to our project which tells `lrpar` to
+//! statically compile the lexer and parser files:
+//!
+//! ```text
+//! use cfgrammar::yacc::YaccKind;
+//! use lrlex::LexerBuilder;
+//! use lrpar::CTParserBuilder;
+//!
+//! fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let lex_rule_ids_map = CTParserBuilder::new()
+//!         .yacckind(YaccKind::Grmtools)
+//!         .process_file_in_src("calc.y")?;
+//!     LexerBuilder::new()
+//!         .rule_ids_map(lex_rule_ids_map)
+//!         .process_file_in_src("calc.l")?;
+//!     Ok(())
+//! }
+//! ```
+//!
+//! where `src/calc.l` is as follows:
+//!
+//! ```text
+//! %%
+//! [0-9]+ "INT"
+//! \+ "+"
+//! \* "*"
+//! \( "("
+//! \) ")"
+//! [\t ]+ ;
+//! ```
+//!
+//! and `src/calc.y` is as follows:
+//!
+//! ```text
+//! %start Expr
+//! %avoid_insert "INT"
+//! %%
+//! Expr -> Result<u64, ()>:
+//!       Term '+' Expr { Ok($1? + $3?) }
+//!     | Term { $1 }
+//!     ;
+//!
+//! Term -> Result<u64, ()>:
+//!       Factor '*' Term { Ok($1? * $3?) }
+//!     | Factor { $1 }
+//!     ;
+//!
+//! Factor -> Result<u64, ()>:
+//!       '(' Expr ')' { $2 }
+//!     | 'INT'
+//!       {
+//!           let v = $1.map_err(|_| ())?;
+//!           parse_int($lexer.lexeme_str(&v))
+//!       }
+//!     ;
+//! %%
+//! // Any functions here are in scope for all the grammar actions above.
+//!
+//! fn parse_int(s: &str) -> Result<u64, ()> {
+//!     match s.parse::<u64>() {
+//!         Ok(val) => Ok(val),
+//!         Err(_) => {
+//!             eprintln!("{} cannot be represented as a u64", s);
+//!             Err(())
+//!         }
+//!     }
+//! }
+//! ```
+//!
+//! Because we specified that our Yacc file is in `Grmtools` format, each rule has a
+//! separate Rust type to which all its functions conform (in this case, all the
+//! rules have the same type, but that's not a requirement).
+//!
+//! A simple `src/main.rs` is as follows:
+//!
+//! ```text
+//! use std::io::{self, BufRead, Write};
+//!
+//! use lrlex::lrlex_mod;
+//! use lrpar::lrpar_mod;
+//!
+//! // Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
+//! lrlex_mod!(calc_l);
+//! // Using `lrpar_mod!` brings the lexer for `calc.l` into scope.
+//! lrpar_mod!(calc_y);
+//!
+//! fn main() {
+//!     // We need to get a `LexerDef` for the `calc` language in order that we can lex input.
+//!     let lexerdef = calc_l::lexerdef();
+//!     let stdin = io::stdin();
+//!     loop {
+//!         print!(">>> ");
+//!         io::stdout().flush().ok();
+//!         match stdin.lock().lines().next() {
+//!             Some(Ok(ref l)) => {
+//!                 if l.trim().is_empty() {
+//!                     continue;
+//!                 }
+//!                 // Now we create a lexer with the `lexer` method with which we can lex an input.
+//!                 let mut lexer = lexerdef.lexer(l);
+//!                 // Pass the lexer to the parser and lex and parse the input.
+//!                 let (res, errs) = calc_y::parse(&mut lexer);
+//!                 for e in errs {
+//!                     println!("{}", e.pp(&lexer, &calc_y::token_epp));
+//!                 }
+//!                 match res {
+//!                     Some(Ok(r)) => println!("Result: {}", r),
+//!                     _ => eprintln!("Unable to evaluate expression.")
+//!                 }
+//!             }
+//!             _ => break
+//!         }
+//!     }
+//! }
+//! ```
+//!
+//! We can now `cargo run` our project and evaluate simple expressions:
+//!
+//! ```text
+//! >>> 2 + 3
+//! Result: 5
+//! >>> 2 + 3 * 4
+//! Result: 14
+//! >>> (2 + 3) * 4
+//! Result: 20
+//! ```
+//!
+//! `lrpar` also comes with advanced [error
+//! recovery](https://softdevteam.github.io/grmtools/master/book/errorrecovery.html) built-in:
+//!
+//! ```text
+//! >>> 2 + + 3
+//! Parsing error at line 1 column 5. Repair sequences found:
+//!    1: Delete +
+//!    2: Insert INT
+//! Result: 5
+//! >>> 2 + 3 3
+//! Parsing error at line 1 column 7. Repair sequences found:
+//!    1: Insert *
+//!    2: Insert +
+//!    3: Delete 3
+//! Result: 11
+//! >>> 2 + 3 4 5
+//! Parsing error at line 1 column 7. Repair sequences found:
+//!    1: Insert *, Delete 4
+//!    2: Insert +, Delete 4
+//!    3: Delete 4, Delete 5
+//!    4: Insert +, Shift 4, Delete 5
+//!    5: Insert +, Shift 4, Insert +
+//!    6: Insert *, Shift 4, Delete 5
+//!    7: Insert *, Shift 4, Insert *
+//!    8: Insert *, Shift 4, Insert +
+//!    9: Insert +, Shift 4, Insert *
+//! Result: 17
+//! ```
+
 mod astar;
 mod cpctplus;
+#[doc(hidden)]
 pub mod ctbuilder;
+#[doc(hidden)]
 pub mod lex;
 pub use crate::lex::{LexError, Lexeme, Lexer};
 mod panic;
+#[doc(hidden)]
 pub mod parser;
-pub use crate::parser::{
-    LexParseError, Node, ParseError, ParseRepair, RTParserBuilder, RecoveryKind
+pub use crate::{
+    ctbuilder::CTParserBuilder,
+    parser::{LexParseError, Node, ParseError, ParseRepair, RTParserBuilder, RecoveryKind}
 };
 mod mf;
-
-pub use crate::ctbuilder::CTParserBuilder;
 
 /// A convenience macro for including statically compiled `.y` files. A file `src/x.y` which is
 /// statically compiled by lrpar can then be used in a crate with `lrpar_mod!(x)`.

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -539,11 +539,18 @@ pub trait Recoverer<StorageT: Hash + PrimInt + Unsigned, ActionT> {
     ) -> (usize, Vec<Vec<ParseRepair<StorageT>>>);
 }
 
+/// What recovery algorithm should be used when a syntax error is encountered?
 #[derive(Clone, Copy, Debug)]
 pub enum RecoveryKind {
+    /// The CPCT+ algorithm from Diekmann/Tratt "Don't Panic! Better, Fewer, Syntax Errors for LR
+    /// Parsers".
     CPCTPlus,
+    /// The MF algorithm from Diekmann/Tratt "Don't Panic! Better, Fewer, Syntax Errors for LR
+    /// Parsers".
     MF,
+    #[doc(hidden)]
     Panic,
+    /// Don't use error recovery: return as soon as the first syntax error is encountered.
     None
 }
 


### PR DESCRIPTION
Before this, the docs.rs output was Spartan, to say the least, and probably off-putting due to the lack of documentation.