### PR TITLE
Move from "point" indexes to spans

### DIFF
--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -7,7 +7,7 @@ use std::{
 use num_traits::{PrimInt, Unsigned};
 use regex::{self, Regex, RegexBuilder};
 
-use lrpar::{LexError, Lexeme, Lexer};
+use lrpar::{LexError, Lexeme, Lexer, Span};
 
 pub struct Rule<StorageT> {
     /// If `Some`, the ID that lexemes created against this rule will be given (lrlex gives such
@@ -204,14 +204,14 @@ impl<'a, StorageT: Copy + Eq + Hash + PrimInt + Unsigned> LRLexer<'a, StorageT> 
                             lexemes.push(Ok(Lexeme::new(tok_id, old_i, Some(longest))));
                         }
                         None => {
-                            lexemes.push(Err(LexError { idx: old_i }));
+                            lexemes.push(Err(LexError::new(Span::new(old_i, old_i))));
                             break;
                         }
                     }
                 }
                 i += longest;
             } else {
-                lexemes.push(Err(LexError { idx: old_i }));
+                lexemes.push(Err(LexError::new(Span::new(old_i, old_i))));
                 break;
             }
         }
@@ -231,12 +231,16 @@ impl<'a, StorageT: Copy + Eq + Hash + PrimInt + Unsigned> Lexer<StorageT>
         Box::new(self.lexemes.iter().cloned())
     }
 
-    fn line_col(&self, i: usize) -> (usize, usize) {
-        if i > self.s.len() {
-            panic!("Offset {} exceeds known input length {}", i, self.s.len());
+    fn line_col(&self, span: Span) -> ((usize, usize), (usize, usize)) {
+        if span.end() > self.s.len() {
+            panic!(
+                "Span {:?} exceeds known input length {}",
+                span,
+                self.s.len()
+            );
         }
 
-        fn line_col_off<StorageT>(lexer: &LRLexer<StorageT>, i: usize) -> (usize, usize) {
+        fn lc_byte<StorageT>(lexer: &LRLexer<StorageT>, i: usize) -> (usize, usize) {
             if lexer.newlines.is_empty() || i < lexer.newlines[0] {
                 return (1, i);
             }
@@ -252,9 +256,16 @@ impl<'a, StorageT: Copy + Eq + Hash + PrimInt + Unsigned> Lexer<StorageT>
             )
         }
 
-        let (line_idx, col_byte) = line_col_off(self, i);
-        let line = self.surrounding_line_str(i);
-        (line_idx, line[..col_byte].chars().count() + 1)
+        fn lc_char<StorageT: Copy + Eq + Hash + PrimInt + Unsigned>(
+            lexer: &LRLexer<StorageT>,
+            i: usize
+        ) -> (usize, usize) {
+            let (line_idx, col_byte) = lc_byte(lexer, i);
+            let line = lexer.surrounding_line_str(i);
+            (line_idx, line[..col_byte].chars().count() + 1)
+        }
+
+        (lc_char(self, span.start()), lc_char(self, span.end()))
     }
 
     fn surrounding_line_str(&self, i: usize) -> &str {
@@ -333,8 +344,11 @@ mod test {
         let lexerdef = parse_lex::<u8>(&src).unwrap();
         match lexerdef.lexer(&"abc").iter().nth(0).unwrap() {
             Ok(_) => panic!("Invalid input lexed"),
-            Err(LexError { idx: 0 }) => (),
-            Err(e) => panic!("Incorrect error returned {:?}", e)
+            Err(e) => {
+                if e.span().start() != 0 || e.span().end() != 0 {
+                    panic!("Incorrect span returned {:?}", e.span());
+                }
+            }
         };
     }
 
@@ -409,22 +423,22 @@ if 'IF'
         let lexer = lexerdef.lexer("a b c");
         let lexemes = lexer.iter().map(|x| x.unwrap()).collect::<Vec<_>>();
         assert_eq!(lexemes.len(), 3);
-        assert_eq!(lexer.line_col(lexemes[1].start()), (1, 3));
+        assert_eq!(lexer.line_col(lexemes[1].span()), ((1, 3), (1, 4)));
         assert_eq!(lexer.surrounding_line_str(lexemes[1].start()), "a b c");
 
         let lexer = lexerdef.lexer("a b c\n");
         let lexemes = lexer.iter().map(|x| x.unwrap()).collect::<Vec<_>>();
         assert_eq!(lexemes.len(), 3);
-        assert_eq!(lexer.line_col(lexemes[1].start()), (1, 3));
+        assert_eq!(lexer.line_col(lexemes[1].span()), ((1, 3), (1, 4)));
         assert_eq!(lexer.surrounding_line_str(lexemes[1].start()), "a b c");
 
         let lexer = lexerdef.lexer(" a\nb\n  c d");
         let lexemes = lexer.iter().map(|x| x.unwrap()).collect::<Vec<_>>();
         assert_eq!(lexemes.len(), 4);
-        assert_eq!(lexer.line_col(lexemes[0].start()), (1, 2));
-        assert_eq!(lexer.line_col(lexemes[1].start()), (2, 1));
-        assert_eq!(lexer.line_col(lexemes[2].start()), (3, 3));
-        assert_eq!(lexer.line_col(lexemes[3].start()), (3, 5));
+        assert_eq!(lexer.line_col(lexemes[0].span()), ((1, 2), (1, 3)));
+        assert_eq!(lexer.line_col(lexemes[1].span()), ((2, 1), (2, 2)));
+        assert_eq!(lexer.line_col(lexemes[2].span()), ((3, 3), (3, 4)));
+        assert_eq!(lexer.line_col(lexemes[3].span()), ((3, 5), (3, 6)));
         assert_eq!(lexer.surrounding_line_str(lexemes[0].start()), " a");
         assert_eq!(lexer.surrounding_line_str(lexemes[1].start()), "b");
         assert_eq!(lexer.surrounding_line_str(lexemes[2].start()), "  c d");
@@ -445,9 +459,9 @@ if 'IF'
         let lexer = lexerdef.lexer(" a\n❤ b");
         let lexemes = lexer.iter().map(|x| x.unwrap()).collect::<Vec<_>>();
         assert_eq!(lexemes.len(), 3);
-        assert_eq!(lexer.line_col(lexemes[0].start()), (1, 2));
-        assert_eq!(lexer.line_col(lexemes[1].start()), (2, 1));
-        assert_eq!(lexer.line_col(lexemes[2].start()), (2, 3));
+        assert_eq!(lexer.line_col(lexemes[0].span()), ((1, 2), (1, 3)));
+        assert_eq!(lexer.line_col(lexemes[1].span()), ((2, 1), (2, 2)));
+        assert_eq!(lexer.line_col(lexemes[2].span()), ((2, 3), (2, 4)));
         assert_eq!(lexer.surrounding_line_str(lexemes[0].start()), " a");
         assert_eq!(lexer.surrounding_line_str(lexemes[1].start()), "❤ b");
         assert_eq!(lexer.surrounding_line_str(lexemes[2].start()), "❤ b");
@@ -467,7 +481,7 @@ if 'IF'
 
         let lexer = lexerdef.lexer("a b c");
 
-        lexer.line_col(100);
+        lexer.line_col(Span::new(100, 100));
     }
 
     #[test]
@@ -490,8 +504,11 @@ if 'IF'
 
         match lexerdef.lexer(&" a ").iter().nth(0).unwrap() {
             Ok(_) => panic!("Invalid input lexed"),
-            Err(LexError { idx: 1 }) => (),
-            Err(e) => panic!("Incorrect error returned {:?}", e)
+            Err(e) => {
+                if e.span().start() != 1 || e.span().end() != 1 {
+                    panic!("Incorrect span returned {:?}", e.span());
+                }
+            }
         };
     }
 }

