### PR TITLE
Change the lrlex API to support generating different styles of lexers in the future

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,12 @@
-# grmtools 0.7.1 (20xx-xx-xx)
+# grmtools 0.8.0 (20xx-xx-xx)
+
+## Breaking changes
+
+* `lrlex` now uses a `LexerDef` which all lexer definitions must `impl`. This
+  means that if you want to call methods on a concrete lexer definition, you
+  will almost certainly need to import `lrlex::LexerDef`.
+
+## Deprecations
 
 * `lrlex::NonStreamingLexerDef` has been renamed to
   `lrlex::LRNonStreamingLexerDef`; use of the former is deprecated.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,9 @@
 
 * `lrlex` now uses a `LexerDef` which all lexer definitions must `impl`. This
   means that if you want to call methods on a concrete lexer definition, you
-  will almost certainly need to import `lrlex::LexerDef`.
+  will almost certainly need to import `lrlex::LexerDef`. This opens the
+  possibility that lrlex can seamlessly produce lexers other than
+  `LRNonStreamingLexerDef`s in the future.
 
 ## Deprecations
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,15 @@
+# grmtools 0.7.1 (20xx-xx-xx)
+
+* `lrlex::NonStreamingLexerDef` has been renamed to
+  `lrlex::LRNonStreamingLexerDef`; use of the former is deprecated.
+
+* The `lrlex::build_lex` function has been deprecated in favour of
+  `LRNonStreamingLexerDef::from_str`.
+
+
 # grmtools 0.7.0 (2020-04-30)
 
-## Breaking change
+## Breaking changes
 
 * The `Lexer` trait has been broken into two: `Lexer` and `NonStreamingLexer`.
   The former trait is now only capable of producing `Lexeme`s: the latter is

--- a/lrlex/src/lib/builder.rs
+++ b/lrlex/src/lib/builder.rs
@@ -18,7 +18,10 @@ use num_traits::{PrimInt, Unsigned};
 use regex::Regex;
 use try_from::TryFrom;
 
-use crate::{lexer::LRNonStreamingLexerDef, parser::parse_lex};
+use crate::{
+    lexer::{LRNonStreamingLexerDef, LexerDef},
+    parser::parse_lex
+};
 
 const RUST_FILE_EXT: &str = "rs";
 
