### PR TITLE
Add the dyn keyword where appropriate

### DIFF
--- a/lrpar/cttests/build.rs
+++ b/lrpar/cttests/build.rs
@@ -10,7 +10,7 @@ use yaml_rust::YamlLoader;
 // used), grammar (the grammar rules), and lexer (the lexing rules). The tests are compiled into
 // two modules `<filename>_y` and `<filename>_l`, which we can then import into src/lib.rs and
 // write tests for.
-fn main() -> Result<(), Box<std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out_dir = env::var("OUT_DIR").unwrap();
     for entry in glob("src/*.test")? {
         let path = entry.unwrap();

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -442,7 +442,7 @@ where
     use std::vec;
 
     #[allow(dead_code)]
-    pub fn parse(lexer: &mut Lexer<{storaget}>)
+    pub fn parse(lexer: &mut dyn Lexer<{storaget}>)
           -> (Option<{actiont}>, Vec<LexParseError<{storaget}>>)
     {{",
                     storaget = StorageT::type_name(),
@@ -453,7 +453,7 @@ where
                 outs.push_str(&format!(
                     "use lrpar::Node;
 
-    pub fn parse(lexer: &mut Lexer<{storaget}>)
+    pub fn parse(lexer: &mut dyn Lexer<{storaget}>)
           -> (Option<Node<{storaget}>>, Vec<LexParseError<{storaget}>>)
     {{",
                     storaget = StorageT::type_name()
@@ -461,7 +461,7 @@ where
             }
             YaccKind::Original(YaccOriginalActionKind::NoAction) => {
                 outs.push_str(&format!(
-                    "    #[allow(dead_code)]\n    pub fn parse(lexer: &mut Lexer<{storaget}>)
+                    "    #[allow(dead_code)]\n    pub fn parse(lexer: &mut dyn Lexer<{storaget}>)
           -> Vec<LexParseError<{storaget}>>
     {{",
                     storaget = StorageT::type_name()
@@ -499,8 +499,8 @@ where
                 // action function references
                 outs.push_str(&format!(
                     "\n        #[allow(clippy::type_complexity)]
-        let mut actions: Vec<&Fn(RIdx<{storaget}>,
-                       &Lexer<{storaget}>,
+        let mut actions: Vec<&dyn Fn(RIdx<{storaget}>,
+                       &dyn Lexer<{storaget}>,
                        (usize, usize),
                        vec::Drain<AStackType<{actionskind}, {storaget}>>)
                     -> {actionskind}> = Vec::new();\n",
@@ -606,7 +606,7 @@ where
             // the same time extract &str from tokens and actiontype from nonterminals.
             outs.push_str(&format!(
                 "    fn {prefix}wrapper_{}({prefix}ridx: RIdx<{storaget}>,
-                      {prefix}lexer: &Lexer<{storaget}>,
+                      {prefix}lexer: &dyn Lexer<{storaget}>,
                       {prefix}span: (usize, usize),
                       mut {prefix}args: vec::Drain<AStackType<{actionskind}, {storaget}>>)
                    -> {actionskind} {{",
@@ -736,7 +736,7 @@ where
                 "    // {rulename}
     #[allow(clippy::too_many_arguments)]
     fn {prefix}action_{}({prefix}ridx: RIdx<{storaget}>,
-                     {prefix}lexer: &Lexer<{storaget}>,
+                     {prefix}lexer: &dyn Lexer<{storaget}>,
                      {prefix}span: (usize, usize),
                      {args})
                   -> {actiont} {{\n",


### PR DESCRIPTION
The second commit is key here, because it stops generated grammars causing tens of warnings along the lines of:

```
    warning: trait objects without an explicit `dyn` are deprecated
       --> /home/ltratt/scratch/softdev/yksom/target/debug/build/yksom-b0187fd6ceceb296/out/som_y.rs:475:36
        |
    475 |                       __gt_lexer: &Lexer<u32>,
        |                                    ^^^^^^^^^^ help: use `dyn`: `dyn Lexer<u32>`
```

when compiled with a new(ish) rustc.