### PR TITLE
Flesh out the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,85 @@
 grmtools is a suite of Rust libraries and binaries for parsing text, both at
 compile-time, and run-time. Most users will probably be interested in the
 compile-time Yacc feature, which allows traditional `.y` files to be used
-(mostly) unchanged in Rust. See the
-[grmtools book](https://softdevteam.github.io/grmtools/master/book/)
-for more information, including a
-[quickstart guide](https://softdevteam.github.io/grmtools/master/book/quickstart.html).
+(mostly) unchanged in Rust.
+
+## Quickstart
+
+A minimal example using this library consists of two files (in addition to the
+grammar and lexing definitions). First we need to create a file `build.rs` in
+the root of our project with the following content:
+
+```rust
+use cfgrammar::yacc::YaccKind;
+use lrlex::LexerBuilder;
+use lrpar::{CTParserBuilder};
+
+fn main() -> Result<(), Box<std::error::Error>> {
+    let lex_rule_ids_map = CTParserBuilder::new()
+        .yacckind(YaccKind::Grmtools)
+        .process_file_in_src("grammar.y")?;
+    LexerBuilder::new()
+        .rule_ids_map(lex_rule_ids_map)
+        .process_file_in_src("lexer.l")?;
+    Ok(())
+}
+```
+
+This will generate and compile a parser and lexer using the definitions found
+in `src/lexer.l` and `src/grammar.y`. We can then use the generated lexer and
+parser within our `src/main.rs` file as follows:
+
+```rust
+use std::env;
+
+use lrlex::lrlex_mod;
+use lrpar::lrpar_mod;
+
+// Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
+lrlex_mod!(calc_l);
+// Using `lrpar_mod!` brings the parser for `calc.y` into scope.
+lrpar_mod!(calc_y);
+
+fn main() {
+    // We need to get a `LexerDef` for the `calc` language in order that we can
+    // lex input.
+    let lexerdef = calc_l::lexerdef();
+    let args: Vec<String> = env::args().collect();
+    // Now we create a lexer with the `lexer` method with which we can lex an
+    // input.
+    let mut lexer = lexerdef.lexer(&args[1]);
+    // Pass the lexer to the parser and lex and parse the input.
+    let (res, errs) = calc_y::parse(&mut lexer);
+    for e in errs {
+        println!("{}", e.pp(&lexer, &calc_y::token_epp));
+    }
+    match res {
+        Some(r) => println!("Result: {:?}", r),
+        _ => eprintln!("Unable to evaluate expression.")
+    }
+}
+```
+
+For more information on how to use this library please refer to the [grmtools
+book](https://softdevteam.github.io/grmtools/master/book/), which also includes
+a more detailed [quickstart
+guide](https://softdevteam.github.io/grmtools/master/book/quickstart.html).
+
+## Examples
+
+[lrpar](https://github.com/softdevteam/grmtools/tree/master/lrpar/examples)
+contains several examples on how to use the `lrpar`/`lrlex` libraries, showing
+how to generate [parse
+trees](https://github.com/softdevteam/grmtools/tree/master/lrpar/examples/calc_parsetree)
+and
+[ASTs](https://github.com/softdevteam/grmtools/tree/master/lrpar/examples/calc_ast),
+or [execute
+code](https://github.com/softdevteam/grmtools/tree/master/lrpar/examples/calc_actions)
+while parsing.
+
+## Documentation
+
+- [grmtools book](https://softdevteam.github.io/grmtools/master/book/)
+- [lrpar](https://docs.rs/lrpar/)
+- [lrlex](https://docs.rs/lrlex/)
+- [lrtable](https://docs.rs/lrtable/)

--- a/doc/src/quickstart.md
+++ b/doc/src/quickstart.md
@@ -42,12 +42,13 @@ lrpar = "0.4"
 In this situation we want to statically compile the `.y` grammar and `.l` lexer
 into Rust code. We thus need to create a
 [`build.rs`](https://doc.rust-lang.org/cargo/reference/build-scripts.html)
-file which can process the lexer and grammar.  Our `build.rs` file thus looks as follows:
+file inside the root of our project which can process the lexer and grammar.
+Our `build.rs` file thus looks as follows:
 
 ```rust
 use cfgrammar::yacc::YaccKind;
 use lrlex::LexerBuilder;
-use lrpar::{CTParserBuilder, ActionKind};
+use lrpar::{CTParserBuilder};
 
 fn main() -> Result<(), Box<std::error::Error>> {
     let lex_rule_ids_map = CTParserBuilder::new()
@@ -191,7 +192,7 @@ use lrpar::lrpar_mod;
 
 // Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
 lrlex_mod!(calc_l);
-// Using `lrpar_mod!` brings the lexer for `calc.l` into scope.
+// Using `lrpar_mod!` brings the parser for `calc.y` into scope.
 lrpar_mod!(calc_y);
 
 fn main() {


### PR DESCRIPTION
f861301 adds a shortened version of the quickstart guide to the README. It also adds some other useful links to it.

6b2644f fixes a few typos and one error in the quickstart guide.