### PR TITLE
decouple lexer & text lifetimes

### DIFF
--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -92,10 +92,10 @@ impl<StorageT: Copy + Eq + Hash + PrimInt + Unsigned> LexerDef<StorageT> {
     /// benign: some lexers deliberately define tokens which are not used (e.g. reserving future
     /// keywords). A non-empty set #2 is more likely to be an error since there are parts of the
     /// grammar where nothing the user can input will be parseable.
-    pub fn set_rule_ids<'a>(
-        &'a mut self,
+    pub fn set_rule_ids<'b, 'a: 'b>(
+        &'b mut self,
         rule_ids_map: &HashMap<&'a str, StorageT>
-    ) -> (Option<HashSet<&'a str>>, Option<HashSet<&'a str>>) {
+    ) -> (Option<HashSet<&'b str>>, Option<HashSet<&'b str>>) {
         // Because we have to iter_mut over self.rules, we can't easily store a reference to the
         // rule's name at the same time. Instead, we store the index of each such rule and
         // recover the names later.
@@ -156,7 +156,7 @@ impl<StorageT: Copy + Eq + Hash + PrimInt + Unsigned> LexerDef<StorageT> {
     }
 
     /// Return a lexer for the `String` `s` that will lex relative to this `LexerDef`.
-    pub fn lexer<'a>(&'a self, s: &'a str) -> impl Lexer<StorageT> + 'a {
+    pub fn lexer<'b, 'a: 'b>(&'b self, s: &'a str) -> impl Lexer<StorageT> + 'b {
         LRLexer::new(self, s)
     }
 }
@@ -169,8 +169,8 @@ pub struct LRLexer<'a, StorageT> {
     newlines: Vec<usize>
 }
 
-impl<'a, StorageT: Copy + Eq + Hash + PrimInt + Unsigned> LRLexer<'a, StorageT> {
-    fn new(lexerdef: &'a LexerDef<StorageT>, s: &'a str) -> LRLexer<'a, StorageT> {
+impl<'b, 'a: 'b, StorageT: Copy + Eq + Hash + PrimInt + Unsigned> LRLexer<'b, StorageT> {
+    fn new(lexerdef: &'b LexerDef<StorageT>, s: &'a str) -> LRLexer<'b, StorageT> {
         let mut lexemes = vec![];
         let mut newlines = vec![];
         let mut i = 0;

--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -57,13 +57,13 @@ impl<StorageT: Copy + Eq + Hash + PrimInt + Unsigned> LexerDef<StorageT> {
     }
 
     /// Get the `Rule` at index `idx`.
-    pub fn get_rule<'a>(&'a self, idx: usize) -> Option<&'a Rule<StorageT>> {
+    pub fn get_rule(&self, idx: usize) -> Option<&Rule<StorageT>> {
         self.rules.get(idx)
     }
 
     /// Get the `Rule` instance associated with a particular lexeme ID. Panics if no such rule
     /// exists.
-    pub fn get_rule_by_id<'a>(&'a self, tok_id: StorageT) -> &'a Rule<StorageT> {
+    pub fn get_rule_by_id(&self, tok_id: StorageT) -> &Rule<StorageT> {
         &self
             .rules
             .iter()
@@ -72,7 +72,7 @@ impl<StorageT: Copy + Eq + Hash + PrimInt + Unsigned> LexerDef<StorageT> {
     }
 
     /// Get the `Rule` instance associated with a particular name.
-    pub fn get_rule_by_name<'a>(&'a self, n: &str) -> Option<&'a Rule<StorageT>> {
+    pub fn get_rule_by_name(&self, n: &str) -> Option<&Rule<StorageT>> {
         self.rules
             .iter()
             .find(|r| r.name.as_ref().map(String::as_str) == Some(n))
@@ -93,10 +93,10 @@ impl<StorageT: Copy + Eq + Hash + PrimInt + Unsigned> LexerDef<StorageT> {
     /// benign: some lexers deliberately define tokens which are not used (e.g. reserving future
     /// keywords). A non-empty set #2 is more likely to be an error since there are parts of the
     /// grammar where nothing the user can input will be parseable.
-    pub fn set_rule_ids<'b, 'a: 'b>(
-        &'b mut self,
-        rule_ids_map: &HashMap<&'a str, StorageT>
-    ) -> (Option<HashSet<&'b str>>, Option<HashSet<&'b str>>) {
+    pub fn set_rule_ids<'lexerdef, 'external: 'lexerdef>(
+        &'lexerdef mut self,
+        rule_ids_map: &HashMap<&'external str, StorageT>
+    ) -> (Option<HashSet<&'lexerdef str>>, Option<HashSet<&'lexerdef str>>) {
         // Because we have to iter_mut over self.rules, we can't easily store a reference to the
         // rule's name at the same time. Instead, we store the index of each such rule and
         // recover the names later.
@@ -152,7 +152,7 @@ impl<StorageT: Copy + Eq + Hash + PrimInt + Unsigned> LexerDef<StorageT> {
     }
 
     /// Returns an iterator over all rules in this AST.
-    pub fn iter_rules<'a>(&'a self) -> Iter<'a, Rule<StorageT>> {
+    pub fn iter_rules(&self) -> Iter<Rule<StorageT>> {
         self.rules.iter()
     }
 

--- a/lrpar/examples/calc_ast/src/main.rs
+++ b/lrpar/examples/calc_ast/src/main.rs
@@ -52,7 +52,7 @@ fn main() {
     }
 }
 
