### PR TITLE
Configurable module names

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,14 @@ use std::env;
 use lrlex::lrlex_mod;
 use lrpar::lrpar_mod;
 
-// Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
-lrlex_mod!(calc_l);
-// Using `lrpar_mod!` brings the parser for `calc.y` into scope.
-lrpar_mod!(calc_y);
+// Using `lrlex_mod!` brings the lexer for `calc.l` into scope. By default the
+// module name will be `calc_l` (i.e. the file name, minus any extensions,
+// with a suffix of `_l`).
+lrlex_mod!("calc.l");
+// Using `lrpar_mod!` brings the parser for `calc.y` into scope. By default the
+// module name will be `calc_y` (i.e. the file name, minus any extensions,
+// with a suffix of `_y`).
+lrpar_mod!("calc.y");
 
 fn main() {
     // We need to get a `LexerDef` for the `calc` language in order that we can

--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@ lrlex_mod!("calc.l");
 lrpar_mod!("calc.y");
 
 fn main() {
-    // We need to get a `LexerDef` for the `calc` language in order that we can
-    // lex input.
+    // Get the `LexerDef` for the `calc` language.
     let lexerdef = calc_l::lexerdef();
     let args: Vec<String> = env::args().collect();
     // Now we create a lexer with the `lexer` method with which we can lex an

--- a/cfgrammar/src/lib/yacc/mod.rs
+++ b/cfgrammar/src/lib/yacc/mod.rs
@@ -11,7 +11,7 @@ pub use self::{
 };
 
 /// The particular Yacc variant this grammar makes use of.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum YaccKind {
     /// The original Yacc style as documented by
     /// [Johnson](http://dinosaur.compilertools.net/yacc/index.html),
@@ -23,7 +23,7 @@ pub enum YaccKind {
     Eco
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum YaccOriginalActionKind {
     /// Execute user-specified actions attached to each production; also requires a %actiontype
     /// declaration.

--- a/doc/src/quickstart.md
+++ b/doc/src/quickstart.md
@@ -190,13 +190,18 @@ use std::io::{self, BufRead, Write};
 use lrlex::lrlex_mod;
 use lrpar::lrpar_mod;
 
-// Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
+// Using `lrlex_mod!` brings the lexer for `calc.l` into scope. By default the
+// module name will be `calc_l` (i.e. the file name, minus any extensions,
+// with a suffix of `_l`).
 lrlex_mod!("calc.l");
-// Using `lrpar_mod!` brings the parser for `calc.y` into scope.
+// Using `lrpar_mod!` brings the parser for `calc.y` into scope. By default the
+// module name will be `calc_y` (i.e. the file name, minus any extensions,
+// with a suffix of `_y`).
 lrpar_mod!("calc.y");
 
 fn main() {
-    // We need to get a `LexerDef` for the `calc` language in order that we can lex input.
+    // We need to get a `LexerDef` for the `calc` language in order that we can
+    // lex input.
     let lexerdef = calc_l::lexerdef();
     let stdin = io::stdin();
     loop {

--- a/doc/src/quickstart.md
+++ b/doc/src/quickstart.md
@@ -200,8 +200,7 @@ lrlex_mod!("calc.l");
 lrpar_mod!("calc.y");
 
 fn main() {
-    // We need to get a `LexerDef` for the `calc` language in order that we can
-    // lex input.
+    // Get the `LexerDef` for the `calc` language.
     let lexerdef = calc_l::lexerdef();
     let stdin = io::stdin();
     loop {
@@ -212,7 +211,8 @@ fn main() {
                 if l.trim().is_empty() {
                     continue;
                 }
-                // Now we create a lexer with the `lexer` method with which we can lex an input.
+                // Now we create a lexer with the `lexer` method with which
+                // we can lex an input.
                 let lexer = lexerdef.lexer(l);
                 // Pass the lexer to the parser and lex and parse the input.
                 let (res, errs) = calc_y::parse(&lexer);

--- a/lrlex/examples/calclex/src/main.rs
+++ b/lrlex/examples/calclex/src/main.rs
@@ -3,7 +3,8 @@ use std::io::{self, BufRead, Write};
 use lrlex::lrlex_mod;
 use lrpar::Lexer;
 
-// Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
+// Using `lrlex_mod!` brings the lexer for `calc.l` into scope. By default the module name will be
+// `calc_l` (i.e. the file name, minus any extensions, with a suffix of `_l`).
 lrlex_mod!("calc.l");
 
 fn main() {

--- a/lrlex/examples/calclex/src/main.rs
+++ b/lrlex/examples/calclex/src/main.rs
@@ -8,7 +8,7 @@ use lrpar::Lexer;
 lrlex_mod!("calc.l");
 
 fn main() {
-    // We need to get a `LexerDef` for the `calc` language in order that we can lex input.
+    // Get the `LexerDef` for the `calc` language.
     let lexerdef = calc_l::lexerdef();
     let stdin = io::stdin();
     loop {

--- a/lrpar/README.md
+++ b/lrpar/README.md
@@ -101,7 +101,7 @@ lrlex_mod!("calc.l");
 lrpar_mod!("calc.y");
 
 fn main() {
-    // We need to get a `LexerDef` for the `calc` language in order that we can lex input.
+    // Get the `LexerDef` for the `calc` language.
     let lexerdef = calc_l::lexerdef();
     let stdin = io::stdin();
     loop {
@@ -112,7 +112,8 @@ fn main() {
                 if l.trim().is_empty() {
                     continue;
                 }
-                // Now we create a lexer with the `lexer` method with which we can lex an input.
+                // Now we create a lexer with the `lexer` method with which
+                // we can lex an input.
                 let lexer = lexerdef.lexer(l);
                 // Pass the lexer to the parser and lex and parse the input.
                 let (res, errs) = calc_y::parse(&lexer);

--- a/lrpar/examples/calc_actions/src/main.rs
+++ b/lrpar/examples/calc_actions/src/main.rs
@@ -3,9 +3,11 @@ use std::io::{self, BufRead, Write};
 use lrlex::lrlex_mod;
 use lrpar::lrpar_mod;
 
-// Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
+// Using `lrlex_mod!` brings the lexer for `calc.l` into scope. By default the module name will be
+// `calc_l` (i.e. the file name, minus any extensions, with a suffix of `_l`).
 lrlex_mod!("calc.l");
-// Using `lrpar_mod!` brings the parser for `calc.y` into scope.
+// Using `lrpar_mod!` brings the parser for `calc.y` into scope. By default the module name will be
+// `calc_y` (i.e. the file name, minus any extensions, with a suffix of `_y`).
 lrpar_mod!("calc.y");
 
 fn main() {

--- a/lrpar/examples/calc_actions/src/main.rs
+++ b/lrpar/examples/calc_actions/src/main.rs
@@ -11,7 +11,7 @@ lrlex_mod!("calc.l");
 lrpar_mod!("calc.y");
 
 fn main() {
-    // We need to get a `LexerDef` for the `calc` language in order that we can lex input.
+    // Get the `LexerDef` for the `calc` language.
     let lexerdef = calc_l::lexerdef();
     let stdin = io::stdin();
     loop {

--- a/lrpar/examples/calc_ast/src/main.rs
+++ b/lrpar/examples/calc_ast/src/main.rs
@@ -13,7 +13,7 @@ lrpar_mod!("calc.y");
 use calc_y::Expr;
 
 fn main() {
-    // We need to get a `LexerDef` for the `calc` language in order that we can lex input.
+    // Get the `LexerDef` for the `calc` language.
     let lexerdef = calc_l::lexerdef();
     let stdin = io::stdin();
     loop {

--- a/lrpar/examples/calc_ast/src/main.rs
+++ b/lrpar/examples/calc_ast/src/main.rs
@@ -3,9 +3,11 @@ use std::io::{self, BufRead, Write};
 use lrlex::lrlex_mod;
 use lrpar::lrpar_mod;
 
-// Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
+// Using `lrlex_mod!` brings the lexer for `calc.l` into scope. By default the module name will be
+// `calc_l` (i.e. the file name, minus any extensions, with a suffix of `_l`).
 lrlex_mod!("calc.l");
-// Using `lrpar_mod!` brings the parser for `calc.y` into scope.
+// Using `lrpar_mod!` brings the parser for `calc.y` into scope. By default the module name will be
+// `calc_y` (i.e. the file name, minus any extensions, with a suffix of `_y`).
 lrpar_mod!("calc.y");
 
 use calc_y::Expr;

--- a/lrpar/examples/calc_parsetree/src/main.rs
+++ b/lrpar/examples/calc_parsetree/src/main.rs
@@ -12,7 +12,7 @@ lrlex_mod!("calc.l");
 lrpar_mod!("calc.y");
 
 fn main() {
-    // We need to get a `LexerDef` for the `calc` language in order that we can lex input.
+    // Get the `LexerDef` for the `calc` language.
     let lexerdef = calc_l::lexerdef();
     let stdin = io::stdin();
     loop {

--- a/lrpar/examples/calc_parsetree/src/main.rs
+++ b/lrpar/examples/calc_parsetree/src/main.rs
@@ -4,9 +4,11 @@ use cfgrammar::RIdx;
 use lrlex::lrlex_mod;
 use lrpar::{lrpar_mod, Node};
 
-// Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
+// Using `lrlex_mod!` brings the lexer for `calc.l` into scope. By default the module name will be
+// `calc_l` (i.e. the file name, minus any extensions, with a suffix of `_l`).
 lrlex_mod!("calc.l");
-// Using `lrpar_mod!` brings the parser for `calc.y` into scope.
+// Using `lrpar_mod!` brings the parser for `calc.y` into scope. By default the module name will be
+// `calc_y` (i.e. the file name, minus any extensions, with a suffix of `_y`).
 lrpar_mod!("calc.y");
 
 fn main() {

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -100,9 +100,11 @@
 //! use lrlex::lrlex_mod;
 //! use lrpar::lrpar_mod;
 //!
-//! // Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
+//! // Using `lrlex_mod!` brings the lexer for `calc.l` into scope. By default the module name
+//! // will be `calc_l` (i.e. the file name, minus any extensions, with a suffix of `_l`).
 //! lrlex_mod!("calc.l");
-//! // Using `lrpar_mod!` brings the parser for `calc.y` into scope.
+//! // Using `lrpar_mod!` brings the parser for `calc.y` into scope. By default the module name
+//! // will be `calc_y` (i.e. the file name, minus any extensions, with a suffix of `_y`).
 //! lrpar_mod!("calc.y");
 //!
 //! fn main() {

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -108,7 +108,7 @@
 //! lrpar_mod!("calc.y");
 //!
 //! fn main() {
-//!     // We need to get a `LexerDef` for the `calc` language in order that we can lex input.
+//!     // Get the `LexerDef` for the `calc` language.
 //!     let lexerdef = calc_l::lexerdef();
 //!     let stdin = io::stdin();
 //!     loop {


### PR DESCRIPTION
This allows users to choose what module names are put in generated codes. The default mechanism remains as before, so this is a backwards compatible change.