### PR TITLE
More flexible input lifetime

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,31 @@
+# grmtools 0.7.0 (2020-XX-XX)
+
+## Breaking change
+
+* `Lexer` now takes a lifetime `'input` which allows the input to last longer
+  than the `Lexer` itself. `Lexer::span_str` and `Lexer::span_lines_str` have
+  changed from:
+    ```rustc
+    fn span_str(&self, span: Span) -> &str;
+    fn span_lines_str(&self, span: Span) -> &str;
+    ```
+  to:
+    ```rustc
+    fn span_str(&self, span: Span) -> &'input str;
+    fn span_lines_str(&self, span: Span) -> &'input str;
+    ```
+  This change allows users to throw away the `Lexer` but still keep around
+  structures (e.g. ASTs) which reference the user's input.
+
+  rustc infers the `'input` lifetime in some situations but not others,
+  so if you get an error:
+    ```
+    error[E0106]: missing lifetime specifier
+    ```
+  then it is likely that you need to change a type from `Lexer` to
+  `Lexer<'input>`.
+
+
 # grmtools 0.6.2 (2020-03-22)
 
 * Fix two Clippy warnings and suppress two others.

--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -163,14 +163,14 @@ impl<StorageT: Copy + Eq + Hash + PrimInt + Unsigned> LexerDef<StorageT> {
 
 /// A lexer holds a reference to a string and can lex it into `Lexeme`s. Although the struct is
 /// tied to a single string, no guarantees are made about whether the lexemes are cached or not.
-pub struct LRLexer<'a, StorageT> {
-    s: &'a str,
+pub struct LRLexer<'input, StorageT> {
+    s: &'input str,
     lexemes: Vec<Result<Lexeme<StorageT>, LexError>>,
     newlines: Vec<usize>
 }
 
