### PR TITLE
Don't encode lexeme insertion in the API for lexemes end/length.

### DIFF
--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -290,8 +290,7 @@ impl<'a, StorageT: Copy + Eq + Hash + PrimInt + Unsigned> Lexer<StorageT>
     }
 
     fn lexeme_str(&self, l: &Lexeme<StorageT>) -> &str {
-        let st = l.start();
-        &self.s[st..l.end().unwrap_or(st)]
+        &self.s[l.start()..l.end()]
     }
 }
 
@@ -321,11 +320,11 @@ mod test {
         let lex1 = lexemes[0];
         assert_eq!(lex1.tok_id(), 1u8);
         assert_eq!(lex1.start(), 0);
-        assert_eq!(lex1.len(), Some(3));
+        assert_eq!(lex1.len(), 3);
         let lex2 = lexemes[1];
         assert_eq!(lex2.tok_id(), 0);
         assert_eq!(lex2.start(), 4);
-        assert_eq!(lex2.len(), Some(3));
+        assert_eq!(lex2.len(), 3);
     }
 
     #[test]
@@ -361,11 +360,11 @@ if 'IF'
         let lex1 = lexemes[0];
         assert_eq!(lex1.tok_id(), 1u8);
         assert_eq!(lex1.start(), 0);
-        assert_eq!(lex1.len(), Some(3));
+        assert_eq!(lex1.len(), 3);
         let lex2 = lexemes[1];
         assert_eq!(lex2.tok_id(), 0);
         assert_eq!(lex2.start(), 4);
-        assert_eq!(lex2.len(), Some(2));
+        assert_eq!(lex2.len(), 2);
     }
 
     #[test]
@@ -384,15 +383,15 @@ if 'IF'
         assert_eq!(lexemes.len(), 3);
         let lex1 = lexemes[0];
         assert_eq!(lex1.start(), 0);
-        assert_eq!(lex1.len(), Some(1));
+        assert_eq!(lex1.len(), 1);
         assert_eq!(lexer.lexeme_str(&lex1), "a");
         let lex2 = lexemes[1];
         assert_eq!(lex2.start(), 2);
-        assert_eq!(lex2.len(), Some(3));
+        assert_eq!(lex2.len(), 3);
         assert_eq!(lexer.lexeme_str(&lex2), "❤");
         let lex3 = lexemes[2];
         assert_eq!(lex3.start(), 6);
-        assert_eq!(lex3.len(), Some(1));
+        assert_eq!(lex3.len(), 1);
         assert_eq!(lexer.lexeme_str(&lex3), "a");
     }
 

--- a/lrlex/src/main.rs
+++ b/lrlex/src/main.rs
@@ -71,7 +71,7 @@ fn main() {
         println!(
             "{} {}",
             lexerdef.get_rule_by_id(l.tok_id()).name.as_ref().unwrap(),
-            &input[l.start()..l.end().unwrap_or_else(|| l.start())]
+            &input[l.start()..l.end()]
         );
     }
 }

