### PR TITLE
Rethink the lexer API

### DIFF
--- a/lrlex/examples/calclex/src/main.rs
+++ b/lrlex/examples/calclex/src/main.rs
@@ -18,10 +18,7 @@ fn main() {
                 // Now we create a lexer with the `lexer` method with which we can lex an input.
                 // Note that each lexer can only lex one input in its lifetime.
                 let lexer = lexerdef.lexer(l);
-                match lexer.all_lexemes() {
-                    Ok(lexemes) => println!("{:?}", lexemes),
-                    Err(e) => println!("{:?}", e)
-                }
+                println!("{:?}", lexer.iter().collect::<Vec<_>>());
             }
             _ => break
         }

--- a/lrlex/src/main.rs
+++ b/lrlex/src/main.rs
@@ -57,12 +57,14 @@ fn main() {
         process::exit(1);
     });
     let input = &read_file(&matches.free[1]);
-    let lexemes = lexerdef.lexer(input).all_lexemes().unwrap();
-    for l in &lexemes {
-        println!(
-            "{} {}",
-            lexerdef.get_rule_by_id(l.tok_id()).name.as_ref().unwrap(),
-            &input[l.start()..l.end()]
-        );
+    for r in lexerdef.lexer(input).iter() {
+        match r {
+            Ok(l) => println!(
+                "{} {}",
+                lexerdef.get_rule_by_id(l.tok_id()).name.as_ref().unwrap(),
+                &input[l.start()..l.end()]
+            ),
+            Err(e) => println!("{:?}", e)
+        }
     }
 }


### PR DESCRIPTION
https://github.com/softdevteam/grmtools/pull/120/commits/4905cc22ce2a34d4f7922264ab7e925ed5b8a9c9 was a necessary commit at the time, but unsatisfactory: it made every lexer require internal mutability. I've spent a long time thinking about how to improve this, and made a couple of attempts: this PR is my first successful attempt at a change!

In essence, this PR separates a `Lexer` from an iterator over `Lexeme`s. The crucial change in the API can be seen clearly at https://github.com/softdevteam/grmtools/commit/8377643f6f09d676f30b75f4122dee149d20b5a6#diff-ffcacced45f7cad40cdf0c1a5518c089R23 where `next` is removed and `iter` put in its place. This then allows simple lexers (like `lrlex`) to not require interior mutability at all.

Most of https://github.com/softdevteam/grmtools/commit/8377643f6f09d676f30b75f4122dee149d20b5a6 then percolates the necessary changes through the rest of grmtools.