-fn eval(lexer: &dyn Lexer<u32>, e: Expr) -> Result<u64, (Span, &'static str)> {
+fn eval<'a,'b:'a>(lexer: &'a dyn Lexer<'b,'b,u32>, e: Expr) -> Result<u64, (Span, &'static str)> {
     match e {
         Expr::Add { span, lhs, rhs } => eval(lexer, *lhs)?
             .checked_add(eval(lexer, *rhs)?)
@@ -63,6 +63,7 @@ fn eval(lexer: &dyn Lexer<u32>, e: Expr) -> Result<u64, (Span, &'static str)> {
         Expr::Number { span } => lexer
             .span_str(span)
             .parse::<u64>()
-            .map_err(|_| (span, "cannot be represented as a u64"))
+            .ok()
+            .ok_or((span, "cannot be represented as a u64"))
     }
 }

--- a/lrpar/examples/calc_ast/src/main.rs
+++ b/lrpar/examples/calc_ast/src/main.rs
@@ -52,7 +52,7 @@ fn main() {
     }
 }
 
-fn eval<'a,'b:'a>(lexer: &'a dyn Lexer<'b,'b,u32>, e: Expr) -> Result<u64, (Span, &'static str)> {
+fn eval<'temp, 'lexer:'temp, 'input: 'lexer>(lexer: &'temp dyn Lexer<'lexer,'input,u32>, e: Expr) -> Result<u64, (Span, &'static str)> {
     match e {
         Expr::Add { span, lhs, rhs } => eval(lexer, *lhs)?
             .checked_add(eval(lexer, *rhs)?)
@@ -63,7 +63,6 @@ fn eval<'a,'b:'a>(lexer: &'a dyn Lexer<'b,'b,u32>, e: Expr) -> Result<u64, (Span
         Expr::Number { span } => lexer
             .span_str(span)
             .parse::<u64>()
-            .ok()
-            .ok_or((span, "cannot be represented as a u64"))
+            .map_err(|_| (span,"cannot be represented as a u64"))
     }
 }

