### PR TITLE
lrlex should exit with a return code of 1 if it can't lex input.

### DIFF
--- a/lrlex/src/main.rs
+++ b/lrlex/src/main.rs
@@ -64,7 +64,10 @@ fn main() {
                 lexerdef.get_rule_by_id(l.tok_id()).name.as_ref().unwrap(),
                 &input[l.start()..l.end()]
             ),
-            Err(e) => println!("{:?}", e)
+            Err(e) => {
+                println!("{:?}", e);
+                process::exit(1);
+            }
         }
     }
 }


### PR DESCRIPTION
This used to be the behaviour, but at some point was lost.