### PR TITLE
Update example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ use cfgrammar::yacc::YaccKind;
 use lrlex::LexerBuilder;
 use lrpar::{CTParserBuilder};
 
-fn main() -> Result<(), Box<std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let lex_rule_ids_map = CTParserBuilder::new()
         .yacckind(YaccKind::Grmtools)
         .process_file_in_src("grammar.y")?;


### PR DESCRIPTION
Use explicit dyn trait to disable warning by rustc.

```
warning: trait objects without an explicit `dyn` are deprecated
 --> src/main.rs:5:29
  |
5 | fn main() -> Result<(), Box<std::error::Error>> {
  |                             ^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn std::error::Error`
  |
  = note: `#[warn(bare_trait_objects)]` on by default
```