--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -98,8 +98,8 @@ impl<StorageT: PrimInt + Unsigned> PartialEq for PathFNode<StorageT> {
 
 impl<StorageT: PrimInt + Unsigned> Eq for PathFNode<StorageT> {}
 
-struct CPCTPlus<'a, 'b: 'a, 'c:'b, 'lexer: 'c, 'input: 'lexer, StorageT: 'static + Eq + Hash, ActionT: 'a> {
-    parser: &'a Parser<'b, 'c, 'lexer,'input, StorageT, ActionT>
+struct CPCTPlus<'cpc, 'rtpb: 'cpc, 'ext:'rtpb, 'lexer: 'rtpb, 'input: 'lexer, StorageT: 'static + Eq + Hash, ActionT: 'cpc> {
+    parser: &'cpc Parser<'rtpb,'ext,'lexer,'input,StorageT, ActionT>
 }
 
 pub(crate) fn recoverer<'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>(
@@ -112,8 +112,8 @@ where
     Box::new(CPCTPlus { parser })
 }
 
-impl<'a, 'b: 'a, 'c: 'b, 'lexer: 'c,'input:'lexer, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
-    Recoverer<StorageT, ActionT> for CPCTPlus<'a, 'b,'c, 'lexer,'input, StorageT, ActionT>
+impl<'cpc, 'rtpb: 'cpc, 'ext: 'rtpb, 'lexer: 'ext,'input:'lexer, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'cpc>
+    Recoverer<StorageT, ActionT> for CPCTPlus<'cpc, 'rtpb,'ext, 'lexer,'input, StorageT, ActionT>
 where
     usize: AsPrimitive<StorageT>,
     u32: AsPrimitive<StorageT>
@@ -241,8 +241,8 @@ where
     }
 }
 
-impl<'a, 'b:'a, 'c: 'b, 'lexer: 'c,'input:'lexer, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
-    CPCTPlus<'a, 'b, 'c, 'lexer,'input, StorageT, ActionT>
+impl<'cpc, 'rtpb: 'cpc, 'ext: 'rtpb, 'lexer: 'ext,'input:'lexer, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'cpc>
+    CPCTPlus<'cpc, 'rtpb, 'ext, 'lexer,'input, StorageT, ActionT>
 where
     usize: AsPrimitive<StorageT>,
     u32: AsPrimitive<StorageT>

--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -98,8 +98,8 @@ impl<StorageT: PrimInt + Unsigned> PartialEq for PathFNode<StorageT> {
 
 impl<StorageT: PrimInt + Unsigned> Eq for PathFNode<StorageT> {}
 
-struct CPCTPlus<'a, 'input, StorageT: 'static + Eq + Hash, ActionT: 'a> {
-    parser: &'a Parser<'a, 'input, StorageT, ActionT>
+struct CPCTPlus<'a, 'b: 'a, 'c:'b, 'lexer: 'c, 'input: 'lexer, StorageT: 'static + Eq + Hash, ActionT: 'a> {
+    parser: &'a Parser<'b, 'c, 'lexer,'input, StorageT, ActionT>
 }
 
 pub(crate) fn recoverer<'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>(
@@ -112,8 +112,8 @@ where
     Box::new(CPCTPlus { parser })
 }
 
-impl<'a, 'input, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
-    Recoverer<StorageT, ActionT> for CPCTPlus<'a, 'input, StorageT, ActionT>
+impl<'a, 'b: 'a, 'c: 'b, 'lexer: 'c,'input:'lexer, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
+    Recoverer<StorageT, ActionT> for CPCTPlus<'a, 'b,'c, 'lexer,'input, StorageT, ActionT>
 where
     usize: AsPrimitive<StorageT>,
     u32: AsPrimitive<StorageT>
@@ -241,8 +241,8 @@ where
     }
 }
 
-impl<'a, 'input, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
-    CPCTPlus<'a, 'input, StorageT, ActionT>
+impl<'a, 'b:'a, 'c: 'b, 'lexer: 'c,'input:'lexer, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
+    CPCTPlus<'a, 'b, 'c, 'lexer,'input, StorageT, ActionT>
 where
     usize: AsPrimitive<StorageT>,
     u32: AsPrimitive<StorageT>

