### PR TITLE
Split the lexer trait in two

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,14 +2,24 @@
 
 ## Breaking change
 
-* `Lexer` now takes a lifetime `'input` which allows the input to last longer
-  than the `Lexer` itself. `Lexer::span_str` and `Lexer::span_lines_str` have
-  changed from:
+* The `Lexer` trait has been broken into two: `Lexer` and `NonStreamingLexer`.
+  The former trait is now only capable of producing `Lexeme`s: the latter is
+  capable of producing substrings of the input and calculating line/column
+  information. This split allows the flexibility to introduce streaming lexers
+  in the future (which will not be able to produce substrings of the input in
+  the same way as a `NonStreamingLexer`).
+
+  Most users will need to replace references to the `Lexer` trait
+  in their code to `NonStreamingLexer`.
+
+* `NonStreamingLexer` takes a lifetime `'input` which allows the input to last
+  longer than the `NonStreamingLexer` itself. `Lexer::span_str` and
+  `Lexer::span_lines_str` had the following definitions:
     ```rustc
     fn span_str(&self, span: Span) -> &str;
     fn span_lines_str(&self, span: Span) -> &str;
     ```
-  to:
+  As part of `NonStreamingLexer` their definitions are now:
     ```rustc
     fn span_str(&self, span: Span) -> &'input str;
     fn span_lines_str(&self, span: Span) -> &'input str;
@@ -22,8 +32,8 @@
     ```
     error[E0106]: missing lifetime specifier
     ```
-  then it is likely that you need to change a type from `Lexer` to
-  `Lexer<'input>`.
+  then it is likely that you need to change a type from `NonStreamingLexer` to
+  `NonStreamingLexer<'input>`.
 
 
 # grmtools 0.6.2 (2020-03-22)

--- a/doc/src/ast_example.md
+++ b/doc/src/ast_example.md
@@ -68,7 +68,7 @@ Our `main.rs` file then looks as follows:
 use std::io::{self, BufRead, Write};
 
 use lrlex::lrlex_mod;
-use lrpar::{lrpar_mod, Lexer, Span};
+use lrpar::{lrpar_mod, NonStreamingLexer, Span};
 
 lrlex_mod!("calc.l");
 lrpar_mod!("calc.y");
@@ -113,7 +113,7 @@ fn main() {
     }
 }
 
