### PR TITLE
Enable the `$span` variable by default.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,10 @@
    * The `$span` special variable now returns a `Span` rather than `(usize,
      usize`).
 
+* The `$span` special variable is now enabled at all times and no longer needs
+  to be turned on with `CTBuilder::span_var`. This function has thus been
+  removed.
+
 
 # grmtools 0.5.1 (2020-01-02)
 

--- a/doc/src/actioncode.md
+++ b/doc/src/actioncode.md
@@ -18,12 +18,9 @@ Action code is normal Rust code with the addition of the following special varia
    stored by the grammar without copying memory.
 
  * `$span` is a
-   [`lrpar::Span`](https://softdevteam.github.io/grmtools/master/api/lrpar/struct.CTParserBuilder.html)
+   [`lrpar::Span`](https://softdevteam.github.io/grmtools/master/api/lrpar/struct.Span.html)
    tuple (with both elements of type `usize`) which captures how much of the
-   user's input the current production matched. This can be useful when storing
-   debugging information. Note that this variable is not enabled by default as
-   it may slow parsing down: use `CTParserBuilder::span_var(true)` to enable
-   it.
+   user's input the current production matched.
 
  * `$$` is equivalent to `$` in normal Rust code.
 

--- a/lrpar/cttests/build.rs
+++ b/lrpar/cttests/build.rs
@@ -52,7 +52,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             outp.set_extension("rs");
             let lex_rule_ids_map = CTParserBuilder::new()
                 .yacckind(yacckind)
-                .span_var(true)
                 .process_file(pg.to_str().unwrap(), &outp)?;
 
             let mut outl = PathBuf::from(&out_dir);

--- a/lrpar/examples/calc_ast/build.rs
+++ b/lrpar/examples/calc_ast/build.rs
@@ -11,7 +11,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ".l" for lrlex).
     let lex_rule_ids_map = CTParserBuilder::new()
         .yacckind(YaccKind::Grmtools)
-        .span_var(true)
         .process_file_in_src("calc.y")?;
     LexerBuilder::new()
         .rule_ids_map(lex_rule_ids_map)

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -104,7 +104,6 @@ where
     recoverer: RecoveryKind,
     yacckind: Option<YaccKind>,
     error_on_conflicts: bool,
-    span_var: bool,
     conflicts: Option<(
         YaccGrammar<StorageT>,
         StateGraph<StorageT>,
@@ -158,7 +157,6 @@ where
             recoverer: RecoveryKind::MF,
             yacckind: None,
             error_on_conflicts: true,
-            span_var: false,
             conflicts: None,
             phantom: PhantomData
         }
@@ -188,13 +186,6 @@ where
     /// any Shift/Reduce or Reduce/Reduce conflicts. Defaults to `true`.
     pub fn error_on_conflicts(mut self, b: bool) -> Self {
         self.error_on_conflicts = b;
-        self
-    }
-
-    /// If set to true, action code will be able to reference the `$span` variable. Note that
-    /// enabling this feature might slow the parser down. Defaults to `false`.
-    pub fn span_var(mut self, b: bool) -> Self {
-        self.span_var = b;
         self
     }
 
@@ -442,7 +433,6 @@ where
             "   Error on conflicts: {:?}\n",
             self.error_on_conflicts
         ));
-        cache.push_str(&format!("   Span var: {:?}\n", self.span_var));
 
         // Record the rule IDs map
         for tidx in grm.iter_tidxs() {
@@ -799,7 +789,7 @@ where
                                 format!("{prefix}lexer", prefix = ACTION_PREFIX).as_str()
                             );
                             last = last + off + "$lexer".len();
-                        } else if self.span_var && pre_action[last + off..].starts_with("$span") {
+                        } else if pre_action[last + off..].starts_with("$span") {
                             outs.push_str(&pre_action[last..last + off]);
                             outs.push_str(format!("{prefix}span", prefix = ACTION_PREFIX).as_str());
                             last = last + off + "$span".len();


### PR DESCRIPTION
Also remove the `span_var(bool)` function of `CTBuilder`. Maybe one day this will make sense, but at the moment it has no performance effect, so its presence is misleading for users.