--- a/lrpar/src/lib/lex.rs
+++ b/lrpar/src/lib/lex.rs
@@ -36,7 +36,7 @@ impl fmt::Display for LexError {
 }
 
 /// The trait which all lexers which want to interact with `lrpar` must implement.
-pub trait Lexer<StorageT: Hash + PrimInt + Unsigned> {
+pub trait Lexer<'lexer, 'input: 'lexer, StorageT: Hash + PrimInt + Unsigned> {
     /// Iterate over all the lexemes in this lexer. Note that:
     ///   * The lexer may or may not stop after the first [LexError] is encountered.
     ///   * There are no guarantees about whether the lexer caches anything if this method is
@@ -48,7 +48,7 @@ pub trait Lexer<StorageT: Hash + PrimInt + Unsigned> {
     /// # Panics
     ///
     /// If the span exceeds the known input.
-    fn span_str(&self, span: Span) -> &str;
+    fn span_str(&self, span: Span) -> &'input str;
 
     /// Return the lines containing the input at `span` (including *all* the text on the lines
     /// that `span` starts and ends on).
@@ -56,7 +56,7 @@ pub trait Lexer<StorageT: Hash + PrimInt + Unsigned> {
     /// # Panics
     ///
     /// If the span exceeds the known input.
-    fn span_lines_str(&self, span: Span) -> &str;
+    fn span_lines_str(&self, span: Span) -> &'input str;
 
     /// Return `((start line, start column), (end line, end column))` for `span`. Note that column
     /// *characters* (not bytes) are returned.

--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -106,22 +106,22 @@ impl<StorageT: PrimInt + Unsigned> PartialEq for PathFNode<StorageT> {
 
 impl<StorageT: PrimInt + Unsigned> Eq for PathFNode<StorageT> {}
 
-struct MF<'a, 'b:'a,'c: 'b, 'lexer:'c,'input:'lexer, StorageT: 'static + Eq + Hash, ActionT: 'a> {
+struct MF<'mf,'rtpb:'mf,'ext:'rtpb,'lexer:'ext,'input:'lexer, StorageT: 'static + Eq + Hash, ActionT: 'mf> {
     dist: Dist<StorageT>,
-    parser: &'a Parser<'b, 'c, 'lexer,'input, StorageT, ActionT>
+    parser: &'mf Parser<'rtpb,'ext,'lexer,'input,StorageT, ActionT>
 }
 
 pub(crate) fn recoverer<
-    'a,
-    'b: 'a,
-    'c: 'b,
-    'lexer: 'c,
-    'input: 'lexer,
-    StorageT: 'static + Debug + Hash + PrimInt + Unsigned,
-    ActionT: 'b
+   'mf,
+   'rtpb: 'mf,
+   'ext: 'rtpb,
+   'lexer:'ext,
+   'input: 'lexer,
+   StorageT: 'static + Debug + Hash + PrimInt + Unsigned,
+   ActionT: 'mf
 >(
-    parser: &'a Parser<'b,'c, 'lexer,'input, StorageT, ActionT>
-) -> Box<dyn Recoverer<StorageT, ActionT> + 'a>
+    parser: &'mf Parser<'rtpb,'ext,'lexer,'input,StorageT, ActionT>
+) -> Box<dyn Recoverer<StorageT, ActionT> + 'mf>
 where
     usize: AsPrimitive<StorageT>,
     u32: AsPrimitive<StorageT>
@@ -135,8 +135,8 @@ where
     Box::new(MF { dist, parser })
 }
 
-impl<'a, 'b: 'a, 'c: 'b, 'lexer: 'c, 'input:'lexer, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
-    Recoverer<StorageT, ActionT> for MF<'a, 'b, 'c,'lexer, 'input, StorageT, ActionT>
+impl<'mf,'rtpb:'mf,'ext:'rtpb,'lexer:'ext,'input:'lexer, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'mf>
+    Recoverer<StorageT, ActionT> for MF<'mf,'rtpb,'ext,'lexer, 'input, StorageT, ActionT>
 where
     usize: AsPrimitive<StorageT>,
     u32: AsPrimitive<StorageT>
@@ -251,8 +251,8 @@ where
     }
 }
 