--- a/lrpar/cttests/src/calc_actiontype.test
+++ b/lrpar/cttests/src/calc_actiontype.test
@@ -19,7 +19,7 @@ grammar: |
                 match $lexer.lexeme_str(&l).parse::<u64>() {
                     Ok(v) => Ok(v),
                     Err(_) => {
-                        let (_, col) = $lexer.line_col(l.start());
+                        let ((_, col), _) = $lexer.line_col(l.span());
                         eprintln!("Error at column {}: '{}' cannot be represented as a u64",
                                   col,
                                   $lexer.lexeme_str(&l));

--- a/lrpar/src/lib/lex.rs
+++ b/lrpar/src/lib/lex.rs
@@ -55,9 +55,13 @@ pub trait Lexer<StorageT: Hash + PrimInt + Unsigned> {
     /// If the span exceeds the known input.
     fn line_col(&self, span: Span) -> ((usize, usize), (usize, usize));
 
-    /// Return the line containing the byte at position `off`. Panics if the offset exceeds the
-    /// known input.
-    fn surrounding_line_str(&self, off: usize) -> &str;
+    /// Return the lines containing the input at `span` (including the text before and after the
+    /// `Span` on the lines that the `Span` starts and ends).
+    ///
+    /// # Panics
+    ///
+    /// If the span exceeds the known input.
+    fn span_lines_str(&self, span: Span) -> &str;
 }
 
 /// A `Lexeme` represents a segment of the user's input that conforms to a known type. Note that

--- a/lrpar/src/lib/lex.rs
+++ b/lrpar/src/lib/lex.rs
@@ -5,6 +5,8 @@ use std::{error::Error, fmt, hash::Hash, mem::size_of};
 use num_traits::{PrimInt, Unsigned};
 use static_assertions::const_assert;
 
+use crate::Span;
+
 /// A Lexing error.
 #[derive(Copy, Clone, Debug)]
 pub struct LexError {
@@ -105,6 +107,10 @@ impl<StorageT: Copy> Lexeme<StorageT> {
             const_assert!(size_of::<usize>() >= size_of::<u32>());
             self.len as usize
         }
+    }
+
+    pub fn span(&self) -> Span {
+        Span::new(self.start(), self.len())
     }
 
     /// Returns `true` if this lexeme was inserted as the result of error recovery, or `false`

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -207,6 +207,7 @@ pub use cfgrammar::RIdx;
 
 /// A `Span` records the start/end/length of a portion of the input (i.e. it doesn't hold a
 /// reference / copy of the actual input).
+#[derive(Clone, Copy, Debug)]
 pub struct Span {
     start: usize,
     end: usize

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -204,3 +204,39 @@ macro_rules! lrpar_mod {
 
 #[doc(hidden)]
 pub use cfgrammar::RIdx;
+
+/// A `Span` records the start/end/length of a portion of the input (i.e. it doesn't hold a
+/// reference / copy of the actual input).
+pub struct Span {
+    start: usize,
+    end: usize
+}
+
+impl Span {
+    /// Create a new span starting at byte `start` and ending at byte `end`.
+    ///
+    /// # Panics
+    ///
+    /// If `end` is less than `start`.
+    pub fn new(start: usize, end: usize) -> Self {
+        if end < start {
+            panic!("Span starts ({}) after it ends ({})!", start, end);
+        }
+        Span { start, end }
+    }
+
+    /// Byte offset of the start of the span.
+    pub fn start(&self) -> usize {
+        self.start
+    }
+
+    /// Byte offset of the end of the span.
+    pub fn end(&self) -> usize {
+        self.end
+    }
+
+    /// Length in bytes of the span.
+    pub fn len(&self) -> usize {
+        self.end - self.start
+    }
+}

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -621,11 +621,11 @@ impl<StorageT: Hash + PrimInt + Unsigned> LexParseError<StorageT> {
     ) -> String {
         match self {
             LexParseError::LexError(e) => {
-                let (line, col) = lexer.line_col(e.idx);
+                let ((line, col), _) = lexer.line_col(e.span());
                 format!("Lexing error at line {} column {}.", line, col)
             }
             LexParseError::ParseError(e) => {
-                let (line, col) = lexer.line_col(e.lexeme().start());
+                let ((line, col), _) = lexer.line_col(e.lexeme().span());
                 let mut out = format!("Parsing error at line {} column {}.", line, col);
                 let repairs_len = e.repairs().len();
                 if repairs_len == 0 {
@@ -864,7 +864,7 @@ pub(crate) mod test {
     use regex::Regex;
 
     use super::*;
-    use crate::lex::Lexeme;
+    use crate::{lex::Lexeme, Span};
 
     pub(crate) fn do_parse(
         rcvry_kind: RecoveryKind,
@@ -937,7 +937,7 @@ pub(crate) mod test {
             Box::new(self.lexemes.iter().map(|x| Ok(*x)))
         }
 
-        fn line_col(&self, _: usize) -> (usize, usize) {
+        fn line_col(&self, _: Span) -> ((usize, usize), (usize, usize)) {
             unreachable!();
         }
 

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -941,7 +941,7 @@ pub(crate) mod test {
             unreachable!();
         }
 
-        fn surrounding_line_str(&self, _: usize) -> &str {
+        fn span_lines_str(&self, _: Span) -> &str {
             unreachable!();
         }
 


### PR DESCRIPTION
Previously we identified lexemes (and points of errors) as happening at a single byte offset in the index. This is sometimes sufficient (e.g. for lexing errors), but parse errors are more naturally expressed as happening across a span of the input.

This PR thus introduces the concept of a "span" [*]. A span tells one a start and end byte offset in input. This is a breaking API change, and has several knock on effects, though much of the PR is inevitably minor churn. One advantage of spans can be seen in the [`test_multiline_lexeme`](https://github.com/softdevteam/grmtools/commit/8620ac5eeadf2ab6bf235e31801db0b378a2575f#diff-1a9216bfbedf1a82401b1d47edc4a375R527) test.

[*] The terminology is from rustc, though the concept is as old as the hills -- Converge did this properly, and I have no good justification for why I didn't start things properly off in grmtools. Oh well.