### PR TITLE
Use the "dyn error" trick to simplify action code.

### DIFF
--- a/lrpar/examples/calc_actions/src/main.rs
+++ b/lrpar/examples/calc_actions/src/main.rs
@@ -31,6 +31,7 @@ fn main() {
                 }
                 match res {
                     Some(Ok(r)) => println!("Result: {}", r),
+                    Some(Err(e)) => eprintln!("{}", e),
                     _ => eprintln!("Unable to evaluate expression.")
                 }
             }


### PR DESCRIPTION
This was introduced in #161, and allows us to change `$1.map_err(|_| ())?` to `$1?`. This then allows us to easily cope with other types of error, such as pointing out to the user when overflow has occurred (previously this caused a panic).