-impl<'a, StorageT: Copy + Eq + Hash + PrimInt + Unsigned> LRLexer<'a, StorageT> {
-    fn new(lexerdef: &'a LexerDef<StorageT>, s: &'a str) -> LRLexer<'a, StorageT> {
+impl<'input, StorageT: Copy + Eq + Hash + PrimInt + Unsigned> LRLexer<'input, StorageT> {
+    fn new(lexerdef: &LexerDef<StorageT>, s: &'input str) -> LRLexer<'input, StorageT> {
         let mut lexemes = vec![];
         let mut newlines = vec![];
         let mut i = 0;
@@ -224,14 +224,14 @@ impl<'a, StorageT: Copy + Eq + Hash + PrimInt + Unsigned> LRLexer<'a, StorageT> 
     }
 }
 
-impl<'a, StorageT: Copy + Eq + Hash + PrimInt + Unsigned> Lexer<StorageT>
-    for LRLexer<'a, StorageT>
+impl<'input, StorageT: Copy + Eq + Hash + PrimInt + Unsigned> Lexer<'input, StorageT>
+    for LRLexer<'input, StorageT>
 {
-    fn iter<'b>(&'b self) -> Box<dyn Iterator<Item = Result<Lexeme<StorageT>, LexError>> + 'b> {
+    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = Result<Lexeme<StorageT>, LexError>> + 'a> {
         Box::new(self.lexemes.iter().cloned())
     }
 
-    fn span_str(&self, span: Span) -> &str {
+    fn span_str(&self, span: Span) -> &'input str {
         if span.end() > self.s.len() {
             panic!(
                 "Span {:?} exceeds known input length {}",
@@ -242,7 +242,7 @@ impl<'a, StorageT: Copy + Eq + Hash + PrimInt + Unsigned> Lexer<StorageT>
         &self.s[span.start()..span.end()]
     }
 
-    fn span_lines_str(&self, span: Span) -> &str {
+    fn span_lines_str(&self, span: Span) -> &'input str {
         debug_assert!(span.end() >= span.start());
         if span.end() > self.s.len() {
             panic!(

--- a/lrpar/cttests/src/lexer_lifetime.test
+++ b/lrpar/cttests/src/lexer_lifetime.test
@@ -3,8 +3,8 @@ yacckind: Grmtools
 grammar: |
     %start T
     %%
-    T -> ():
-        "ID" { }
+    T -> &'input str:
+        "ID" { $lexer.span_str($1.unwrap().span()) }
         ;
 lexer: |
     %%

--- a/lrpar/cttests/src/lexer_lifetime.test
+++ b/lrpar/cttests/src/lexer_lifetime.test
@@ -1,0 +1,11 @@
+name: Test that the lexer does not have to outlive the input's lifetime
+yacckind: Grmtools
+grammar: |
+    %start T
+    %%
+    T -> ():
+        "ID" { }
+        ;
+lexer: |
+    %%
+    [a-z] "ID"

--- a/lrpar/cttests/src/lib.rs
+++ b/lrpar/cttests/src/lib.rs
@@ -1,6 +1,8 @@
 use lrlex::lrlex_mod;
 use lrpar::lrpar_mod;
 #[cfg(test)]
+use lrpar::Lexer;
+#[cfg(test)]
 use lrpar::Span;
 
 lrlex_mod!("calc_multitypes.l");
@@ -11,6 +13,9 @@ lrpar_mod!("calc_actiontype.y");
 
 lrlex_mod!("calc_noactions.l");
 lrpar_mod!("calc_noactions.y");
+
+lrlex_mod!("lexer_lifetime.l");
+lrpar_mod!("lexer_lifetime.y");
 
 lrlex_mod!("multitypes.l");
 lrpar_mod!("multitypes.y");
@@ -95,6 +100,19 @@ fn test_calc_multitypes() {
     let lexer = lexerdef.lexer("1++2");
     let (res, _errs) = calc_multitypes_y::parse(&lexer);
     assert_eq!(res, Some(Ok(3)));
+}
+
+#[test]
+fn test_lexer_lifetime() {
+    // This test only exists to make sure that this code compiles: there's no need for us to
+    // actually run anything.
+    let lexerdef = lexer_lifetime_l::lexerdef();
+    let input = "a";
+    let _ = {
+        let lexer = lexerdef.lexer(&input);
+        let lx = lexer.iter().next().unwrap().unwrap();
+        lexer.span_str(lx.span())
+    };
 }
 
 #[test]

--- a/lrpar/cttests/src/lib.rs
+++ b/lrpar/cttests/src/lib.rs
@@ -103,7 +103,7 @@ fn test_calc_multitypes() {
 }
 
 #[test]
-fn test_lexer_lifetime() {
+fn test_input_lifetime() {
     // This test only exists to make sure that this code compiles: there's no need for us to
     // actually run anything.
     let lexerdef = lexer_lifetime_l::lexerdef();
@@ -113,6 +113,22 @@ fn test_lexer_lifetime() {
         let lx = lexer.iter().next().unwrap().unwrap();
         lexer.span_str(lx.span())
     };
+}
+
+#[test]
+fn test_lexer_lifetime() {
+    // This test only exists to make sure that this code compiles: there's no need for us to
+    // actually run anything.
+
+    pub fn parse_data<'a>(input: &'a str) -> Option<&'a str> {
+        let lexer_def = crate::lexer_lifetime_l::lexerdef();
+        let l = lexer_def.lexer(input);
+        match crate::lexer_lifetime_y::parse(&l) {
+            (Option::Some(x), _) => Some(x),
+            _ => None
+        }
+    }
+    parse_data("abc");
 }
 
 #[test]

--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -98,8 +98,8 @@ impl<StorageT: PrimInt + Unsigned> PartialEq for PathFNode<StorageT> {
 
 impl<StorageT: PrimInt + Unsigned> Eq for PathFNode<StorageT> {}
 
-struct CPCTPlus<'a, 'b: 'a, StorageT: 'static + Eq + Hash, ActionT: 'a> {
-    parser: &'a Parser<'a, 'b, StorageT, ActionT>
+struct CPCTPlus<'a, 'b: 'a, 'input: 'b, StorageT: 'static + Eq + Hash, ActionT: 'a> {
+    parser: &'a Parser<'a, 'b, 'input, StorageT, ActionT>
 }
 
 pub(crate) fn recoverer<'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>(
@@ -112,8 +112,13 @@ where
     Box::new(CPCTPlus { parser })
 }
 
-impl<'a, 'b: 'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
-    Recoverer<StorageT, ActionT> for CPCTPlus<'a, 'b, StorageT, ActionT>
+impl<
+        'a,
+        'b: 'a,
+        'input: 'b,
+        StorageT: 'static + Debug + Hash + PrimInt + Unsigned,
+        ActionT: 'a
+    > Recoverer<StorageT, ActionT> for CPCTPlus<'a, 'b, 'input, StorageT, ActionT>
 where
     usize: AsPrimitive<StorageT>,
     u32: AsPrimitive<StorageT>
@@ -241,8 +246,13 @@ where
     }
 }
 
-impl<'a, 'b: 'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
-    CPCTPlus<'a, 'b, StorageT, ActionT>
+impl<
+        'a,
+        'b: 'a,
+        'input: 'b,
+        StorageT: 'static + Debug + Hash + PrimInt + Unsigned,
+        ActionT: 'a
+    > CPCTPlus<'a, 'b, 'input, StorageT, ActionT>
 where
     usize: AsPrimitive<StorageT>,
     u32: AsPrimitive<StorageT>

--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -98,7 +98,7 @@ impl<StorageT: PrimInt + Unsigned> PartialEq for PathFNode<StorageT> {
 
 impl<StorageT: PrimInt + Unsigned> Eq for PathFNode<StorageT> {}
 
-struct CPCTPlus<'a, 'b, StorageT: 'static + Eq + Hash, ActionT: 'a> {
+struct CPCTPlus<'a, 'b: 'a, StorageT: 'static + Eq + Hash, ActionT: 'a> {
     parser: &'a Parser<'a, 'b, StorageT, ActionT>
 }
 
@@ -112,7 +112,7 @@ where
     Box::new(CPCTPlus { parser })
 }
 
-impl<'a, 'b, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
+impl<'a, 'b: 'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
     Recoverer<StorageT, ActionT> for CPCTPlus<'a, 'b, StorageT, ActionT>
 where
     usize: AsPrimitive<StorageT>,
@@ -241,7 +241,7 @@ where
     }
 }
 
