### PR TITLE
Make lrlex_mod and lrpar_mod take in the same filenames as process_file_in_src

### DIFF
--- a/doc/src/quickstart.md
+++ b/doc/src/quickstart.md
@@ -191,9 +191,9 @@ use lrlex::lrlex_mod;
 use lrpar::lrpar_mod;
 
 // Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
-lrlex_mod!(calc_l);
+lrlex_mod!("calc.l");
 // Using `lrpar_mod!` brings the parser for `calc.y` into scope.
-lrpar_mod!(calc_y);
+lrpar_mod!("calc.y");
 
 fn main() {
     // We need to get a `LexerDef` for the `calc` language in order that we can lex input.

--- a/lrlex/examples/calclex/src/main.rs
+++ b/lrlex/examples/calclex/src/main.rs
@@ -4,7 +4,7 @@ use lrlex::lrlex_mod;
 use lrpar::Lexer;
 
 // Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
-lrlex_mod!(calc_l);
+lrlex_mod!("calc.l");
 
 fn main() {
     // We need to get a `LexerDef` for the `calc` language in order that we can lex input.

--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -62,11 +62,11 @@ pub fn build_lex<StorageT: Copy + Eq + Hash + PrimInt + TryFrom<usize> + Unsigne
     parse_lex(s)
 }
 
-/// A convenience macro for including statically compiled `.l` files. A file `src/x.l` which is
-/// statically compiled by lrlex can then be used in a crate with `lrlex_mod!(x)`.
+/// A convenience macro for including statically compiled `.l` files. A file `src/a/b/c.l` which is
+/// statically compiled by lrlex can then be used in a crate with `lrlex_mod!("a/b/c.l")`.
 #[macro_export]
 macro_rules! lrlex_mod {
-    ($n:ident) => {
-        include!(concat!(env!("OUT_DIR"), "/", stringify!($n), ".rs"));
+    ($path:expr) => {
+        include!(concat!(env!("OUT_DIR"), "/", $path, ".rs"));
     };
 }

--- a/lrpar/README.md
+++ b/lrpar/README.md
@@ -96,9 +96,9 @@ use lrlex::lrlex_mod;
 use lrpar::lrpar_mod;
 
 // Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
-lrlex_mod!(calc_l);
+lrlex_mod!("calc.l");
 // Using `lrpar_mod!` brings the lexer for `calc.l` into scope.
-lrpar_mod!(calc_y);
+lrpar_mod!("calc.y");
 
 fn main() {
     // We need to get a `LexerDef` for the `calc` language in order that we can lex input.

--- a/lrpar/README.md
+++ b/lrpar/README.md
@@ -97,7 +97,7 @@ use lrpar::lrpar_mod;
 
 // Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
 lrlex_mod!("calc.l");
-// Using `lrpar_mod!` brings the lexer for `calc.l` into scope.
+// Using `lrpar_mod!` brings the parser for `calc.y` into scope.
 lrpar_mod!("calc.y");
 
 fn main() {

--- a/lrpar/cttests/build.rs
+++ b/lrpar/cttests/build.rs
@@ -34,18 +34,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 s => panic!("YaccKind '{}' not supported", s)
             };
 
+            // The code below, in essence, replicates lrlex and lrpar's internal / undocumented
+            // filename conventions. If those change, this code will also have to change.
+
             // Create grammar files
             let base = path.file_stem().unwrap().to_str().unwrap();
             let mut pg = PathBuf::from(&out_dir);
-            pg.push(format!("{}.y", base));
+            pg.push(format!("{}.y.rs", base));
             fs::write(&pg, &grm).unwrap();
             let mut pl = PathBuf::from(&out_dir);
-            pl.push(format!("{}.l", base));
+            pl.push(format!("{}.l.rs", base));
             fs::write(&pl, &lex).unwrap();
 
             // Build parser and lexer
             let mut outp = PathBuf::from(&out_dir);
-            outp.push(format!("{}_y", base));
+            outp.push(format!("{}.y.rs", base));
             outp.set_extension("rs");
             let lex_rule_ids_map = CTParserBuilder::new()
                 .yacckind(yacckind)
@@ -53,7 +56,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .process_file(pg.to_str().unwrap(), &outp)?;
 
             let mut outl = PathBuf::from(&out_dir);
-            outl.push(format!("{}_l", base));
+            outl.push(format!("{}.l.rs", base));
             outl.set_extension("rs");
             LexerBuilder::new()
                 .rule_ids_map(lex_rule_ids_map)

--- a/lrpar/cttests/src/lib.rs
+++ b/lrpar/cttests/src/lib.rs
@@ -1,23 +1,23 @@
 use lrlex::lrlex_mod;
 use lrpar::lrpar_mod;
 
-lrlex_mod!(calc_multitypes_l);
-lrpar_mod!(calc_multitypes_y);
+lrlex_mod!("calc_multitypes.l");
+lrpar_mod!("calc_multitypes.y");
 
-lrlex_mod!(calc_actiontype_l);
-lrpar_mod!(calc_actiontype_y);
+lrlex_mod!("calc_actiontype.l");
+lrpar_mod!("calc_actiontype.y");
 
-lrlex_mod!(calc_noactions_l);
-lrpar_mod!(calc_noactions_y);
+lrlex_mod!("calc_noactions.l");
+lrpar_mod!("calc_noactions.y");
 
-lrlex_mod!(multitypes_l);
-lrpar_mod!(multitypes_y);
+lrlex_mod!("multitypes.l");
+lrpar_mod!("multitypes.y");
 
-lrlex_mod!(passthrough_l);
-lrpar_mod!(passthrough_y);
+lrlex_mod!("passthrough.l");
+lrpar_mod!("passthrough.y");
 
-lrlex_mod!(span_l);
-lrpar_mod!(span_y);
+lrlex_mod!("span.l");
+lrpar_mod!("span.y");
 
 #[test]
 fn multitypes() {

--- a/lrpar/examples/calc_actions/src/main.rs
+++ b/lrpar/examples/calc_actions/src/main.rs
@@ -5,7 +5,7 @@ use lrpar::lrpar_mod;
 
 // Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
 lrlex_mod!("calc.l");
-// Using `lrpar_mod!` brings the lexer for `calc.l` into scope.
+// Using `lrpar_mod!` brings the parser for `calc.y` into scope.
 lrpar_mod!("calc.y");
 
 fn main() {

--- a/lrpar/examples/calc_actions/src/main.rs
+++ b/lrpar/examples/calc_actions/src/main.rs
@@ -4,9 +4,9 @@ use lrlex::lrlex_mod;
 use lrpar::lrpar_mod;
 
 // Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
-lrlex_mod!(calc_l);
+lrlex_mod!("calc.l");
 // Using `lrpar_mod!` brings the lexer for `calc.l` into scope.
-lrpar_mod!(calc_y);
+lrpar_mod!("calc.y");
 
 fn main() {
     // We need to get a `LexerDef` for the `calc` language in order that we can lex input.

--- a/lrpar/examples/calc_ast/src/main.rs
+++ b/lrpar/examples/calc_ast/src/main.rs
@@ -5,7 +5,7 @@ use lrpar::lrpar_mod;
 
 // Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
 lrlex_mod!("calc.l");
-// Using `lrpar_mod!` brings the lexer for `calc.l` into scope.
+// Using `lrpar_mod!` brings the parser for `calc.y` into scope.
 lrpar_mod!("calc.y");
 
 use calc_y::Expr;

--- a/lrpar/examples/calc_ast/src/main.rs
+++ b/lrpar/examples/calc_ast/src/main.rs
@@ -4,9 +4,9 @@ use lrlex::lrlex_mod;
 use lrpar::lrpar_mod;
 
 // Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
-lrlex_mod!(calc_l);
+lrlex_mod!("calc.l");
 // Using `lrpar_mod!` brings the lexer for `calc.l` into scope.
-lrpar_mod!(calc_y);
+lrpar_mod!("calc.y");
 
 use calc_y::Expr;
 

--- a/lrpar/examples/calc_parsetree/src/main.rs
+++ b/lrpar/examples/calc_parsetree/src/main.rs
@@ -6,7 +6,7 @@ use lrpar::{lrpar_mod, Node};
 
 // Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
 lrlex_mod!("calc.l");
-// Using `lrpar_mod!` brings the lexer for `calc.l` into scope.
+// Using `lrpar_mod!` brings the parser for `calc.y` into scope.
 lrpar_mod!("calc.y");
 
 fn main() {

--- a/lrpar/examples/calc_parsetree/src/main.rs
+++ b/lrpar/examples/calc_parsetree/src/main.rs
@@ -5,9 +5,9 @@ use lrlex::lrlex_mod;
 use lrpar::{lrpar_mod, Node};
 
 // Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
-lrlex_mod!(calc_l);
+lrlex_mod!("calc.l");
 // Using `lrpar_mod!` brings the lexer for `calc.l` into scope.
-lrpar_mod!(calc_y);
+lrpar_mod!("calc.y");
 
 fn main() {
     // We need to get a `LexerDef` for the `calc` language in order that we can lex input.

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -102,7 +102,7 @@
 //!
 //! // Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
 //! lrlex_mod!("calc.l");
-//! // Using `lrpar_mod!` brings the lexer for `calc.l` into scope.
+//! // Using `lrpar_mod!` brings the parser for `calc.y` into scope.
 //! lrpar_mod!("calc.y");
 //!
 //! fn main() {

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -191,12 +191,12 @@ pub use crate::{
 };
 mod mf;
 
-/// A convenience macro for including statically compiled `.y` files. A file `src/x.y` which is
-/// statically compiled by lrpar can then be used in a crate with `lrpar_mod!(x)`.
+/// A convenience macro for including statically compiled `.y` files. A file `src/a/b/c.y` which is
+/// statically compiled by lrpar can then be used in a crate with `lrpar_mod!("a/b/c.y")`.
 #[macro_export]
 macro_rules! lrpar_mod {
-    ($n:ident) => {
-        include!(concat!(env!("OUT_DIR"), "/", stringify!($n), ".rs"));
+    ($path:expr) => {
+        include!(concat!(env!("OUT_DIR"), "/", $path, ".rs"));
     };
 }
 

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -101,9 +101,9 @@
 //! use lrpar::lrpar_mod;
 //!
 //! // Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
-//! lrlex_mod!(calc_l);
+//! lrlex_mod!("calc.l");
 //! // Using `lrpar_mod!` brings the lexer for `calc.l` into scope.
-//! lrpar_mod!(calc_y);
+//! lrpar_mod!("calc.y");
 //!
 //! fn main() {
 //!     // We need to get a `LexerDef` for the `calc` language in order that we can lex input.


### PR DESCRIPTION
Previously one wrote:

```
    .process_file_in_src("a/b/grm.y")
```

but then:

```
    lrpar_mod!(grm_y)
```

(and the same sort of thing for lrlex_mod), which is inconsistent.

This commit changes things so that while `process_file_in_src` stays the same, rpar_mod/lrlex_mod now become:

```
    lrpar_mod!("a/b/grm.y")
```

i.e. both take a string argument with an identical filename. Inside Rust's build directory, these are stored with the same directory structure (something like `target/debug/build/project-hash/out/a/b/grm.y`) which means that, as a happy bonus, you can now have two grammars with the same name in different parts of the hierarchy (though you can't import both in the same file, as they share the same module name).

Making this change was a bit more involved than I expected, partly due to the horrors of macro_rules, which can't backtrack and thus can't do the string-ish processing we might have liked. Instead, if you pass something that isn't a string to lrpar_mod/lrlex_mod, you'll get an odd error.

Fixes https://github.com/softdevteam/grmtools/issues/132.