-impl<'a, 'b: 'a, 'c: 'b, 'lexer: 'c, 'input: 'lexer, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
-    MF<'a, 'b, 'c, 'lexer, 'input, StorageT, ActionT>
+impl<'mf,'rtpb:'mf,'ext:'rtpb,'lexer:'ext,'input:'lexer, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'mf>
+  MF<'mf,'rtpb,'ext,'lexer, 'input, StorageT, ActionT>
 where
     usize: AsPrimitive<StorageT>,
     u32: AsPrimitive<StorageT>

--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -106,18 +106,21 @@ impl<StorageT: PrimInt + Unsigned> PartialEq for PathFNode<StorageT> {
 
 impl<StorageT: PrimInt + Unsigned> Eq for PathFNode<StorageT> {}
 
-struct MF<'a, 'input, StorageT: 'static + Eq + Hash, ActionT: 'a> {
+struct MF<'a, 'b:'a,'c: 'b, 'lexer:'c,'input:'lexer, StorageT: 'static + Eq + Hash, ActionT: 'a> {
     dist: Dist<StorageT>,
-    parser: &'a Parser<'a, 'input, StorageT, ActionT>
+    parser: &'a Parser<'b, 'c, 'lexer,'input, StorageT, ActionT>
 }
 
 pub(crate) fn recoverer<
     'a,
-    'input,
+    'b: 'a,
+    'c: 'b,
+    'lexer: 'c,
+    'input: 'lexer,
     StorageT: 'static + Debug + Hash + PrimInt + Unsigned,
-    ActionT: 'a
+    ActionT: 'b
 >(
-    parser: &'a Parser<'a, 'input, StorageT, ActionT>
+    parser: &'a Parser<'b,'c, 'lexer,'input, StorageT, ActionT>
 ) -> Box<dyn Recoverer<StorageT, ActionT> + 'a>
 where
     usize: AsPrimitive<StorageT>,
@@ -127,13 +130,13 @@ where
         parser.grm,
         parser.sgraph,
         parser.stable,
-        parser.token_cost.as_ref()
+        parser.token_cost,
     );
     Box::new(MF { dist, parser })
 }
 
-impl<'a, 'input, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
-    Recoverer<StorageT, ActionT> for MF<'a, 'input, StorageT, ActionT>
+impl<'a, 'b: 'a, 'c: 'b, 'lexer: 'c, 'input:'lexer, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
+    Recoverer<StorageT, ActionT> for MF<'a, 'b, 'c,'lexer, 'input, StorageT, ActionT>
 where
     usize: AsPrimitive<StorageT>,
     u32: AsPrimitive<StorageT>
@@ -248,8 +251,8 @@ where
     }
 }
 
