### PR TITLE
Panic if timeout in debug

### DIFF
--- a/cfgrammar/Cargo.toml
+++ b/cfgrammar/Cargo.toml
@@ -17,8 +17,8 @@ path = "src/lib/mod.rs"
 [dependencies]
 getopts = "0.2"
 lazy_static = "1.0"
-indexmap = "1.0"
+indexmap = "1.3"
 num-traits = "0.2"
-regex = "1.0"
+regex = "1.3"
 serde = { version="1.0", features=["derive"], optional=true }
 vob = { version="2.0", features=["serde"] }

--- a/lrlex/Cargo.toml
+++ b/lrlex/Cargo.toml
@@ -18,10 +18,10 @@ name = "lrlex"
 path = "src/lib/mod.rs"
 
 [dependencies]
-getopts = "0.2.15" # only needed for src/main.rs
-lazy_static = "1.2"
+getopts = "0.2" # only needed for src/main.rs
+lazy_static = "1.4"
 lrpar = { path = "../lrpar", version = "0.4" }
-regex = "1.0"
+regex = "1.3"
 num-traits = "0.2"
 try_from = "0.3"
 typename = "0.1"

--- a/lrpar/Cargo.toml
+++ b/lrpar/Cargo.toml
@@ -19,22 +19,22 @@ path = "src/lib/mod.rs"
 vergen = "2"
 
 [dependencies]
-bincode = "1.0"
 cactus = "1.0"
+bincode = "1.2"
 cfgrammar = { path="../cfgrammar", version = "0.4", features=["serde"] }
 filetime = "0.2"
 getopts = "0.2"
-indexmap = "1.0"
-lazy_static = "1.2"
+indexmap = "1.3"
+lazy_static = "1.4"
 lrtable = { path="../lrtable", version = "0.4", features=["serde"] }
 num-traits = "0.2"
-packedvec = "1.0"
-rmp-serde = "0.13"
+packedvec = "1.2"
+rmp-serde = "0.14"
 serde = { version="1.0", features=["derive"] }
-static_assertions = "0.3"
+static_assertions = "1.1"
 typename = "0.1"
 vob = "2.0"
-regex = "1.0"
+regex = "1.3"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/lrpar/Cargo.toml
+++ b/lrpar/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/lib/mod.rs"
 vergen = "2"
 
 [dependencies]
-cactus = "1.0"
 bincode = "1.2"
+cactus = "1.0"
 cfgrammar = { path="../cfgrammar", version = "0.4", features=["serde"] }
 filetime = "0.2"
 getopts = "0.2"

--- a/lrpar/src/lib/astar.rs
+++ b/lrpar/src/lib/astar.rs
@@ -62,6 +62,9 @@ where
         }
 
         if !neighbours(true, &n, &mut next) {
+            #[cfg(test)]
+            panic!("Timeout occurred.");
+            #[cfg(not(test))]
             return Vec::new();
         }
         for (nbr_cost, nbr_hrstc, nbr) in next.drain(..) {

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -18,6 +18,9 @@ use crate::{
     mf, panic
 };
 
+#[cfg(test)]
+const RECOVERY_TIME_BUDGET: u64 = 60_000; // milliseconds
+#[cfg(not(test))]
 const RECOVERY_TIME_BUDGET: u64 = 500; // milliseconds
 
 /// A generic parse tree.

--- a/lrtable/Cargo.toml
+++ b/lrtable/Cargo.toml
@@ -16,12 +16,12 @@ path = "src/lib/mod.rs"
 [dependencies]
 getopts = "0.2"
 fnv = "1.0"
-macro-attr = "0.2.0"
-newtype_derive = "0.1.6"
+macro-attr = "0.2"
+newtype_derive = "0.1"
 num-traits = "0.2"
 cfgrammar = { path="../cfgrammar", version = "0.4", features=["serde"] }
 serde = { version="1.0", features=["derive"], optional=true }
 vob = { version="2.0", features=["serde"] }
 sparsevec = { version="0.1", features=["serde"] }
-static_assertions = "0.3"
+static_assertions = "1.1"
 try_from = "0.3"


### PR DESCRIPTION
Error recovery has a timeout, but that is not very useful in test mode which is slow enough that it's not hard to hit the limit. And, when that happens, much confusion results. This PR changes things so that in test mode the timeout is a) increased b) if triggered causes a `panic`. This should stop us being confused again in the future...