### PR TITLE
Rename Lexeme::is_empty() to Lexeme::inserted().

### DIFF
--- a/lrpar/src/lib/lex.rs
+++ b/lrpar/src/lib/lex.rs
@@ -120,8 +120,9 @@ impl<StorageT: Copy> Lexeme<StorageT> {
         }
     }
 
-    /// Returns `true` if this lexeme is the result of error recovery, or `false` otherwise.
-    pub fn is_empty(&self) -> bool {
+    /// Returns `true` if this lexeme was inserted as the result of error recovery, or `false`
+    /// otherwise.
+    pub fn inserted(&self) -> bool {
         self.len == u32::max_value()
     }
 }

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -1115,7 +1115,8 @@ Call: 'ID' '(' ')';";
         let err_tok_id = usize::from(grm.eof_token_idx()).to_u16().unwrap();
         match &errs[0] {
             LexParseError::ParseError(e) => {
-                assert_eq!(e.lexeme(), &Lexeme::new(err_tok_id, 2, None))
+                assert_eq!(e.lexeme(), &Lexeme::new(err_tok_id, 2, None));
+                assert!(e.lexeme().inserted());
             }
             _ => unreachable!()
         }
@@ -1126,7 +1127,8 @@ Call: 'ID' '(' ')';";
         let err_tok_id = usize::from(grm.token_idx("ID").unwrap()).to_u16().unwrap();
         match &errs[0] {
             LexParseError::ParseError(e) => {
-                assert_eq!(e.lexeme(), &Lexeme::new(err_tok_id, 2, Some(1)))
+                assert_eq!(e.lexeme(), &Lexeme::new(err_tok_id, 2, Some(1)));
+                assert!(!e.lexeme().inserted());
             }
             _ => unreachable!()
         }


### PR DESCRIPTION
The previous name was simply confusing because, though rare, you can have empty lexemes that aren't the result of error recovery (e.g.  DEDENT tokens in Python).