### PR TITLE
Convert dynamic to static assertions when possible.

### DIFF
--- a/lrpar/Cargo.toml
+++ b/lrpar/Cargo.toml
@@ -33,6 +33,7 @@ num-traits = "0.2"
 packedvec = "1.0"
 rmp-serde = "0.13"
 serde = { version="1.0", features=["derive"] }
+static_assertions = "0.3"
 typename = "0.1"
 vob = "2.0"
 regex = "1.0"

--- a/lrpar/src/lib/lex.rs
+++ b/lrpar/src/lib/lex.rs
@@ -10,6 +10,7 @@
 use std::{error::Error, fmt, hash::Hash, mem::size_of};
 
 use num_traits::{PrimInt, Unsigned};
+use static_assertions::const_assert;
 
 /// A Lexing error.
 #[derive(Copy, Clone, Debug)]
@@ -78,7 +79,7 @@ impl<StorageT: Copy> Lexeme<StorageT> {
     /// token is the result of user input, then `Some(n)` should be passed to `len`; if the token
     /// is the result of error recovery, then `None` should be passed to `len`.
     pub fn new(tok_id: StorageT, start: usize, len: Option<usize>) -> Self {
-        debug_assert!(size_of::<usize>() >= size_of::<u32>());
+        const_assert!(size_of::<usize>() >= size_of::<u32>());
         let len = if let Some(l) = len {
             if l >= u32::max_value() as usize {
                 panic!("Can't currently represent lexeme of length {}.", l);
@@ -115,7 +116,7 @@ impl<StorageT: Copy> Lexeme<StorageT> {
         if self.len == u32::max_value() {
             None
         } else {
-            debug_assert!(size_of::<usize>() >= size_of::<u32>());
+            const_assert!(size_of::<usize>() >= size_of::<u32>());
             Some(self.len as usize)
         }
     }

--- a/lrtable/Cargo.toml
+++ b/lrtable/Cargo.toml
@@ -25,4 +25,5 @@ cfgrammar = { path="../cfgrammar", version = "0.3", features=["serde"] }
 serde = { version="1.0", features=["derive"], optional=true }
 vob = { version="2.0", features=["serde"] }
 sparsevec = { version="0.1", features=["serde"] }
+static_assertions = "0.3"
 try_from = "0.3"

--- a/lrtable/src/lib/mod.rs
+++ b/lrtable/src/lib/mod.rs
@@ -16,6 +16,7 @@ use std::{hash::Hash, mem::size_of};
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+use static_assertions::const_assert;
 
 mod itemset;
 mod pager;
@@ -52,7 +53,7 @@ impl From<StIdxStorageT> for StIdx {
 
 impl From<StIdx> for usize {
     fn from(st: StIdx) -> Self {
-        debug_assert!(size_of::<usize>() >= size_of::<StIdxStorageT>());
+        const_assert!(size_of::<usize>() >= size_of::<StIdxStorageT>());
         st.0 as usize
     }
 }


### PR DESCRIPTION
Unfortunately we can't convert type parameters to constant assertions as the constant assertions are checked before the type parameters are expanded.