### PR TITLE
Parse $ variables in actions in a better fashion.

### DIFF
--- a/doc/src/actioncode.md
+++ b/doc/src/actioncode.md
@@ -18,3 +18,7 @@ Action code is normal Rust code with the addition of the following special varia
    captures how much of the user's input the current production matched. This
    can be useful when storing debugging information. Note that this variable is
    not enabled by default: use `CTParserBuilder::span_var(true)` to enable it.
+
+ * `$$` is equivalent to `$` in normal Rust code.
+
+Any other variables beginning with `$` are treated as errors.

--- a/lrpar/cttests/src/lib.rs
+++ b/lrpar/cttests/src/lib.rs
@@ -13,6 +13,9 @@ lrpar_mod!(calc_noactions_y);
 lrlex_mod!(multitypes_l);
 lrpar_mod!(multitypes_y);
 
+lrlex_mod!(passthrough_l);
+lrpar_mod!(passthrough_y);
+
 lrlex_mod!(span_l);
 lrpar_mod!(span_y);
 
@@ -136,6 +139,16 @@ fn test_span() {
         (Some(ref spans), _) if spans == &vec![(1, 2), (1, 2), (1, 2), (0, 3), (0, 3), (0, 3)] => {
             ()
         }
+        _ => unreachable!()
+    }
+}
+
+#[test]
+fn test_passthrough() {
+    let lexerdef = passthrough_l::lexerdef();
+    let mut lexer = lexerdef.lexer("101");
+    match passthrough_y::parse(&mut lexer) {
+        (Some(Ok(ref s)), _) if s == "$101" => (),
         _ => unreachable!()
     }
 }

--- a/lrpar/cttests/src/passthrough.test
+++ b/lrpar/cttests/src/passthrough.test
@@ -1,0 +1,16 @@
+name: Test that $$ is passed through correctly.
+yacckind: Grmtools
+grammar: |
+    %start Expr
+    %avoid_insert "INT"
+    %%
+    Expr -> Result<String, ()>:
+        Num { $1 }
+        ;
+    Num -> Result<String, ()>:
+        "INT" { Ok(format!("$${}", $lexer.lexeme_str(&$1.unwrap()))) }
+        ;
+lexer: |
+    %%
+    [0-9]+ "INT"
+


### PR DESCRIPTION
This is more efficient than the old mechanism, and also adds an escape mechanism for "$": "$$" in an action is equivalent to "$" in normal Rust code. The passthrough test hopefully makes this clear.

In a sense, this is an alternative to the fix suggested in https://github.com/softdevteam/grmtools/issues/59, which I think we can never really make work well. The "$$" escaping thing is relatively well known in other contexts, so hopefully it isn't too surprising, though note that Yacc uses `$$` to mean the return value of an action (a convention which we do not use). So perhaps it's not ideal in that regard, but it's hard to imagine anyone thinking that Yacc's special return pseudo-variable is a great idea!

Comments welcome: this isn't a "merge and forget" sort of PR. Maybe this isn't the best solution!