### PR TITLE
Have buildbot test the build with stable.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -6,12 +6,14 @@ export CARGO_HOME="`pwd`/.cargo"
 export RUSTUP_HOME="`pwd`/.rustup"
 
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh
-sh rustup.sh --default-host x86_64-unknown-linux-gnu --default-toolchain nightly -y --no-modify-path
-
+sh rustup.sh -y --no-modify-path
 export PATH=`pwd`/.cargo/bin/:$PATH
 
+rustup toolchain install nightly
 rustup component add --toolchain nightly rustfmt-preview || cargo +nightly install --force rustfmt-nightly
-
 cargo +nightly fmt --all -- --check
+
+rustup toolchain install stable
+rustup default stable
 cargo test
 cargo test --release


### PR DESCRIPTION
Previously we were only testing with nightly, which might unintentionally allow us to use features that aren't available on stable.