-impl<'a, 'input, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
-    MF<'a, 'input, StorageT, ActionT>
+impl<'a, 'b: 'a, 'c: 'b, 'lexer: 'c, 'input: 'lexer, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
+    MF<'a, 'b, 'c, 'lexer, 'input, StorageT, ActionT>
 where
     usize: AsPrimitive<StorageT>,
     u32: AsPrimitive<StorageT>

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -464,7 +464,7 @@ where
     /// a lexeme constructed to look as if contains the EOF token).
     pub(crate) fn next_lexeme(&self, laidx: usize) -> Lexeme<StorageT> {
         let llen = self.lexemes.len();
-        __debug_assert!(laidx <= llen);
+        debug_assert!(laidx <= llen);
         if laidx < llen {
             self.lexemes[laidx]
         } else {
@@ -472,7 +472,7 @@ where
             let last_la_end = if llen == 0 {
                 0
             } else {
-                __debug_assert!(laidx > 0);
+                debug_assert!(laidx > 0);
                 let last_la = self.lexemes[laidx - 1];
                 last_la.span().end()
             };
@@ -489,7 +489,7 @@ where
     /// EOF `TIdx`).
     pub(crate) fn next_tidx(&self, laidx: usize) -> TIdx<StorageT> {
         let ll = self.lexemes.len();
-        __debug_assert!(laidx <= ll);
+        debug_assert!(laidx <= ll);
         if laidx < ll {
             TIdx(self.lexemes[laidx].tok_id())
         } else {


### PR DESCRIPTION
Happy to make/remake any changes that are requested. Great project BTW!

I think I found a small error when working with the `lrpar` library.

This is the rough example: [original source code (sorry for the mess)](https://github.com/valarauca/trollparse/blob/a2a170ad534546c881bea89ba32fc4a3e62b7f5e/src/lib.rs#L31-#L36), the [super::error_handling](https://github.com/valarauca/trollparse/blob/a2a170ad534546c881bea89ba32fc4a3e62b7f5e/src/lib.rs#L39-#L56) is just something to give me syntax highlighting on errors.

```rust

    /// handles parsing of the input and attempts to return an AST
    pub fn parser<'a>(input: &'a str) -> Result<Source<'a>,String> {
        let l = lexerdef();
        let lexer_def = l.lexer(input);
        super::error_handling(input, parse, &lexer_def)
    }
 ````

Gives me the following error

```
error[E0515]: cannot return value referencing local variable `lexer_def`
  --> src/lib.rs:35:9
   |
35 |         super::error_handling(input, parse, &lexer_def)
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------^
   |         |                                   |
   |         |                                   `lexer_def` is borrowed here
   |         returns a value referencing data owned by the current function

error[E0515]: cannot return value referencing local variable `l`
  --> src/lib.rs:35:9
   |
34 |         let lexer_def = l.lexer(input);
   |                         - `l` is borrowed here
35 |         super::error_handling(input, parse, &lexer_def)
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returns a value referencing data owned by the current function
```

This confuses me because [`Source<'a>`](https://github.com/valarauca/trollparse/blob/master/src/parser2.y#L102-#L109) has references to the underlying source code, but not fields/elements owned by the lexer.

I think the problem is with [`impl Lexer<StorageT>` is created](https://docs.rs/lrlex/0.6.2/lrlex/struct.LexerDef.html#method.lexer) 

```
    pub fn lexer<'a>(&'a self, s: &'a str) -> impl Lexer<StorageT> + 'a
```

The `LexerDef` equates its own `&self` lifetime to that of the input buffer. Which means `impl Lexer<StorageT>` will live as long as our input buffer, but our input buffer also cannot outlive `impl Lexer<StorageT>`. 

I am _attempting_ to decouple this, because while we do what `impl Lexer` to keep the input buffer alive (if necessary) we also want to ensure that the input buffer can outlive `impl Lexer`.

This is why I'm suggesting the introduction of the `'a: 'b` to a few places, _but I'm not sure I hit them all_. The basic idea is stating `'input: 'lexer` or "_the input may outlive the lexer, but the lexer may not outlive the input_". 

**TL;DR** 

Right now I see a generated function of the signature:

````
pub fn parse<'input>(
    lexer: &'input (dyn Lexer<u32> + 'input)
) -> (Option<Result<Source<'input>, Lexeme<u32>>>, Vec<LexParseError<u32>>)
````

And I think it should be

````
pub fn parse<'lexer, 'lexer: 'input>(
    lexer: &'lexer (dyn Lexer<u32> + 'input)
) -> (Option<Result<Source<'input>, Lexeme<u32>>>, Vec<LexParseError<u32>>)
````

But I'm not sure where to make this change.