--- a/lrpar/examples/calc_parsetree/src/main.rs
+++ b/lrpar/examples/calc_parsetree/src/main.rs
@@ -86,9 +86,7 @@ impl<'a> Eval<'a> {
             } if ridx == calc_y::R_FACTOR => {
                 if nodes.len() == 1 {
                     if let Node::Term { lexeme } = nodes[0] {
-                        self.s[lexeme.start()..lexeme.end().unwrap_or_else(|| lexeme.start())]
-                            .parse()
-                            .unwrap()
+                        self.s[lexeme.start()..lexeme.end()].parse().unwrap()
                     } else {
                         unreachable!();
                     }

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -636,10 +636,10 @@ where
                             "
         let {prefix}arg_{} = match {prefix}args.next().unwrap() {{
             AStackType::Lexeme(l) => {{
-                if l.len().is_some() {{
-                    Ok(l)
-                }} else {{
+                if l.inserted() {{
                     Err(l)
+                }} else {{
+                    Ok(l)
                 }}
             }},
             AStackType::ActionType(_) => unreachable!()

--- a/lrpar/src/lib/lex.rs
+++ b/lrpar/src/lib/lex.rs
@@ -101,23 +101,26 @@ impl<StorageT: Copy> Lexeme<StorageT> {
         self.start
     }
 
-    /// Byte offset of the end of the lexeme, or `None` if this lexeme is the result of error
-    /// recovery.
-    pub fn end(&self) -> Option<usize> {
-        if let Some(l) = self.len() {
-            Some(self.start() + l)
+    /// Byte offset of the end of the lexeme.
+    ///
+    /// Note that if this lexeme was inserted by error recovery, it will end at the same place it
+    /// started (i.e. `self.start() == self.end()).
+    pub fn end(&self) -> usize {
+        if self.len == u32::max_value() {
+            self.start
         } else {
-            None
+            self.start + (self.len as usize)
         }
     }
 
-    /// Length in bytes of the lexeme, or `None` if this lexeme is the result of error recovery.
-    pub fn len(&self) -> Option<usize> {
+    /// Length in bytes of the lexeme. Note that if this lexeme was inserted by error recovery, it
+    /// will have a length of 0.
+    pub fn len(&self) -> usize {
         if self.len == u32::max_value() {
-            None
+            0
         } else {
             const_assert!(size_of::<usize>() >= size_of::<u32>());
-            Some(self.len as usize)
+            self.len as usize
         }
     }
 

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -58,7 +58,7 @@ where
                 Node::Term { lexeme } => {
                     let tidx = TIdx(lexeme.tok_id());
                     let tn = grm.token_name(tidx).unwrap();
-                    let lt = &input[lexeme.start()..lexeme.end().unwrap_or_else(|| lexeme.start())];
+                    let lt = &input[lexeme.start()..lexeme.end()];
                     s.push_str(&format!("{} {}\n", tn, lt));
                 }
                 Node::Nonterm { ridx, ref nodes } => {
@@ -319,7 +319,7 @@ where
                     let la_lexeme = self.next_lexeme(laidx);
                     pstack.push(state_id);
                     astack.push(AStackType::Lexeme(la_lexeme));
-                    span.push(la_lexeme.end().unwrap_or_else(|| la_lexeme.start()));
+                    span.push(la_lexeme.end());
                     laidx += 1;
                 }
                 Action::Accept => {
@@ -441,7 +441,7 @@ where
                                 self.next_lexeme(laidx)
                             };
                             astack_uw.push(AStackType::Lexeme(la_lexeme));
-                            span_uw.push(la_lexeme.end().unwrap_or_else(|| la_lexeme.start()));
+                            span_uw.push(la_lexeme.end());
                         }
                     }
                     pstack.push(state_id);
@@ -472,7 +472,7 @@ where
             } else {
                 debug_assert!(laidx > 0);
                 let last_la = self.lexemes[laidx - 1];
-                last_la.start() + last_la.len().unwrap_or(0)
+                last_la.end()
             };
 
             Lexeme::new(


### PR DESCRIPTION
This seemed like a good idea when I created the API, but it's turned out to be a pain in practise. The issue is that lexemes inserted by error recovery have no contents or length. I was worried that users would forget this fact, and end up in odd situations (e.g. having variables with names that are the empty string): `end` and `len` both returned `None` if the lexeme was the result of error recovery. In practise, this doesn't seem to be an issue: our actions API clearly differentiates lexemes inserted by error recovery such that they don't really leak into normal code. That makes the API verbose to use without much of a gain with this idiom common:

```rust
lexeme.end().unwrap_or_else(|| lexeme.start())
```

This commit thus simplifies things so that `end()` and `len()` return `usize`s without concern for whether the lexeme is the result of error recovery or not.

Fixes #106.