### PR TITLE
Remove the typename crate and use std::any::type_name.

### DIFF
--- a/lrlex/Cargo.toml
+++ b/lrlex/Cargo.toml
@@ -24,4 +24,3 @@ lrpar = { path = "../lrpar", version = "0.7" }
 regex = "1.3"
 num-traits = "0.2"
 try_from = "0.3"
-typename = "0.1"

--- a/lrlex/src/lib/builder.rs
+++ b/lrlex/src/lib/builder.rs
@@ -1,6 +1,7 @@
 //! Build grammars at run-time.
 
 use std::{
+    any::type_name,
     collections::{HashMap, HashSet},
     convert::AsRef,
     env::{current_dir, var},
@@ -16,7 +17,6 @@ use lazy_static::lazy_static;
 use num_traits::{PrimInt, Unsigned};
 use regex::Regex;
 use try_from::TryFrom;
-use typename::TypeName;
 
 use crate::{lexer::NonStreamingLexerDef, parser::parse_lex};
 
@@ -37,7 +37,7 @@ pub struct LexerBuilder<'a, StorageT = u32> {
 
 impl<'a, StorageT> LexerBuilder<'a, StorageT>
 where
-    StorageT: Copy + Debug + Eq + Hash + PrimInt + TryFrom<usize> + TypeName + Unsigned
+    StorageT: Copy + Debug + Eq + Hash + PrimInt + TryFrom<usize> + Unsigned
 {
     /// Create a new `LexerBuilder`.
     ///
@@ -207,7 +207,7 @@ where
                     outs.push_str(&format!(
                         "#[allow(dead_code)]\npub const T_{}: {} = {:?};\n",
                         n.to_ascii_uppercase(),
-                        StorageT::type_name(),
+                        type_name::<StorageT>(),
                         *id
                     ));
                 }
@@ -246,7 +246,7 @@ where
     }
 }
 
-impl<StorageT: Copy + Debug + Eq + TypeName> NonStreamingLexerDef<StorageT> {
+impl<StorageT: Copy + Debug + Eq> NonStreamingLexerDef<StorageT> {
     pub(crate) fn rust_pp(&self, outs: &mut String) {
         // Header
         outs.push_str(&format!(
@@ -255,7 +255,7 @@ impl<StorageT: Copy + Debug + Eq + TypeName> NonStreamingLexerDef<StorageT> {
 #[allow(dead_code)]
 pub fn lexerdef() -> NonStreamingLexerDef<{}> {{
     let rules = vec![",
-            StorageT::type_name()
+            type_name::<StorageT>()
         ));
 
         // Individual rules

--- a/lrpar/Cargo.toml
+++ b/lrpar/Cargo.toml
@@ -32,7 +32,6 @@ packedvec = "1.2"
 rmp-serde = "0.14"
 serde = { version="1.0", features=["derive"] }
 static_assertions = "1.1"
-typename = "0.1"
 vob = "2.0"
 regex = "1.3"
 


### PR DESCRIPTION
The typename crate is now deprecated because we can get the same behaviour from the standard library with `std::any::type_name`.