### PR TITLE
Deprecate Lexeme methods

### DIFF
--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -344,11 +344,11 @@ mod test {
         assert_eq!(lexemes.len(), 2);
         let lex1 = lexemes[0];
         assert_eq!(lex1.tok_id(), 1u8);
-        assert_eq!(lex1.start(), 0);
+        assert_eq!(lex1.span().start(), 0);
         assert_eq!(lex1.len(), 3);
         let lex2 = lexemes[1];
         assert_eq!(lex2.tok_id(), 0);
-        assert_eq!(lex2.start(), 4);
+        assert_eq!(lex2.span().start(), 4);
         assert_eq!(lex2.len(), 3);
     }
 
@@ -391,11 +391,11 @@ if 'IF'
         assert_eq!(lexemes.len(), 2);
         let lex1 = lexemes[0];
         assert_eq!(lex1.tok_id(), 1u8);
-        assert_eq!(lex1.start(), 0);
+        assert_eq!(lex1.span().start(), 0);
         assert_eq!(lex1.len(), 3);
         let lex2 = lexemes[1];
         assert_eq!(lex2.tok_id(), 0);
-        assert_eq!(lex2.start(), 4);
+        assert_eq!(lex2.span().start(), 4);
         assert_eq!(lex2.len(), 2);
     }
 
@@ -414,15 +414,15 @@ if 'IF'
         let lexemes = lexer.iter().map(|x| x.unwrap()).collect::<Vec<_>>();
         assert_eq!(lexemes.len(), 3);
         let lex1 = lexemes[0];
-        assert_eq!(lex1.start(), 0);
+        assert_eq!(lex1.span().start(), 0);
         assert_eq!(lex1.len(), 1);
         assert_eq!(lexer.span_str(lex1.span()), "a");
         let lex2 = lexemes[1];
-        assert_eq!(lex2.start(), 2);
+        assert_eq!(lex2.span().start(), 2);
         assert_eq!(lex2.len(), 3);
         assert_eq!(lexer.span_str(lex2.span()), "❤");
         let lex3 = lexemes[2];
-        assert_eq!(lex3.start(), 6);
+        assert_eq!(lex3.span().start(), 6);
         assert_eq!(lex3.len(), 1);
         assert_eq!(lexer.span_str(lex3.span()), "a");
     }

--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -345,11 +345,11 @@ mod test {
         let lex1 = lexemes[0];
         assert_eq!(lex1.tok_id(), 1u8);
         assert_eq!(lex1.span().start(), 0);
-        assert_eq!(lex1.len(), 3);
+        assert_eq!(lex1.span().len(), 3);
         let lex2 = lexemes[1];
         assert_eq!(lex2.tok_id(), 0);
         assert_eq!(lex2.span().start(), 4);
-        assert_eq!(lex2.len(), 3);
+        assert_eq!(lex2.span().len(), 3);
     }
 
     #[test]
@@ -392,11 +392,11 @@ if 'IF'
         let lex1 = lexemes[0];
         assert_eq!(lex1.tok_id(), 1u8);
         assert_eq!(lex1.span().start(), 0);
-        assert_eq!(lex1.len(), 3);
+        assert_eq!(lex1.span().len(), 3);
         let lex2 = lexemes[1];
         assert_eq!(lex2.tok_id(), 0);
         assert_eq!(lex2.span().start(), 4);
-        assert_eq!(lex2.len(), 2);
+        assert_eq!(lex2.span().len(), 2);
     }
 
     #[test]
@@ -415,15 +415,15 @@ if 'IF'
         assert_eq!(lexemes.len(), 3);
         let lex1 = lexemes[0];
         assert_eq!(lex1.span().start(), 0);
-        assert_eq!(lex1.len(), 1);
+        assert_eq!(lex1.span().len(), 1);
         assert_eq!(lexer.span_str(lex1.span()), "a");
         let lex2 = lexemes[1];
         assert_eq!(lex2.span().start(), 2);
