### PR TITLE
Fix two Clippy warnings and suppress two others.

### DIFF
--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -804,6 +804,7 @@ where
 
 /// Return the cost of a minimal string for each rule in this grammar. The cost of a
 /// token is specified by the user-defined `token_cost` function.
+#[allow(clippy::unnecessary_unwrap)]
 fn rule_min_costs<StorageT: 'static + PrimInt + Unsigned>(
     grm: &YaccGrammar<StorageT>,
     token_costs: &[u8]
@@ -892,6 +893,7 @@ where
 /// Return the cost of the maximal string for each rule in this grammar (u32::max_val()
 /// representing "this rule can generate strings of infinite length"). The cost of a
 /// token is specified by the user-defined `token_cost` function.
+#[allow(clippy::unnecessary_unwrap)]
 fn rule_max_costs<StorageT: 'static + PrimInt + Unsigned>(
     grm: &YaccGrammar<StorageT>,
     token_costs: &[u8]

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -297,7 +297,7 @@ where
                     let prior = *pstack.last().unwrap();
                     pstack.push(self.stable.goto(prior, ridx).unwrap());
 
-                    let span = if spans.len() == 0 {
+                    let span = if spans.is_empty() {
                         Span::new(0, 0)
                     } else if pop_idx - 1 < spans.len() {
                         Span::new(spans[pop_idx - 1].start(), spans[spans.len() - 1].end())
@@ -410,7 +410,7 @@ where
                     let pop_idx = pstack.len() - self.grm.prod(pidx).len();
                     if let Some(ref mut astack_uw) = *astack {
                         if let Some(ref mut spans_uw) = *spans {
-                            let span = if spans_uw.len() == 0 {
+                            let span = if spans_uw.is_empty() {
                                 Span::new(0, 0)
                             } else if pop_idx - 1 < spans_uw.len() {
                                 Span::new(


### PR DESCRIPTION
The warnings are about unnecessary unwraps, but I've now tried 3 separate ways of rewriting the code that offends Clippy and each time it becomes harder to understand. I think the "unnecessary unwrap" warning is generally the right one, but that the particular code fragments it complains about here are an unusual exception: I've therefore suppressed the warnings only in the two functions in question.