-impl<'a, 'b, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
+impl<'a, 'b: 'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
     CPCTPlus<'a, 'b, StorageT, ActionT>
 where
     usize: AsPrimitive<StorageT>,

--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -98,8 +98,8 @@ impl<StorageT: PrimInt + Unsigned> PartialEq for PathFNode<StorageT> {
 
 impl<StorageT: PrimInt + Unsigned> Eq for PathFNode<StorageT> {}
 
-struct CPCTPlus<'a, 'input, StorageT: 'static + Eq + Hash, ActionT: 'a> {
-    parser: &'a Parser<'a, 'input, StorageT, ActionT>
+struct CPCTPlus<'a, 'b, StorageT: 'static + Eq + Hash, ActionT: 'a> {
+    parser: &'a Parser<'a, 'b, StorageT, ActionT>
 }
 
 pub(crate) fn recoverer<'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>(
@@ -112,8 +112,8 @@ where
     Box::new(CPCTPlus { parser })
 }
 
-impl<'a, 'input, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
-    Recoverer<StorageT, ActionT> for CPCTPlus<'a, 'input, StorageT, ActionT>
+impl<'a, 'b, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
+    Recoverer<StorageT, ActionT> for CPCTPlus<'a, 'b, StorageT, ActionT>
 where
     usize: AsPrimitive<StorageT>,
     u32: AsPrimitive<StorageT>
@@ -241,8 +241,8 @@ where
     }
 }
 