-        assert_eq!(lex2.len(), 3);
+        assert_eq!(lex2.span().len(), 3);
         assert_eq!(lexer.span_str(lex2.span()), "❤");
         let lex3 = lexemes[2];
         assert_eq!(lex3.span().start(), 6);
-        assert_eq!(lex3.len(), 1);
+        assert_eq!(lex3.span().len(), 1);
         assert_eq!(lexer.span_str(lex3.span()), "a");
     }
 

--- a/lrlex/src/main.rs
+++ b/lrlex/src/main.rs
@@ -62,7 +62,7 @@ fn main() {
             Ok(l) => println!(
                 "{} {}",
                 lexerdef.get_rule_by_id(l.tok_id()).name.as_ref().unwrap(),
-                &input[l.start()..l.end()]
+                &input[l.span().start()..l.span().end()]
             ),
             Err(e) => {
                 println!("{:?}", e);

--- a/lrpar/examples/calc_parsetree/src/main.rs
+++ b/lrpar/examples/calc_parsetree/src/main.rs
@@ -79,7 +79,9 @@ impl<'a> Eval<'a> {
             } if ridx == calc_y::R_FACTOR => {
                 if nodes.len() == 1 {
                     if let Node::Term { lexeme } = nodes[0] {
-                        self.s[lexeme.start()..lexeme.end()].parse().unwrap()
+                        self.s[lexeme.span().start()..lexeme.span().end()]
+                            .parse()
+                            .unwrap()
                     } else {
                         unreachable!();
                     }

--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -257,7 +257,7 @@ where
             let next_lexeme = self.parser.next_lexeme(n.laidx);
             let new_lexeme = Lexeme::new(
                 StorageT::from(u32::from(tidx)).unwrap(),
-                next_lexeme.start(),
+                next_lexeme.span().start(),
                 None
             );
             let (new_laidx, n_pstack) = self.parser.lr_cactus(

--- a/lrpar/src/lib/lex.rs
+++ b/lrpar/src/lib/lex.rs
@@ -105,6 +105,7 @@ impl<StorageT: Copy> Lexeme<StorageT> {
     }
 
     /// Byte offset of the start of the lexeme
+    #[deprecated(since = "0.6.1", note = "Please use span().start() instead")]
     pub fn start(&self) -> usize {
         self.start
     }
@@ -134,7 +135,7 @@ impl<StorageT: Copy> Lexeme<StorageT> {
     }
 
     pub fn span(&self) -> Span {
-        Span::new(self.start(), self.end())
+        Span::new(self.start, self.end())
     }
 
     /// Returns `true` if this lexeme was inserted as the result of error recovery, or `false`

--- a/lrpar/src/lib/lex.rs
+++ b/lrpar/src/lib/lex.rs
@@ -38,20 +38,20 @@ impl fmt::Display for LexError {
 /// The trait which all lexers which want to interact with `lrpar` must implement.
 pub trait Lexer<StorageT: Hash + PrimInt + Unsigned> {
     /// Iterate over all the lexemes in this lexer. Note that:
-    ///   * The lexer may or may not stop after the first `LexError` is encountered.
+    ///   * The lexer may or may not stop after the first [LexError] is encountered.
     ///   * There are no guarantees about whether the lexer caches anything if this method is
     ///     called more than once (i.e. it might be slow to call this more than once).
     fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = Result<Lexeme<StorageT>, LexError>> + 'a>;
 
-    /// Return the user input associated with a [`Span`](::Span).
+    /// Return the user input associated with a [Span].
     ///
     /// # Panics
     ///
     /// If the span exceeds the known input.
     fn span_str(&self, span: Span) -> &str;
 
-    /// Return the lines containing the input at `span` (including the text before and after the
-    /// `Span` on the lines that the `Span` starts and ends).
+    /// Return the lines containing the input at `span` (including *all* the text on the lines
+    /// that `span` starts and ends on).
     ///
     /// # Panics
     ///
@@ -72,7 +72,7 @@ pub trait Lexer<StorageT: Hash + PrimInt + Unsigned> {
 /// match the regular expressions `[0-9]+`), error recovery might cause a lexeme to have a length
 /// of 0. Users can detect the difference between a lexeme with an intentionally zero length from a
 /// lexeme with zero length due to error recovery through the
-/// [`inserted`](struct.Lexeme.html#method.inserted) method.
+/// [`inserted`](Lexeme::inserted) method.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Lexeme<StorageT> {
     // The long-term aim is to pack this struct so that len can be longer than u32 while everything
@@ -127,6 +127,7 @@ impl<StorageT: Copy> Lexeme<StorageT> {
         self.span().len()
     }
 
+    /// Obtain this `Lexeme`'s [Span].
     pub fn span(&self) -> Span {
         let end = if self.len == u32::max_value() {
             self.start

--- a/lrpar/src/lib/lex.rs
+++ b/lrpar/src/lib/lex.rs
@@ -114,12 +114,9 @@ impl<StorageT: Copy> Lexeme<StorageT> {
     ///
     /// Note that if this lexeme was inserted by error recovery, it will end at the same place it
     /// started (i.e. `self.start() == self.end()`).
+    #[deprecated(since = "0.6.1", note = "Please use span().end() instead")]
     pub fn end(&self) -> usize {
-        if self.len == u32::max_value() {
-            self.start
-        } else {
-            self.start + (self.len as usize)
-        }
+        self.span().end()
     }
 
     /// Length in bytes of the lexeme.
@@ -135,7 +132,12 @@ impl<StorageT: Copy> Lexeme<StorageT> {
     }
 
     pub fn span(&self) -> Span {
-        Span::new(self.start, self.end())
+        let end = if self.len == u32::max_value() {
+            self.start
+        } else {
+            self.start + (self.len as usize)
+        };
+        Span::new(self.start, end)
     }
 
     /// Returns `true` if this lexeme was inserted as the result of error recovery, or `false`

--- a/lrpar/src/lib/lex.rs
+++ b/lrpar/src/lib/lex.rs
@@ -122,13 +122,9 @@ impl<StorageT: Copy> Lexeme<StorageT> {
     /// Length in bytes of the lexeme.
     ///
     /// Note that if this lexeme was inserted by error recovery, it will have a length of 0.
+    #[deprecated(since = "0.6.1", note = "Please use span().len() instead")]
     pub fn len(&self) -> usize {
-        if self.len == u32::max_value() {
-            0
-        } else {
-            const_assert!(size_of::<usize>() >= size_of::<u32>());
-            self.len as usize
-        }
+        self.span().len()
     }
 
     pub fn span(&self) -> Span {

--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -608,7 +608,7 @@ where
                 let next_lexeme = parser.next_lexeme(laidx);
                 let new_lexeme = Lexeme::new(
                     StorageT::from(u32::from(tidx)).unwrap(),
-                    next_lexeme.start(),
+                    next_lexeme.span().start(),
                     None
                 );
                 parser.lr_upto(

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -240,4 +240,9 @@ impl Span {
     pub fn len(&self) -> usize {
         self.end - self.start
     }
+
+    /// Returns `true` if this `Span` covers 0 bytes, or `false` otherwise.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -52,7 +52,7 @@ where
                 Node::Term { lexeme } => {
                     let tidx = TIdx(lexeme.tok_id());
                     let tn = grm.token_name(tidx).unwrap();
-                    let lt = &input[lexeme.start()..lexeme.end()];
+                    let lt = &input[lexeme.span().start()..lexeme.span().end()];
                     s.push_str(&format!("{} {}\n", tn, lt));
                 }
                 Node::Nonterm { ridx, ref nodes } => {

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -482,7 +482,7 @@ where
             } else {
                 debug_assert!(laidx > 0);
                 let last_la = self.lexemes[laidx - 1];
-                last_la.end()
+                last_la.span().end()
             };
 
             Lexeme::new(


### PR DESCRIPTION
This PR mostly concerns itself with deprecating methods in `Lexeme` that can now be accessed via `Span`s. These methods do no great harm, and internally to lrpar, they're marginally faster. However, there's little point in exposing a public API that duplicates information.