### PR TITLE
Add "dyn".

### DIFF
--- a/doc/src/quickstart.md
+++ b/doc/src/quickstart.md
@@ -50,7 +50,7 @@ use cfgrammar::yacc::YaccKind;
 use lrlex::LexerBuilder;
 use lrpar::{CTParserBuilder};
 
-fn main() -> Result<(), Box<std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let lex_rule_ids_map = CTParserBuilder::new()
         .yacckind(YaccKind::Grmtools)
         .process_file_in_src("calc.y")?;


### PR DESCRIPTION
Without this one gets a warning from rustc that:

```
  trait objects without an explicit `dyn` are deprecated
```