### PR TITLE
Add links from the book to the crates and source.

### DIFF
--- a/doc/src/README.md
+++ b/doc/src/README.md
@@ -1,7 +1,7 @@
 # grmtools
 
-grmtools is a suite of Rust libraries and binaries for parsing text, both at
-compile-time, and run-time. Most users will probably be interested in the
-compile-time Yacc feature, which allows traditional `.y` files to be used mostly
-unchanged in Rust. See the [Quickstart Guide](quickstart.md) for a quick
-introduction to this feature.
+[grmtools](https://github.com/softdevteam/grmtools/) is a suite of Rust
+libraries and binaries for parsing text, both at compile-time, and run-time.
+Most users will probably be interested in the compile-time Yacc feature, which
+allows traditional `.y` files to be used mostly unchanged in Rust. See the
+[Quickstart Guide](quickstart.md) for a quick introduction to this feature.

--- a/doc/src/cfgrammar.md
+++ b/doc/src/cfgrammar.md
@@ -1,7 +1,9 @@
 # `cfgrammar`
 
-`cfgrammar` reads in grammar files, processes them, and provides a convenient
-API for operating with them. Most users only need to think about `cfgrammar` to the
+`cfgrammar` ([crate](https://crates.io/crates/cfgrammar);
+[source](https://github.com/softdevteam/grmtools/tree/master/cfgrammar)) reads
+in grammar files, processes them, and provides a convenient API for operating
+with them. Most users only need to think about `cfgrammar` to the
 extent that they are required to use it to specify what Yacc variant they wish
 to use.
 

--- a/doc/src/libsandtools.md
+++ b/doc/src/libsandtools.md
@@ -1,4 +1,4 @@
 # The individual libraries and tools
 
-`grmtools` consists of several libraries and command-line tools. The following
-sections describe each.
+[grmtools](https://github.com/softdevteam/grmtools/) consists of several
+libraries and command-line tools. The following sections describe each.

--- a/doc/src/lrlex.md
+++ b/doc/src/lrlex.md
@@ -1,7 +1,8 @@
 # `lrlex`
 
-`lrlex` is a partial replacement for
-[`lex`](http://dinosaur.compilertools.net/lex/index.html) /
+`lrlex` ([crate](https://crates.io/crates/lrlex);
+[source](https://github.com/softdevteam/grmtools/tree/master/lrlex)) is a
+partial replacement for [`lex`](http://dinosaur.compilertools.net/lex/index.html) /
 [`flex`](https://westes.github.io/flex/manual/). It takes an input string and
 splits it into *lexemes* based on a `.l` file. Unfortunately, many real-world
 languages have corner cases which exceed the power that `lrlex` can provide.

--- a/doc/src/lrpar.md
+++ b/doc/src/lrpar.md
@@ -1,5 +1,7 @@
 # `lrpar`
 
-`lrpar` is the LR parser library aspect of grmtools. It takes in streams of
-lexemes and parses them, determining if they successfully match a grammar or
-not; if not, it can optionally recover from errors.
+`lrpar` ([crate](https://crates.io/crates/lrpar);
+[source](https://github.com/softdevteam/grmtools/tree/master/lrpar)) is the LR
+parser library aspect of grmtools. It takes in streams of lexemes and parses
+them, determining if they successfully match a grammar or not; if not, it can
+optionally recover from errors.

--- a/doc/src/lrtable.md
+++ b/doc/src/lrtable.md
@@ -1,8 +1,10 @@
 # `lrtable`
 
-`lrtable` takes in grammars from [`cfgrammar`](cfgrammar.html) and creates LR
-state tables from them. Few users will be interested in its functionality
-directly, except those doing advanced forms of grammar analysis.
+`lrtable` ([crate](https://crates.io/crates/lrtable);
+[source](https://github.com/softdevteam/grmtools/tree/master/lrtable)) takes in
+grammars from [`cfgrammar`](cfgrammar.html) and creates LR state tables from
+them. Few users will be interested in its functionality directly, except those
+doing advanced forms of grammar analysis.
 
 One, admittedly fairly advanced, aspect worth noting is that
 `lrtable` uses [Pager's


### PR DESCRIPTION
This means that readers who are directed first to the book have a sporting chance of actually finding the source code.