-impl<'a, 'input, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
-    CPCTPlus<'a, 'input, StorageT, ActionT>
+impl<'a, 'b, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
+    CPCTPlus<'a, 'b, StorageT, ActionT>
 where
     usize: AsPrimitive<StorageT>,
     u32: AsPrimitive<StorageT>

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -461,7 +461,7 @@ where
                 outs.push_str(&format!(
                     "
     #[allow(dead_code)]
-    pub fn parse<'input>(lexer: &'input dyn ::lrpar::Lexer<{storaget}>)
+    pub fn parse<'lexer, 'input: 'lexer>(lexer: &'lexer dyn ::lrpar::Lexer<'input, {storaget}>)
           -> (::std::option::Option<{actiont}>, ::std::vec::Vec<::lrpar::LexParseError<{storaget}>>)
     {{",
                     storaget = StorageT::type_name(),
@@ -522,7 +522,7 @@ where
                 outs.push_str(&format!(
                     "\n        #[allow(clippy::type_complexity)]
         let mut actions: ::std::vec::Vec<&dyn Fn(::cfgrammar::RIdx<{storaget}>,
-                       &'input dyn ::lrpar::Lexer<{storaget}>,
+                       &'lexer dyn ::lrpar::Lexer<'input, {storaget}>,
                        ::lrpar::Span,
                        ::std::vec::Drain<::lrpar::parser::AStackType<{actionskind}<'input>, {storaget}>>)
                     -> {actionskind}<'input>> = ::std::vec::Vec::new();\n",
@@ -627,8 +627,8 @@ where
             // element from the argument vector (e.g. $1 is replaced by args[0]). At
             // the same time extract &str from tokens and actiontype from nonterminals.
             outs.push_str(&format!(
-                "    fn {prefix}wrapper_{}<'input>({prefix}ridx: ::cfgrammar::RIdx<{storaget}>,
-                      {prefix}lexer: &'input dyn ::lrpar::Lexer<{storaget}>,
+                "    fn {prefix}wrapper_{}<'lexer, 'input: 'lexer>({prefix}ridx: ::cfgrammar::RIdx<{storaget}>,
+                      {prefix}lexer: &'lexer dyn ::lrpar::Lexer<'input, {storaget}>,
                       {prefix}span: ::lrpar::Span,
                       mut {prefix}args: ::std::vec::Drain<::lrpar::parser::AStackType<{actionskind}<'input>, {storaget}>>)
                    -> {actionskind}<'input> {{",
@@ -786,8 +786,8 @@ where
             outs.push_str(&format!(
                 "    // {rulename}
     #[allow(clippy::too_many_arguments)]
-    fn {prefix}action_{}<'input>({prefix}ridx: ::cfgrammar::RIdx<{storaget}>,
-                     {prefix}lexer: &'input dyn ::lrpar::Lexer<{storaget}>,
+    fn {prefix}action_{}<'lexer, 'input: 'lexer>({prefix}ridx: ::cfgrammar::RIdx<{storaget}>,
+                     {prefix}lexer: &'lexer dyn ::lrpar::Lexer<'input, {storaget}>,
                      {prefix}span: ::lrpar::Span,
                      {args}) {returnt} {{\n",
                 usize::from(pidx),

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -461,7 +461,7 @@ where
                 outs.push_str(&format!(
                     "
     #[allow(dead_code)]
-    pub fn parse<'input>(lexer: &'input (dyn ::lrpar::Lexer<{storaget}> + 'input))
+    pub fn parse<'input>(lexer: &'input dyn ::lrpar::Lexer<{storaget}>)
           -> (::std::option::Option<{actiont}>, ::std::vec::Vec<::lrpar::LexParseError<{storaget}>>)
     {{",
                     storaget = StorageT::type_name(),
@@ -522,7 +522,7 @@ where
                 outs.push_str(&format!(
                     "\n        #[allow(clippy::type_complexity)]
         let mut actions: ::std::vec::Vec<&dyn Fn(::cfgrammar::RIdx<{storaget}>,
-                       &'input (dyn ::lrpar::Lexer<{storaget}> + 'input),
+                       &'input dyn ::lrpar::Lexer<{storaget}>,
                        ::lrpar::Span,
                        ::std::vec::Drain<::lrpar::parser::AStackType<{actionskind}<'input>, {storaget}>>)
                     -> {actionskind}<'input>> = ::std::vec::Vec::new();\n",
@@ -628,7 +628,7 @@ where
             // the same time extract &str from tokens and actiontype from nonterminals.
             outs.push_str(&format!(
                 "    fn {prefix}wrapper_{}<'input>({prefix}ridx: ::cfgrammar::RIdx<{storaget}>,
-                      {prefix}lexer: &'input (dyn ::lrpar::Lexer<{storaget}> + 'input),
+                      {prefix}lexer: &'input dyn ::lrpar::Lexer<{storaget}>,
                       {prefix}span: ::lrpar::Span,
                       mut {prefix}args: ::std::vec::Drain<::lrpar::parser::AStackType<{actionskind}<'input>, {storaget}>>)
                    -> {actionskind}<'input> {{",
@@ -787,7 +787,7 @@ where
                 "    // {rulename}
     #[allow(clippy::too_many_arguments)]
     fn {prefix}action_{}<'input>({prefix}ridx: ::cfgrammar::RIdx<{storaget}>,
-                     {prefix}lexer: &'input (dyn ::lrpar::Lexer<{storaget}> + 'input),
+                     {prefix}lexer: &'input dyn ::lrpar::Lexer<{storaget}>,
                      {prefix}span: ::lrpar::Span,
                      {args}) {returnt} {{\n",
                 usize::from(pidx),

--- a/lrpar/src/lib/lex.rs
+++ b/lrpar/src/lib/lex.rs
@@ -36,7 +36,7 @@ impl fmt::Display for LexError {
 }
 
 /// The trait which all lexers which want to interact with `lrpar` must implement.
-pub trait Lexer<StorageT: Hash + PrimInt + Unsigned> {
+pub trait Lexer<'input, StorageT: Hash + PrimInt + Unsigned> {
     /// Iterate over all the lexemes in this lexer. Note that:
     ///   * The lexer may or may not stop after the first [LexError] is encountered.
     ///   * There are no guarantees about whether the lexer caches anything if this method is
@@ -48,7 +48,7 @@ pub trait Lexer<StorageT: Hash + PrimInt + Unsigned> {
     /// # Panics
     ///
     /// If the span exceeds the known input.
-    fn span_str(&self, span: Span) -> &str;
+    fn span_str(&self, span: Span) -> &'input str;
 
     /// Return the lines containing the input at `span` (including *all* the text on the lines
     /// that `span` starts and ends on).
@@ -56,7 +56,7 @@ pub trait Lexer<StorageT: Hash + PrimInt + Unsigned> {
     /// # Panics
     ///
     /// If the span exceeds the known input.
-    fn span_lines_str(&self, span: Span) -> &str;
+    fn span_lines_str(&self, span: Span) -> &'input str;
 
     /// Return `((start line, start column), (end line, end column))` for `span`. Note that column
     /// *characters* (not bytes) are returned.

--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -106,18 +106,18 @@ impl<StorageT: PrimInt + Unsigned> PartialEq for PathFNode<StorageT> {
 
 impl<StorageT: PrimInt + Unsigned> Eq for PathFNode<StorageT> {}
 
-struct MF<'a, 'input, StorageT: 'static + Eq + Hash, ActionT: 'a> {
+struct MF<'a, 'b, StorageT: 'static + Eq + Hash, ActionT: 'a> {
     dist: Dist<StorageT>,
-    parser: &'a Parser<'a, 'input, StorageT, ActionT>
+    parser: &'a Parser<'a, 'b, StorageT, ActionT>
 }
 
 pub(crate) fn recoverer<
     'a,
-    'input,
+    'b,
     StorageT: 'static + Debug + Hash + PrimInt + Unsigned,
     ActionT: 'a
 >(
-    parser: &'a Parser<'a, 'input, StorageT, ActionT>
+    parser: &'a Parser<'a, 'b, StorageT, ActionT>
 ) -> Box<dyn Recoverer<StorageT, ActionT> + 'a>
 where
     usize: AsPrimitive<StorageT>,
@@ -132,8 +132,8 @@ where
     Box::new(MF { dist, parser })
 }
 
-impl<'a, 'input, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
-    Recoverer<StorageT, ActionT> for MF<'a, 'input, StorageT, ActionT>
+impl<'a, 'b, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
+    Recoverer<StorageT, ActionT> for MF<'a, 'b, StorageT, ActionT>
 where
     usize: AsPrimitive<StorageT>,
     u32: AsPrimitive<StorageT>
@@ -248,8 +248,8 @@ where
     }
 }
 
-impl<'a, 'input, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
-    MF<'a, 'input, StorageT, ActionT>
+impl<'a, 'b, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
+    MF<'a, 'b, StorageT, ActionT>
 where
     usize: AsPrimitive<StorageT>,
     u32: AsPrimitive<StorageT>

--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -106,18 +106,19 @@ impl<StorageT: PrimInt + Unsigned> PartialEq for PathFNode<StorageT> {
 
 impl<StorageT: PrimInt + Unsigned> Eq for PathFNode<StorageT> {}
 
-struct MF<'a, 'b, StorageT: 'static + Eq + Hash, ActionT: 'a> {
+struct MF<'a, 'b: 'a, 'input: 'b, StorageT: 'static + Eq + Hash, ActionT: 'a> {
     dist: Dist<StorageT>,
-    parser: &'a Parser<'a, 'b, StorageT, ActionT>
+    parser: &'a Parser<'a, 'b, 'input, StorageT, ActionT>
 }
 
 pub(crate) fn recoverer<
     'a,
     'b: 'a,
+    'input: 'b,
     StorageT: 'static + Debug + Hash + PrimInt + Unsigned,
     ActionT: 'a
 >(
-    parser: &'a Parser<'a, 'b, StorageT, ActionT>
+    parser: &'a Parser<'a, 'b, 'input, StorageT, ActionT>
 ) -> Box<dyn Recoverer<StorageT, ActionT> + 'a>
 where
     usize: AsPrimitive<StorageT>,
@@ -132,8 +133,13 @@ where
     Box::new(MF { dist, parser })
 }
 
-impl<'a, 'b: 'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
-    Recoverer<StorageT, ActionT> for MF<'a, 'b, StorageT, ActionT>
+impl<
+        'a,
+        'b: 'a,
+        'input: 'b,
+        StorageT: 'static + Debug + Hash + PrimInt + Unsigned,
+        ActionT: 'a
+    > Recoverer<StorageT, ActionT> for MF<'a, 'b, 'input, StorageT, ActionT>
 where
     usize: AsPrimitive<StorageT>,
     u32: AsPrimitive<StorageT>
@@ -248,8 +254,13 @@ where
     }
 }
 
-impl<'a, 'b: 'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
-    MF<'a, 'b, StorageT, ActionT>
+impl<
+        'a,
+        'b: 'a,
+        'input: 'b,
+        StorageT: 'static + Debug + Hash + PrimInt + Unsigned,
+        ActionT: 'a
+    > MF<'a, 'b, 'input, StorageT, ActionT>
 where
     usize: AsPrimitive<StorageT>,
     u32: AsPrimitive<StorageT>

--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -113,7 +113,7 @@ struct MF<'a, 'b, StorageT: 'static + Eq + Hash, ActionT: 'a> {
 
 pub(crate) fn recoverer<
     'a,
-    'b,
+    'b: 'a,
     StorageT: 'static + Debug + Hash + PrimInt + Unsigned,
     ActionT: 'a
 >(
@@ -132,7 +132,7 @@ where
     Box::new(MF { dist, parser })
 }
 
-impl<'a, 'b, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
+impl<'a, 'b: 'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
     Recoverer<StorageT, ActionT> for MF<'a, 'b, StorageT, ActionT>
 where
     usize: AsPrimitive<StorageT>,
@@ -248,7 +248,7 @@ where
     }
 }
 
-impl<'a, 'b, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
+impl<'a, 'b: 'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
     MF<'a, 'b, StorageT, ActionT>
 where
     usize: AsPrimitive<StorageT>,

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -71,7 +71,7 @@ pub(crate) type PStack = Vec<StIdx>; // Parse stack
 pub(crate) type TokenCostFn<'a, StorageT> = &'a (dyn Fn(TIdx<StorageT>) -> u8 + 'a);
 pub(crate) type ActionFn<'a, 'input, StorageT, ActionT> = &'a dyn Fn(
     RIdx<StorageT>,
-    &'input (dyn Lexer<StorageT> + 'input),
+    &'input dyn Lexer<StorageT>,
     Span,
     vec::Drain<AStackType<ActionT, StorageT>>
 ) -> ActionT;
@@ -107,7 +107,7 @@ where
         token_cost: TokenCostFn<'a, StorageT>,
         sgraph: &StateGraph<StorageT>,
         stable: &StateTable<StorageT>,
-        lexer: &'input (dyn Lexer<StorageT> + 'input),
+        lexer: &'input dyn Lexer<StorageT>,
         lexemes: Vec<Lexeme<StorageT>>
     ) -> (Option<Node<StorageT>>, Vec<LexParseError<StorageT>>) {
         for tidx in grm.iter_tidxs() {
@@ -162,7 +162,7 @@ where
         token_cost: TokenCostFn<'a, StorageT>,
         sgraph: &StateGraph<StorageT>,
         stable: &StateTable<StorageT>,
-        lexer: &'input (dyn Lexer<StorageT> + 'input),
+        lexer: &'input dyn Lexer<StorageT>,
         lexemes: Vec<Lexeme<StorageT>>
     ) -> Vec<LexParseError<StorageT>> {
         for tidx in grm.iter_tidxs() {
@@ -209,7 +209,7 @@ where
         token_cost: TokenCostFn<'a, StorageT>,
         sgraph: &'a StateGraph<StorageT>,
         stable: &'a StateTable<StorageT>,
-        lexer: &'input (dyn Lexer<StorageT> + 'input),
+        lexer: &'input dyn Lexer<StorageT>,
         lexemes: Vec<Lexeme<StorageT>>,
         actions: &'a [ActionFn<'a, 'input, StorageT, ActionT>]
     ) -> (Option<ActionT>, Vec<LexParseError<StorageT>>) {
@@ -768,10 +768,10 @@ where
     /// be a mix of lexing and parsing errors.
     pub fn parse_actions<'input, ActionT: 'a>(
         &self,
-        lexer: &'input (dyn Lexer<StorageT> + 'input),
+        lexer: &'input dyn Lexer<StorageT>,
         actions: &[&dyn Fn(
             RIdx<StorageT>,
-            &'input (dyn Lexer<StorageT> + 'input),
+            &'input dyn Lexer<StorageT>,
             Span,
             vec::Drain<AStackType<ActionT, StorageT>>
         ) -> ActionT]

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -82,7 +82,7 @@ pub enum AStackType<ActionT, StorageT> {
     Lexeme(Lexeme<StorageT>)
 }
 
-pub struct Parser<'a, 'b, StorageT: 'static + Eq + Hash, ActionT: 'a> {
+pub struct Parser<'a, 'b: 'a, StorageT: 'static + Eq + Hash, ActionT: 'a> {
     pub(crate) rcvry_kind: RecoveryKind,
     pub(crate) grm: &'a YaccGrammar<StorageT>,
     pub(crate) token_cost: Box<TokenCostFn<'a, StorageT>>,


### PR DESCRIPTION
This is based on https://github.com/softdevteam/grmtools/pull/174: it tries to decouple the lifetime of a lexer from its input. That PR is a work of near genius: I simply would not have imagined that the outcome it achieves is possible without the PR as a proof-of-existence. The only minor problem was that I couldn't work out how it achieved its effect. I therefore tried to simplify the PR, but didn't get very far. I then tried reimplementing it, and didn't get very far with that either.

This PR is the result of me taking a different approach. First I simplified and unified the existing lifetimes in grmtools, because there were several inconsistencies, which I thought might be responsible for some of the pain in #174. Once that was done I could then add an explicit `'input` lifetime in https://github.com/softdevteam/grmtools/commit/91dab3fd5f21347e87441bb7c1b34493d519ac58 which I *think* achieves the same effect as #174. Certainly it is enough to allow this program to now compile:

```rust
      fn main() {
          let lexerdef = t_l::lexerdef();
          let input = "a";
          let t = {
              let lexer = lexerdef.lexer(&input);
              let lx = lexer.iter().next().unwrap().unwrap();
              lexer.span_str(lx.span())
          };
      }
```

where previously rustc would complain:

```
error[E0597]: `lexer` does not live long enough
  --> src/main.rs:12:9
   |
9  |     let t = {
   |         - borrow later stored here
...
12 |         lexer.span_str(lx.span())
   |         ^^^^^ borrowed value does not live long enough
13 |     };
   |     - `lexer` dropped here while still borrowed

error: aborting due to previous error
```

However, I am not sure if this PR is able to handle all the same cases as #174. I'm hoping that @valarauca will be able to let me know if this solves the problem that led him to create #174. 