-fn eval(lexer: &dyn Lexer<u32>, e: Expr) -> Result<u64, (Span, &'static str)> {
+fn eval(lexer: &dyn NonStreamingLexer<u32>, e: Expr) -> Result<u64, (Span, &'static str)> {
     match e {
         Expr::Add { span, lhs, rhs } => eval(lexer, *lhs)?
             .checked_add(eval(lexer, *rhs)?)

--- a/lrlex/src/lib/builder.rs
+++ b/lrlex/src/lib/builder.rs
@@ -18,7 +18,7 @@ use regex::Regex;
 use try_from::TryFrom;
 use typename::TypeName;
 
-use crate::{lexer::LexerDef, parser::parse_lex};
+use crate::{lexer::NonStreamingLexerDef, parser::parse_lex};
 
 const RUST_FILE_EXT: &str = "rs";
 
@@ -246,14 +246,14 @@ where
     }
 }
 
-impl<StorageT: Copy + Debug + Eq + TypeName> LexerDef<StorageT> {
+impl<StorageT: Copy + Debug + Eq + TypeName> NonStreamingLexerDef<StorageT> {
     pub(crate) fn rust_pp(&self, outs: &mut String) {
         // Header
         outs.push_str(&format!(
-            "use lrlex::{{LexerDef, Rule}};
+            "use lrlex::{{NonStreamingLexerDef, Rule}};
 
 #[allow(dead_code)]
-pub fn lexerdef() -> LexerDef<{}> {{
+pub fn lexerdef() -> NonStreamingLexerDef<{}> {{
     let rules = vec![",
             StorageT::type_name()
         ));
@@ -281,7 +281,7 @@ Rule::new({}, {}, \"{}\".to_string()).unwrap(),",
         outs.push_str(
             "
 ];
-    LexerDef::new(rules)
+    NonStreamingLexerDef::new(rules)
 }
 "
         );

--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -45,8 +45,8 @@ impl<StorageT> Rule<StorageT> {
     }
 }
 
-/// This struct represents, in essence, a .l file in memory. From it one can produce a `NonStreamingLexer`
-/// which actually lexes inputs.
+/// This struct represents, in essence, a .l file in memory. From it one can produce an
+/// [LRNonStreamingLexer] which actually lexes inputs.
 pub struct NonStreamingLexerDef<StorageT> {
     pub(crate) rules: Vec<Rule<StorageT>>
 }
@@ -156,7 +156,8 @@ impl<StorageT: Copy + Eq + Hash + PrimInt + Unsigned> NonStreamingLexerDef<Stora
         self.rules.iter()
     }
 
-    /// Return a lexer for the `String` `s` that will lex relative to this `NonStreamingLexerDef`.
+    /// Return an [LRNonStreamingLexer] for the `String` `s` that will lex relative to this
+    /// [NonStreamingLexerDef].
     pub fn lexer<'lexer, 'input: 'lexer>(
         &'lexer self,
         s: &'input str
@@ -165,8 +166,9 @@ impl<StorageT: Copy + Eq + Hash + PrimInt + Unsigned> NonStreamingLexerDef<Stora
     }
 }
 
-/// A lexer holds a reference to a string and can lex it into `Lexeme`s. Although the struct is
-/// tied to a single string, no guarantees are made about whether the lexemes are cached or not.
+/// An `LRNonStreamingLexer` holds a reference to a string and can lex it into [lrpar::Lexeme]s.
+/// Although the struct is tied to a single string, no guarantees are made about whether the
+/// lexemes are cached or not.
 pub struct LRNonStreamingLexer<'lexer, 'input: 'lexer, StorageT> {
     s: &'input str,
     lexemes: Vec<Result<Lexeme<StorageT>, LexError>>,

--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -13,7 +13,7 @@ mod parser;
 use crate::parser::parse_lex;
 pub use crate::{
     builder::LexerBuilder,
-    lexer::{LexerDef, Rule}
+    lexer::{NonStreamingLexerDef, Rule}
 };
 
 pub type LexBuildResult<T> = Result<T, LexBuildError>;
@@ -58,7 +58,7 @@ impl fmt::Display for LexBuildError {
 
 pub fn build_lex<StorageT: Copy + Eq + Hash + PrimInt + TryFrom<usize> + Unsigned>(
     s: &str
-) -> Result<LexerDef<StorageT>, LexBuildError> {
+) -> Result<NonStreamingLexerDef<StorageT>, LexBuildError> {
     parse_lex(s)
 }
 

--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -1,3 +1,10 @@
+//! `lrlex` is a partial replacement for [`lex`](http://dinosaur.compilertools.net/lex/index.html)
+//! / [`flex`](https://westes.github.io/flex/manual/). It takes in a `.l` file and statically
+//! compiles it to Rust code. The resulting [NonStreamingLexerDef] can then be given an input
+//! string, from which it instantiates an [LRNonStreamingLexer]. This provides an iterator which
+//! can produce the sequence of [lrpar::Lexeme]s for that input, as well as answer basic queries
+//! about [lrpar::Span]s (e.g. extracting substrings, calculating line and column numbers).
+
 #![allow(clippy::new_without_default)]
 #![allow(clippy::type_complexity)]
 
@@ -13,7 +20,7 @@ mod parser;
 use crate::parser::parse_lex;
 pub use crate::{
     builder::LexerBuilder,
-    lexer::{NonStreamingLexerDef, Rule}
+    lexer::{LRNonStreamingLexer, NonStreamingLexerDef, Rule}
 };
 
 pub type LexBuildResult<T> = Result<T, LexBuildError>;

--- a/lrlex/src/lib/parser.rs
+++ b/lrlex/src/lib/parser.rs
@@ -4,7 +4,7 @@ use num_traits::{PrimInt, Unsigned};
 use try_from::TryFrom;
 
 use crate::{
-    lexer::{LexerDef, Rule},
+    lexer::{NonStreamingLexerDef, Rule},
     LexBuildError, LexBuildResult, LexErrorKind
 };
 
@@ -164,8 +164,8 @@ impl<StorageT: TryFrom<usize>> LexParser<StorageT> {
 
 pub fn parse_lex<StorageT: Copy + Eq + Hash + PrimInt + TryFrom<usize> + Unsigned>(
     s: &str
-) -> LexBuildResult<LexerDef<StorageT>> {
-    LexParser::new(s.to_string()).map(|p| LexerDef::new(p.rules))
+) -> LexBuildResult<NonStreamingLexerDef<StorageT>> {
+    LexParser::new(s.to_string()).map(|p| NonStreamingLexerDef::new(p.rules))
 }
 
 #[cfg(test)]

--- a/lrlex/src/main.rs
+++ b/lrlex/src/main.rs
@@ -7,7 +7,7 @@ use std::{
     process
 };
 
-use lrlex::{build_lex, LexerDef};
+use lrlex::{build_lex, NonStreamingLexerDef};
 use lrpar::Lexer;
 
 fn usage(prog: &str, msg: &str) {
@@ -52,10 +52,11 @@ fn main() {
     }
 
     let lex_l_path = &matches.free[0];
-    let lexerdef: LexerDef<usize> = build_lex(&read_file(lex_l_path)).unwrap_or_else(|s| {
-        writeln!(&mut stderr(), "{}: {}", &lex_l_path, &s).ok();
-        process::exit(1);
-    });
+    let lexerdef: NonStreamingLexerDef<usize> =
+        build_lex(&read_file(lex_l_path)).unwrap_or_else(|s| {
+            writeln!(&mut stderr(), "{}: {}", &lex_l_path, &s).ok();
+            process::exit(1);
+        });
     let input = &read_file(&matches.free[1]);
     for r in lexerdef.lexer(input).iter() {
         match r {

--- a/lrpar/cttests/src/lib.rs
+++ b/lrpar/cttests/src/lib.rs
@@ -1,9 +1,9 @@
 use lrlex::lrlex_mod;
 use lrpar::lrpar_mod;
 #[cfg(test)]
-use lrpar::Lexer;
-#[cfg(test)]
 use lrpar::Span;
+#[cfg(test)]
+use lrpar::{Lexer, NonStreamingLexer};
 
 lrlex_mod!("calc_multitypes.l");
 lrpar_mod!("calc_multitypes.y");

--- a/lrpar/examples/calc_ast/src/main.rs
+++ b/lrpar/examples/calc_ast/src/main.rs
@@ -1,7 +1,7 @@
 use std::io::{self, BufRead, Write};
 
 use lrlex::lrlex_mod;
-use lrpar::{lrpar_mod, Lexer, Span};
+use lrpar::{lrpar_mod, NonStreamingLexer, Span};
 
 // Using `lrlex_mod!` brings the lexer for `calc.l` into scope. By default the module name will be
 // `calc_l` (i.e. the file name, minus any extensions, with a suffix of `_l`).
@@ -52,7 +52,7 @@ fn main() {
     }
 }
 
-fn eval(lexer: &dyn Lexer<u32>, e: Expr) -> Result<u64, (Span, &'static str)> {
+fn eval(lexer: &dyn NonStreamingLexer<u32>, e: Expr) -> Result<u64, (Span, &'static str)> {
     match e {
         Expr::Add { span, lhs, rhs } => eval(lexer, *lhs)?
             .checked_add(eval(lexer, *rhs)?)

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -461,7 +461,7 @@ where
                 outs.push_str(&format!(
                     "
     #[allow(dead_code)]
-    pub fn parse<'lexer, 'input: 'lexer>(lexer: &'lexer dyn ::lrpar::Lexer<'input, {storaget}>)
+    pub fn parse<'lexer, 'input: 'lexer>(lexer: &'lexer dyn ::lrpar::NonStreamingLexer<'input, {storaget}>)
           -> (::std::option::Option<{actiont}>, ::std::vec::Vec<::lrpar::LexParseError<{storaget}>>)
     {{",
                     storaget = StorageT::type_name(),
@@ -472,7 +472,7 @@ where
                 outs.push_str(&format!(
                     "
     #[allow(dead_code)]
-    pub fn parse(lexer: &dyn ::lrpar::Lexer<{storaget}>)
+    pub fn parse(lexer: &dyn ::lrpar::NonStreamingLexer<{storaget}>)
           -> (::std::option::Option<::lrpar::Node<{storaget}>>,
               ::std::vec::Vec<::lrpar::LexParseError<{storaget}>>)
     {{",
@@ -483,7 +483,7 @@ where
                 outs.push_str(&format!(
                     "
     #[allow(dead_code)]
-    pub fn parse(lexer: &dyn ::lrpar::Lexer<{storaget}>)
+    pub fn parse(lexer: &dyn ::lrpar::NonStreamingLexer<{storaget}>)
           -> ::std::vec::Vec<::lrpar::LexParseError<{storaget}>>
     {{",
                     storaget = StorageT::type_name()
@@ -522,7 +522,7 @@ where
                 outs.push_str(&format!(
                     "\n        #[allow(clippy::type_complexity)]
         let mut actions: ::std::vec::Vec<&dyn Fn(::cfgrammar::RIdx<{storaget}>,
-                       &'lexer dyn ::lrpar::Lexer<'input, {storaget}>,
+                       &'lexer dyn ::lrpar::NonStreamingLexer<'input, {storaget}>,
                        ::lrpar::Span,
                        ::std::vec::Drain<::lrpar::parser::AStackType<{actionskind}<'input>, {storaget}>>)
                     -> {actionskind}<'input>> = ::std::vec::Vec::new();\n",
@@ -628,7 +628,7 @@ where
             // the same time extract &str from tokens and actiontype from nonterminals.
             outs.push_str(&format!(
                 "    fn {prefix}wrapper_{}<'lexer, 'input: 'lexer>({prefix}ridx: ::cfgrammar::RIdx<{storaget}>,
-                      {prefix}lexer: &'lexer dyn ::lrpar::Lexer<'input, {storaget}>,
+                      {prefix}lexer: &'lexer dyn ::lrpar::NonStreamingLexer<'input, {storaget}>,
                       {prefix}span: ::lrpar::Span,
                       mut {prefix}args: ::std::vec::Drain<::lrpar::parser::AStackType<{actionskind}<'input>, {storaget}>>)
                    -> {actionskind}<'input> {{",
@@ -787,7 +787,7 @@ where
                 "    // {rulename}
     #[allow(clippy::too_many_arguments)]
     fn {prefix}action_{}<'lexer, 'input: 'lexer>({prefix}ridx: ::cfgrammar::RIdx<{storaget}>,
-                     {prefix}lexer: &'lexer dyn ::lrpar::Lexer<'input, {storaget}>,
+                     {prefix}lexer: &'lexer dyn ::lrpar::NonStreamingLexer<'input, {storaget}>,
                      {prefix}span: ::lrpar::Span,
                      {args}) {returnt} {{\n",
                 usize::from(pidx),

--- a/lrpar/src/lib/lex.rs
+++ b/lrpar/src/lib/lex.rs
@@ -35,14 +35,18 @@ impl fmt::Display for LexError {
     }
 }
 
-/// The trait which all lexers which want to interact with `lrpar` must implement.
-pub trait Lexer<'input, StorageT: Hash + PrimInt + Unsigned> {
+/// The base trait which all lexers which want to interact with `lrpar` must implement.
+pub trait Lexer<StorageT: Hash + PrimInt + Unsigned> {
     /// Iterate over all the lexemes in this lexer. Note that:
     ///   * The lexer may or may not stop after the first [LexError] is encountered.
     ///   * There are no guarantees about whether the lexer caches anything if this method is
     ///     called more than once (i.e. it might be slow to call this more than once).
     fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = Result<Lexeme<StorageT>, LexError>> + 'a>;
+}
 
+/// A `NonStreamingLexer` is one that takes input in one go, and is then able to hand out
+/// substrings to that input and calculate line and column numbers from a [Span].
+pub trait NonStreamingLexer<'input, StorageT: Hash + PrimInt + Unsigned>: Lexer<StorageT> {
     /// Return the user input associated with a [Span].
     ///
     /// # Panics

--- a/lrpar/src/lib/lex.rs
+++ b/lrpar/src/lib/lex.rs
@@ -39,8 +39,8 @@ impl fmt::Display for LexError {
 pub trait Lexer<StorageT: Hash + PrimInt + Unsigned> {
     /// Iterate over all the lexemes in this lexer. Note that:
     ///   * The lexer may or may not stop after the first [LexError] is encountered.
-    ///   * There are no guarantees about whether the lexer caches anything if this method is
-    ///     called more than once (i.e. it might be slow to call this more than once).
+    ///   * There are no guarantees about what happens if this function is called more than once.
+    ///     For example, a streaming lexer may only produce [Lexeme]s on the first call.
     fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = Result<Lexeme<StorageT>, LexError>> + 'a>;
 }
 

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -183,7 +183,7 @@ mod cpctplus;
 pub mod ctbuilder;
 #[doc(hidden)]
 pub mod lex;
-pub use crate::lex::{LexError, Lexeme, Lexer};
+pub use crate::lex::{LexError, Lexeme, Lexer, NonStreamingLexer};
 mod panic;
 #[doc(hidden)]
 pub mod parser;


### PR DESCRIPTION
The previous `Lexer` trait was too inflexible: it could only be used with lexers that were given their input in a single shot. This is fine for non-streaming lexers, but if we ever want to support streaming lexers (e.g. that incrementally lex input taken from a network) in the future, is clearly supoptimal. We might as well bite the bullet now with the two traits looking as follows:

```rust
  pub trait Lexer<StorageT: Hash + PrimInt + Unsigned> {
    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = Result<Lexeme<StorageT>, LexError>> + 'a>;
  }
```

```rust
  pub trait NonStreamingLexer<'input, StorageT: Hash + PrimInt + Unsigned>: Lexer<StorageT> {
    fn span_str(&self, span: Span) -> &'input str;
    fn span_lines_str(&self, span: Span) -> &'input str;
    fn line_col(&self, span: Span) -> ((usize, usize), (usize, usize));
  }
```

In a theoretically perfect world, we would probably structure this as follows:

```rust
  pub trait Lexer<StorageT: Hash + PrimInt + Unsigned> {
    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = Result<Lexeme<StorageT>, LexError>> + 'a>;
  }

  pub trait LineColLexer<StorageT: Hash + PrimInt + Unsigned>: Lexer<StorageT> {
    fn line_col(&self, span: Span) -> ((usize, usize), (usize, usize));
  }

  pub trait NonStreamingLexer<'input, StorageT: Hash + PrimInt + Unsigned>: LineColLexer<StorageT> {
    fn span_str(&self, span: Span) -> &'input str;
    fn span_lines_str(&self, span: Span) -> &'input str;
  }
```

because there's one could build streaming lexers which can answer `line_col` queries. However, splitting things into three traits is rather annoying, as most users want access to `line_col` as well as `span_str`, so they would end up importing `{LineColLexer, NonStreamingLexer}` which seems a bit of boilerplate too far. So this PR collapses `LineColLexer` and `NonStreamingLexer` into one to avoid this boilerplate.