@@ -250,7 +253,7 @@ impl<StorageT: Copy + Debug + Eq> LRNonStreamingLexerDef<StorageT> {
     pub(crate) fn rust_pp(&self, outs: &mut String) {
         // Header
         outs.push_str(&format!(
-            "use lrlex::{{LRNonStreamingLexerDef, Rule}};
+            "use lrlex::{{LexerDef, LRNonStreamingLexerDef, Rule}};
 
 #[allow(dead_code)]
 pub fn lexerdef() -> LRNonStreamingLexerDef<{}> {{

--- a/lrlex/src/lib/builder.rs
+++ b/lrlex/src/lib/builder.rs
@@ -18,7 +18,7 @@ use num_traits::{PrimInt, Unsigned};
 use regex::Regex;
 use try_from::TryFrom;
 
-use crate::{lexer::NonStreamingLexerDef, parser::parse_lex};
+use crate::{lexer::LRNonStreamingLexerDef, parser::parse_lex};
 
 const RUST_FILE_EXT: &str = "rs";
 
@@ -246,14 +246,14 @@ where
     }
 }
 
-impl<StorageT: Copy + Debug + Eq> NonStreamingLexerDef<StorageT> {
+impl<StorageT: Copy + Debug + Eq> LRNonStreamingLexerDef<StorageT> {
     pub(crate) fn rust_pp(&self, outs: &mut String) {
         // Header
         outs.push_str(&format!(
-            "use lrlex::{{NonStreamingLexerDef, Rule}};
+            "use lrlex::{{LRNonStreamingLexerDef, Rule}};
 
 #[allow(dead_code)]
-pub fn lexerdef() -> NonStreamingLexerDef<{}> {{
+pub fn lexerdef() -> LRNonStreamingLexerDef<{}> {{
     let rules = vec![",
             type_name::<StorageT>()
         ));
@@ -281,7 +281,7 @@ Rule::new({}, {}, \"{}\".to_string()).unwrap(),",
         outs.push_str(
             "
 ];
-    NonStreamingLexerDef::new(rules)
+    LRNonStreamingLexerDef::from_rules(rules)
 }
 "
         );

--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -378,7 +378,6 @@ impl<'lexer, 'input: 'lexer, StorageT: Copy + Eq + Hash + PrimInt + Unsigned>
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::parser::parse_lex;
     use std::collections::HashMap;
 
     #[test]
@@ -390,7 +389,7 @@ mod test {
 [ \t] ;
         "
         .to_string();
-        let mut lexerdef = parse_lex(&src).unwrap();
+        let mut lexerdef = LRNonStreamingLexerDef::from_str(&src).unwrap();
         let mut map = HashMap::new();
         map.insert("int", 0);
         map.insert("id", 1);
@@ -419,7 +418,7 @@ mod test {
 [0-9]+ 'int'
         "
         .to_string();
-        let lexerdef = parse_lex::<u8>(&src).unwrap();
+        let lexerdef = LRNonStreamingLexerDef::<u8>::from_str(&src).unwrap();
         match lexerdef.lexer(&"abc").iter().next().unwrap() {
             Ok(_) => panic!("Invalid input lexed"),
             Err(e) => {
@@ -437,7 +436,7 @@ if 'IF'
 [a-z]+ 'ID'
 [ ] ;"
             .to_string();
-        let mut lexerdef = parse_lex(&src).unwrap();
+        let mut lexerdef = LRNonStreamingLexerDef::from_str(&src).unwrap();
         let mut map = HashMap::new();
         map.insert("IF", 0);
         map.insert("ID", 1);
@@ -465,7 +464,7 @@ if 'IF'
 [a❤]+ 'ID'
 [ ] ;"
             .to_string();
-        let mut lexerdef = parse_lex(&src).unwrap();
+        let mut lexerdef = LRNonStreamingLexerDef::from_str(&src).unwrap();
         let mut map = HashMap::new();
         map.insert("ID", 0u8);
         assert_eq!(lexerdef.set_rule_ids(&map), (None, None));
@@ -493,7 +492,7 @@ if 'IF'
 [a-z]+ 'ID'
 [ \\n] ;"
             .to_string();
-        let mut lexerdef = parse_lex(&src).unwrap();
+        let mut lexerdef = LRNonStreamingLexerDef::from_str(&src).unwrap();
         let mut map = HashMap::new();
         map.insert("ID", 0u8);
         assert_eq!(lexerdef.set_rule_ids(&map), (None, None));
@@ -529,7 +528,7 @@ if 'IF'
 [a-z❤]+ 'ID'
 [ \\n] ;"
             .to_string();
-        let mut lexerdef = parse_lex(&src).unwrap();
+        let mut lexerdef = LRNonStreamingLexerDef::from_str(&src).unwrap();
         let mut map = HashMap::new();
         map.insert("ID", 0u8);
         assert_eq!(lexerdef.set_rule_ids(&map), (None, None));
@@ -552,7 +551,7 @@ if 'IF'
 [a-z]+ 'ID'
 [ \\n] ;"
             .to_string();
-        let mut lexerdef = parse_lex(&src).unwrap();
+        let mut lexerdef = LRNonStreamingLexerDef::from_str(&src).unwrap();
         let mut map = HashMap::new();
         map.insert("ID", 0u8);
         assert_eq!(lexerdef.set_rule_ids(&map), (None, None));
@@ -568,7 +567,7 @@ if 'IF'
 [a-z]+ 'ID'
 [ \\n] ;"
             .to_string();
-        let mut lexerdef = parse_lex(&src).unwrap();
+        let mut lexerdef = LRNonStreamingLexerDef::from_str(&src).unwrap();
         let mut map = HashMap::new();
         map.insert("INT", 0u8);
         let mut missing_from_lexer = HashSet::new();
@@ -596,7 +595,7 @@ if 'IF'
 '.*' 'STR'
 [ \\n] ;"
             .to_string();
-        let mut lexerdef = parse_lex(&src).unwrap();
+        let mut lexerdef = LRNonStreamingLexerDef::from_str(&src).unwrap();
         let mut map = HashMap::new();
         map.insert("STR", 0u8);
         assert_eq!(lexerdef.set_rule_ids(&map), (None, None));

--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -18,7 +18,7 @@ mod lexer;
 mod parser;
 
 pub use crate::{
-    builder::LexerBuilder,
+    builder::{LexerBuilder, LexerKind},
     lexer::{LRNonStreamingLexer, LRNonStreamingLexerDef, LexerDef, Rule}
 };
 

--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -1,6 +1,6 @@
 //! `lrlex` is a partial replacement for [`lex`](http://dinosaur.compilertools.net/lex/index.html)
 //! / [`flex`](https://westes.github.io/flex/manual/). It takes in a `.l` file and statically
-//! compiles it to Rust code. The resulting [NonStreamingLexerDef] can then be given an input
+//! compiles it to Rust code. The resulting [LRNonStreamingLexerDef] can then be given an input
 //! string, from which it instantiates an [LRNonStreamingLexer]. This provides an iterator which
 //! can produce the sequence of [lrpar::Lexeme]s for that input, as well as answer basic queries
 //! about [lrpar::Span]s (e.g. extracting substrings, calculating line and column numbers).
@@ -17,10 +17,9 @@ mod builder;
 mod lexer;
 mod parser;
 
-use crate::parser::parse_lex;
 pub use crate::{
     builder::LexerBuilder,
-    lexer::{LRNonStreamingLexer, NonStreamingLexerDef, Rule}
+    lexer::{LRNonStreamingLexer, LRNonStreamingLexerDef, Rule}
 };
 
 pub type LexBuildResult<T> = Result<T, LexBuildError>;
@@ -63,11 +62,18 @@ impl fmt::Display for LexBuildError {
     }
 }
 
+#[deprecated(since = "0.7.1", note = "Please use LRNonStreamingLexerDef::from_str")]
 pub fn build_lex<StorageT: Copy + Eq + Hash + PrimInt + TryFrom<usize> + Unsigned>(
     s: &str
-) -> Result<NonStreamingLexerDef<StorageT>, LexBuildError> {
-    parse_lex(s)
+) -> Result<LRNonStreamingLexerDef<StorageT>, LexBuildError> {
+    LRNonStreamingLexerDef::from_str(s)
 }
+
+#[deprecated(
+    since = "0.7.1",
+    note = "This struct has been renamed to LRNonStreamingLexerDef"
+)]
+pub type NonStreamingLexerDef<StorageT> = LRNonStreamingLexerDef<StorageT>;
 
 /// A convenience macro for including statically compiled `.l` files. A file `src/a/b/c.l` which is
 /// statically compiled by lrlex can then be used in a crate with `lrlex_mod!("a/b/c.l")`.

--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -19,7 +19,7 @@ mod parser;
 
 pub use crate::{
     builder::LexerBuilder,
-    lexer::{LRNonStreamingLexer, LRNonStreamingLexerDef, Rule}
+    lexer::{LRNonStreamingLexer, LRNonStreamingLexerDef, LexerDef, Rule}
 };
 
 pub type LexBuildResult<T> = Result<T, LexBuildError>;
@@ -62,7 +62,7 @@ impl fmt::Display for LexBuildError {
     }
 }
 
-#[deprecated(since = "0.7.1", note = "Please use LRNonStreamingLexerDef::from_str")]
+#[deprecated(since = "0.8.0", note = "Please use LRNonStreamingLexerDef::from_str")]
 pub fn build_lex<StorageT: Copy + Eq + Hash + PrimInt + TryFrom<usize> + Unsigned>(
     s: &str
 ) -> Result<LRNonStreamingLexerDef<StorageT>, LexBuildError> {
@@ -70,7 +70,7 @@ pub fn build_lex<StorageT: Copy + Eq + Hash + PrimInt + TryFrom<usize> + Unsigne
 }
 
 #[deprecated(
-    since = "0.7.1",
+    since = "0.8.0",
     note = "This struct has been renamed to LRNonStreamingLexerDef"
 )]
 pub type NonStreamingLexerDef<StorageT> = LRNonStreamingLexerDef<StorageT>;

--- a/lrlex/src/lib/parser.rs
+++ b/lrlex/src/lib/parser.rs
@@ -4,18 +4,18 @@ use num_traits::{PrimInt, Unsigned};
 use try_from::TryFrom;
 
 use crate::{
-    lexer::{NonStreamingLexerDef, Rule},
+    lexer::{LRNonStreamingLexerDef, Rule},
     LexBuildError, LexBuildResult, LexErrorKind
 };
 
 pub struct LexParser<StorageT> {
     src: String,
     newlines: Vec<usize>,
-    rules: Vec<Rule<StorageT>>
+    pub(crate) rules: Vec<Rule<StorageT>>
 }
 
 impl<StorageT: TryFrom<usize>> LexParser<StorageT> {
-    fn new(src: String) -> LexBuildResult<LexParser<StorageT>> {
+    pub(crate) fn new(src: String) -> LexBuildResult<LexParser<StorageT>> {
         let mut p = LexParser {
             src,
             newlines: vec![0],
@@ -164,8 +164,8 @@ impl<StorageT: TryFrom<usize>> LexParser<StorageT> {
 
 pub fn parse_lex<StorageT: Copy + Eq + Hash + PrimInt + TryFrom<usize> + Unsigned>(
     s: &str
-) -> LexBuildResult<NonStreamingLexerDef<StorageT>> {
-    LexParser::new(s.to_string()).map(|p| NonStreamingLexerDef::new(p.rules))
+) -> LexBuildResult<LRNonStreamingLexerDef<StorageT>> {
+    LRNonStreamingLexerDef::from_str(s)
 }
 
 #[cfg(test)]

--- a/lrlex/src/lib/parser.rs
+++ b/lrlex/src/lib/parser.rs
@@ -1,12 +1,6 @@
-use std::hash::Hash;
-
-use num_traits::{PrimInt, Unsigned};
 use try_from::TryFrom;
 
-use crate::{
-    lexer::{LRNonStreamingLexerDef, LexerDef, Rule},
-    LexBuildError, LexBuildResult, LexErrorKind
-};
+use crate::{lexer::Rule, LexBuildError, LexBuildResult, LexErrorKind};
 
 pub struct LexParser<StorageT> {
     src: String,
@@ -162,15 +156,10 @@ impl<StorageT: TryFrom<usize>> LexParser<StorageT> {
     }
 }
 
-pub fn parse_lex<StorageT: Copy + Eq + Hash + PrimInt + TryFrom<usize> + Unsigned>(
-    s: &str
-) -> LexBuildResult<LRNonStreamingLexerDef<StorageT>> {
-    LRNonStreamingLexerDef::from_str(s)
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::lexer::{LRNonStreamingLexerDef, LexerDef};
 
     #[test]
     fn test_nooptions() {
@@ -178,13 +167,13 @@ mod test {
 %option nounput
         "
         .to_string();
-        assert!(parse_lex::<u8>(&src).is_err());
+        assert!(LRNonStreamingLexerDef::<u8>::from_str(&src).is_err());
     }
 
     #[test]
     fn test_minimum() {
         let src = "%%".to_string();
-        assert!(parse_lex::<u8>(&src).is_ok());
+        assert!(LRNonStreamingLexerDef::<u8>::from_str(&src).is_ok());
     }
 
     #[test]
@@ -195,7 +184,7 @@ mod test {
 \\+ '+'
 "
         .to_string();
-        let ast = parse_lex::<u8>(&src).unwrap();
+        let ast = LRNonStreamingLexerDef::<u8>::from_str(&src).unwrap();
         let intrule = ast.get_rule_by_name("int").unwrap();
         assert_eq!("int", intrule.name.as_ref().unwrap());
         assert_eq!("[0-9]+", intrule.re_str);
@@ -213,7 +202,7 @@ mod test {
 [0-9]+ ;
 "
         .to_string();
-        let ast = parse_lex::<u8>(&src).unwrap();
+        let ast = LRNonStreamingLexerDef::<u8>::from_str(&src).unwrap();
         let intrule = ast.get_rule(0).unwrap();
         assert!(intrule.name.is_none());
         assert_eq!("[0-9]+", intrule.re_str);
@@ -225,8 +214,8 @@ mod test {
 [0-9]
 'int'"
             .to_string();
-        assert!(parse_lex::<u8>(&src).is_err());
-        match parse_lex::<u8>(&src) {
+        assert!(LRNonStreamingLexerDef::<u8>::from_str(&src).is_err());
+        match LRNonStreamingLexerDef::<u8>::from_str(&src) {
             Ok(_) => panic!("Broken rule parsed"),
             Err(LexBuildError {
                 kind: LexErrorKind::MissingSpace,
@@ -242,8 +231,8 @@ mod test {
         let src = "%%
 [0-9] "
             .to_string();
-        assert!(parse_lex::<u8>(&src).is_err());
-        match parse_lex::<u8>(&src) {
+        assert!(LRNonStreamingLexerDef::<u8>::from_str(&src).is_err());
+        match LRNonStreamingLexerDef::<u8>::from_str(&src) {
             Ok(_) => panic!("Broken rule parsed"),
             Err(LexBuildError {
                 kind: LexErrorKind::MissingSpace,
@@ -259,8 +248,8 @@ mod test {
         let src = "%%
 [0-9] int"
             .to_string();
-        assert!(parse_lex::<u8>(&src).is_err());
-        match parse_lex::<u8>(&src) {
+        assert!(LRNonStreamingLexerDef::<u8>::from_str(&src).is_err());
+        match LRNonStreamingLexerDef::<u8>::from_str(&src) {
             Ok(_) => panic!("Broken rule parsed"),
             Err(LexBuildError {
                 kind: LexErrorKind::InvalidName,
@@ -276,8 +265,8 @@ mod test {
         let src = "%%
 [0-9] 'int"
             .to_string();
-        assert!(parse_lex::<u8>(&src).is_err());
-        match parse_lex::<u8>(&src) {
+        assert!(LRNonStreamingLexerDef::<u8>::from_str(&src).is_err());
+        match LRNonStreamingLexerDef::<u8>::from_str(&src) {
             Ok(_) => panic!("Broken rule parsed"),
             Err(LexBuildError {
                 kind: LexErrorKind::InvalidName,
@@ -294,7 +283,7 @@ mod test {
 [0-9] 'int'
 [0-9] 'int'"
             .to_string();
-        match parse_lex::<u8>(&src) {
+        match LRNonStreamingLexerDef::<u8>::from_str(&src) {
             Ok(_) => panic!("Duplicate rule parsed"),
             Err(LexBuildError {
                 kind: LexErrorKind::DuplicateName,
@@ -314,6 +303,6 @@ mod test {
         for i in 0..257 {
             src.push_str(&format!("x 'x{}'\n", i));
         }
-        parse_lex::<u8>(&src).ok();
+        LRNonStreamingLexerDef::<u8>::from_str(&src).ok();
     }
 }

--- a/lrlex/src/lib/parser.rs
+++ b/lrlex/src/lib/parser.rs
@@ -4,7 +4,7 @@ use num_traits::{PrimInt, Unsigned};
 use try_from::TryFrom;
 
 use crate::{
-    lexer::{LRNonStreamingLexerDef, Rule},
+    lexer::{LRNonStreamingLexerDef, LexerDef, Rule},
     LexBuildError, LexBuildResult, LexErrorKind
 };
 

--- a/lrlex/src/main.rs
+++ b/lrlex/src/main.rs
@@ -7,7 +7,7 @@ use std::{
     process
 };
 
-use lrlex::LRNonStreamingLexerDef;
+use lrlex::{LRNonStreamingLexerDef, LexerDef};
 use lrpar::Lexer;
 
 fn usage(prog: &str, msg: &str) {

--- a/lrlex/src/main.rs
+++ b/lrlex/src/main.rs
@@ -7,7 +7,7 @@ use std::{
     process
 };
 
-use lrlex::{build_lex, NonStreamingLexerDef};
+use lrlex::LRNonStreamingLexerDef;
 use lrpar::Lexer;
 
 fn usage(prog: &str, msg: &str) {
@@ -52,8 +52,8 @@ fn main() {
     }
 
     let lex_l_path = &matches.free[0];
-    let lexerdef: NonStreamingLexerDef<usize> =
-        build_lex(&read_file(lex_l_path)).unwrap_or_else(|s| {
+    let lexerdef = LRNonStreamingLexerDef::<usize>::from_str(&read_file(lex_l_path))
+        .unwrap_or_else(|s| {
             writeln!(&mut stderr(), "{}: {}", &lex_l_path, &s).ok();
             process::exit(1);
         });

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -8,7 +8,7 @@ use std::{
 
 use cfgrammar::yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind};
 use getopts::Options;
-use lrlex::LRNonStreamingLexerDef;
+use lrlex::{LRNonStreamingLexerDef, LexerDef};
 use lrpar::parser::{RTParserBuilder, RecoveryKind};
 use lrtable::{from_yacc, Minimiser};
 use num_traits::ToPrimitive;

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -8,7 +8,7 @@ use std::{
 
 use cfgrammar::yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind};
 use getopts::Options;
-use lrlex::build_lex;
+use lrlex::LRNonStreamingLexerDef;
 use lrpar::parser::{RTParserBuilder, RecoveryKind};
 use lrtable::{from_yacc, Minimiser};
 use num_traits::ToPrimitive;
@@ -100,7 +100,7 @@ fn main() {
     }
 
     let lex_l_path = &matches.free[0];
-    let mut lexerdef = match build_lex::<u16>(&read_file(lex_l_path)) {
+    let mut lexerdef = match LRNonStreamingLexerDef::<u16>::from_str(&read_file(lex_l_path)) {
         Ok(ast) => ast,
         Err(s) => {
             writeln!(&mut stderr(), "{}: {}", &lex_l_path, &s).ok();


### PR DESCRIPTION
In #178 we made it possible for lrpar to support multiple different styles of lexer. However, lrlex only supported one style of lexer. This PR makes lrlex more flexible such that it can in the future more easily support multiple styles of lexer (though note that this PR does not implement any additional styles!). This does require tidying up lrlex's API, which was never particularly well designed in the first place, and hasn't seen many changes since. The two big changes are to introduce a `LexerDef` trait to lrlex (https://github.com/softdevteam/grmtools/commit/fb265f0aa41db9bd1000bb903a7dacddd22ba380 allowing you to have multiple styles of lexers) and to introduce `LexerKind`s (https://github.com/softdevteam/grmtools/commit/7f9f542b529b0b3bdee0e0cfa401a812303fcb1d allowing you to select which lexer style you want for compile-time code generation). People using the run-time interface now have to reference an explicit lexer type (as can be seen in https://github.com/softdevteam/grmtools/commit/92615b54984cfa1ba11797e8d8cab987a3b6bb15).

Two of the changes can be handled by `deprecated` warnings (https://github.com/softdevteam/grmtools/commit/92615b54984cfa1ba11797e8d8cab987a3b6bb15) but one is a breaking change (https://github.com/softdevteam/grmtools/commit/fb265f0aa41db9bd1000bb903a7dacddd22ba380). Fortunately, in all three cases, very little user code is likely to be affected in practise as these are the run-time-only interfaces, which only programs like nimbleparse will use. Programs which use the compile-time interface (i.e. the vast majority) are not affected at all.