### PR TITLE
Use stable rustfmt

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,6 +1,0 @@
-indent_style="Block"
-imports_indent="Block"
-trailing_comma="Never"
-use_try_shorthand=true
-use_field_init_shorthand=true
-merge_imports=true

--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -60,5 +60,5 @@ pub use crate::idxnewtype::{PIdx, RIdx, SIdx, TIdx};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Symbol<StorageT> {
     Rule(RIdx<StorageT>),
-    Token(TIdx<StorageT>)
+    Token(TIdx<StorageT>),
 }

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{HashMap, HashSet},
     error::Error,
-    fmt
+    fmt,
 };
 
 use indexmap::{IndexMap, IndexSet};
@@ -22,27 +22,27 @@ pub struct GrammarAST {
     pub implicit_tokens: Option<HashSet<String>>,
     // Error pretty-printers
     pub epp: HashMap<String, String>,
-    pub programs: Option<String>
+    pub programs: Option<String>,
 }
 
 #[derive(Debug)]
 pub struct Rule {
     pub name: String,
     pub pidxs: Vec<usize>, // index into GrammarAST.prod
-    pub actiont: Option<String>
+    pub actiont: Option<String>,
 }
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct Production {
     pub symbols: Vec<Symbol>,
     pub precedence: Option<String>,
-    pub action: Option<String>
+    pub action: Option<String>,
 }
 
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub enum Symbol {
     Rule(String),
-    Token(String)
+    Token(String),
 }
 
 /// The various different possible grammar validation errors.
@@ -53,14 +53,14 @@ pub enum GrammarValidationErrorKind {
     UnknownRuleRef,
     UnknownToken,
     NoPrecForToken,
-    UnknownEPP
+    UnknownEPP,
 }
 
 /// `GrammarAST` validation errors return an instance of this struct.
 #[derive(Debug)]
 pub struct GrammarValidationError {
     pub kind: GrammarValidationErrorKind,
-    pub sym: Option<Symbol>
+    pub sym: Option<Symbol>,
 }
 
 impl Error for GrammarValidationError {}
@@ -91,7 +91,7 @@ impl fmt::Display for GrammarValidationError {
                 f,
                 "Unknown token '{}' in %epp declaration",
                 self.sym.as_ref().unwrap()
-            )
+            ),
         }
     }
 }
@@ -100,7 +100,7 @@ impl fmt::Display for Symbol {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Symbol::Rule(ref s) => write!(f, "{}", s),
-            Symbol::Token(ref s) => write!(f, "{}", s)
+            Symbol::Token(ref s) => write!(f, "{}", s),
         }
     }
 }
@@ -117,7 +117,7 @@ impl GrammarAST {
             avoid_insert: None,
             implicit_tokens: None,
             epp: HashMap::new(),
-            programs: None
+            programs: None,
         }
     }
 
@@ -127,8 +127,8 @@ impl GrammarAST {
             Rule {
                 name,
                 pidxs: Vec::new(),
-                actiont
-            }
+                actiont,
+            },
         );
     }
 
@@ -137,13 +137,13 @@ impl GrammarAST {
         rule_name: String,
         symbols: Vec<Symbol>,
         precedence: Option<String>,
-        action: Option<String>
+        action: Option<String>,
     ) {
         self.rules[&rule_name].pidxs.push(self.prods.len());
         self.prods.push(Production {
             symbols,
             precedence,
-            action
+            action,
         });
     }
 
@@ -172,14 +172,14 @@ impl GrammarAST {
             None => {
                 return Err(GrammarValidationError {
                     kind: GrammarValidationErrorKind::NoStartRule,
-                    sym: None
+                    sym: None,
                 });
             }
             Some(ref s) => {
                 if !self.rules.contains_key(s) {
                     return Err(GrammarValidationError {
                         kind: GrammarValidationErrorKind::InvalidStartRule,
-                        sym: Some(Symbol::Rule(s.clone()))
+                        sym: Some(Symbol::Rule(s.clone())),
                     });
                 }
             }
@@ -191,13 +191,13 @@ impl GrammarAST {
                     if !self.tokens.contains(n) {
                         return Err(GrammarValidationError {
                             kind: GrammarValidationErrorKind::UnknownToken,
-                            sym: Some(Symbol::Token(n.clone()))
+                            sym: Some(Symbol::Token(n.clone())),
                         });
                     }
                     if !self.precs.contains_key(n) {
                         return Err(GrammarValidationError {
                             kind: GrammarValidationErrorKind::NoPrecForToken,
-                            sym: Some(Symbol::Token(n.clone()))
+                            sym: Some(Symbol::Token(n.clone())),
                         });
                     }
                 }
@@ -207,7 +207,7 @@ impl GrammarAST {
                             if !self.rules.contains_key(name) {
                                 return Err(GrammarValidationError {
                                     kind: GrammarValidationErrorKind::UnknownRuleRef,
-                                    sym: Some(sym.clone())
+                                    sym: Some(sym.clone()),
                                 });
                             }
                         }
@@ -215,7 +215,7 @@ impl GrammarAST {
                             if !self.tokens.contains(name) {
                                 return Err(GrammarValidationError {
                                     kind: GrammarValidationErrorKind::UnknownToken,
-                                    sym: Some(sym.clone())
+                                    sym: Some(sym.clone()),
                                 });
                             }
                         }
@@ -234,7 +234,7 @@ impl GrammarAST {
             }
             return Err(GrammarValidationError {
                 kind: GrammarValidationErrorKind::UnknownEPP,
-                sym: Some(Symbol::Token(k.clone()))
+                sym: Some(Symbol::Token(k.clone())),
             });
         }
         Ok(())
@@ -245,7 +245,7 @@ impl GrammarAST {
 mod test {
     use super::{
         super::{AssocKind, Precedence},
-        GrammarAST, GrammarValidationError, GrammarValidationErrorKind, Symbol
+        GrammarAST, GrammarValidationError, GrammarValidationErrorKind, Symbol,
     };
 
     fn rule(n: &str) -> Symbol {
@@ -264,7 +264,7 @@ mod test {
                 kind: GrammarValidationErrorKind::NoStartRule,
                 ..
             }) => (),
-            _ => panic!("Validation error")
+            _ => panic!("Validation error"),
         }
     }
 
@@ -279,7 +279,7 @@ mod test {
                 kind: GrammarValidationErrorKind::InvalidStartRule,
                 ..
             }) => (),
-            _ => panic!("Validation error")
+            _ => panic!("Validation error"),
         }
     }
 
@@ -314,7 +314,7 @@ mod test {
                 kind: GrammarValidationErrorKind::UnknownRuleRef,
                 ..
             }) => (),
-            _ => panic!("Validation error")
+            _ => panic!("Validation error"),
         }
     }
 
@@ -351,7 +351,7 @@ mod test {
                 kind: GrammarValidationErrorKind::UnknownToken,
                 ..
             }) => (),
-            _ => panic!("Validation error")
+            _ => panic!("Validation error"),
         }
     }
 
@@ -366,7 +366,7 @@ mod test {
                 kind: GrammarValidationErrorKind::UnknownRuleRef,
                 ..
             }) => (),
-            _ => panic!("Validation error")
+            _ => panic!("Validation error"),
         }
     }
 
@@ -382,7 +382,7 @@ mod test {
                 kind: GrammarValidationErrorKind::UnknownEPP,
                 ..
             }) => (),
-            _ => panic!("Validation error")
+            _ => panic!("Validation error"),
         }
     }
 
@@ -393,8 +393,8 @@ mod test {
             "b".to_string(),
             Precedence {
                 level: 1,
-                kind: AssocKind::Left
-            }
+                kind: AssocKind::Left,
+            },
         );
         grm.start = Some("A".to_string());
         grm.tokens.insert("b".to_string());
@@ -403,7 +403,7 @@ mod test {
             "A".to_string(),
             vec![token("b")],
             Some("b".to_string()),
-            None
+            None,
         );
         assert!(grm.complete_and_validate().is_ok());
     }
@@ -417,14 +417,14 @@ mod test {
             "A".to_string(),
             vec![token("b")],
             Some("b".to_string()),
-            None
+            None,
         );
         match grm.complete_and_validate() {
             Err(GrammarValidationError {
                 kind: GrammarValidationErrorKind::UnknownToken,
                 ..
             }) => (),
-            _ => panic!("Validation error")
+            _ => panic!("Validation error"),
         }
         grm.tokens.insert("b".to_string());
         match grm.complete_and_validate() {
@@ -432,7 +432,7 @@ mod test {
                 kind: GrammarValidationErrorKind::NoPrecForToken,
                 ..
             }) => (),
-            _ => panic!("Validation error")
+            _ => panic!("Validation error"),
         }
     }
 }

--- a/cfgrammar/src/lib/yacc/firsts.rs
+++ b/cfgrammar/src/lib/yacc/firsts.rs
@@ -27,12 +27,12 @@ use crate::{RIdx, Symbol, TIdx};
 pub struct YaccFirsts<StorageT> {
     firsts: Vec<Vob>,
     epsilons: Vob,
-    phantom: PhantomData<StorageT>
+    phantom: PhantomData<StorageT>,
 }
 
 impl<StorageT: 'static + PrimInt + Unsigned> YaccFirsts<StorageT>
 where
-    usize: AsPrimitive<StorageT>
+    usize: AsPrimitive<StorageT>,
 {
     /// Generates and returns the firsts set for the given grammar.
     pub fn new(grm: &YaccGrammar<StorageT>) -> Self {
@@ -43,7 +43,7 @@ where
         let mut firsts = YaccFirsts {
             firsts,
             epsilons: Vob::from_elem(usize::from(grm.rules_len()), false),
-            phantom: PhantomData
+            phantom: PhantomData,
         };
 
         // Loop looking for changes to the firsts set, until we reach a fixed point. In essence, we
@@ -145,7 +145,7 @@ where
 mod test {
     use super::{
         super::{YaccGrammar, YaccKind, YaccOriginalActionKind},
-        YaccFirsts
+        YaccFirsts,
     };
     use num_traits::{AsPrimitive, PrimInt, Unsigned};
 
@@ -153,15 +153,15 @@ mod test {
         grm: &YaccGrammar<StorageT>,
         firsts: &YaccFirsts<StorageT>,
         rn: &str,
-        should_be: Vec<&str>
+        should_be: Vec<&str>,
     ) where
-        usize: AsPrimitive<StorageT>
+        usize: AsPrimitive<StorageT>,
     {
         let ridx = grm.rule_idx(rn).unwrap();
         for tidx in grm.iter_tidxs() {
             let n = match grm.token_name(tidx) {
                 Some(n) => n,
-                None => &"<no name>"
+                None => &"<no name>",
             };
             match should_be.iter().position(|&x| x == n) {
                 Some(_) => {
@@ -193,7 +193,7 @@ mod test {
           D: 'd';
           E: D | C;
           F: E;
-          "
+          ",
         )
         .unwrap();
         let firsts = grm.firsts();
@@ -214,7 +214,7 @@ mod test {
           C: 'c';
           D: 'd';
           E: D C;
-          "
+          ",
         )
         .unwrap();
         let firsts = grm.firsts();
@@ -233,7 +233,7 @@ mod test {
           B: 'b' | ;
           C: 'c' | ;
           D: C;
-          "
+          ",
         )
         .unwrap();
         let firsts = grm.firsts();
@@ -253,7 +253,7 @@ mod test {
           A: B C;
           B: 'b' | ;
           C: B 'c' B;
-          "
+          ",
         )
         .unwrap();
         let firsts = grm.firsts();
@@ -272,7 +272,7 @@ mod test {
           %%
           A: B 'b';
           B: 'b' | ;
-          "
+          ",
         )
         .unwrap();
         let firsts = grm.firsts();
@@ -292,7 +292,7 @@ mod test {
           C: D A;
           D: 'd' | ;
           F: C D 'f';
-          "
+          ",
         )
         .unwrap()
     }
@@ -324,7 +324,7 @@ mod test {
           D: D 'd' | F;
           F: 'f' | ;
           G: C D;
-          "
+          ",
         )
         .unwrap();
         let firsts = grm.firsts();

--- a/cfgrammar/src/lib/yacc/follows.rs
+++ b/cfgrammar/src/lib/yacc/follows.rs
@@ -24,12 +24,12 @@ use crate::{RIdx, Symbol, TIdx};
 #[derive(Debug)]
 pub struct YaccFollows<StorageT> {
     follows: Vec<Vob>,
-    phantom: PhantomData<StorageT>
+    phantom: PhantomData<StorageT>,
 }
 
 impl<StorageT: 'static + PrimInt + Unsigned> YaccFollows<StorageT>
 where
-    usize: AsPrimitive<StorageT>
+    usize: AsPrimitive<StorageT>,
 {
     /// Generates and returns the Follows set for the given grammar.
     pub fn new(grm: &YaccGrammar<StorageT>) -> Self {
@@ -95,7 +95,7 @@ where
             if !changed {
                 return YaccFollows {
                     follows,
-                    phantom: PhantomData
+                    phantom: PhantomData,
                 };
             }
         }
@@ -116,7 +116,7 @@ where
 mod test {
     use super::{
         super::{YaccGrammar, YaccKind, YaccOriginalActionKind},
-        YaccFollows
+        YaccFollows,
     };
     use num_traits::{AsPrimitive, PrimInt, Unsigned};
 
@@ -124,9 +124,9 @@ mod test {
         grm: &YaccGrammar<StorageT>,
         follows: &YaccFollows<StorageT>,
         rn: &str,
-        should_be: Vec<&str>
+        should_be: Vec<&str>,
     ) where
-        usize: AsPrimitive<StorageT>
+        usize: AsPrimitive<StorageT>,
     {
         let ridx = grm.rule_idx(rn).unwrap();
         for tidx in grm.iter_tidxs() {
@@ -158,7 +158,7 @@ mod test {
                 T: F T2 ;
                 T2: '*' F T2 | ;
                 F: '(' E ')' | 'ID' ;
-          "
+          ",
         )
         .unwrap();
         let follows = grm.follows();
@@ -182,7 +182,7 @@ mod test {
                 B2: 'w' B | 'u' 'w' B ;
                 D : 'v' D2 ;
                 D2: 'x' B D2 | ;
-          "
+          ",
         )
         .unwrap();
         let follows = grm.follows();
@@ -202,7 +202,7 @@ mod test {
                 %%
                 S: A 'b';
                 A: 'b' | ;
-          "
+          ",
         )
         .unwrap();
         let follows = grm.follows();
@@ -221,7 +221,7 @@ mod test {
                   | E '+' 'N'
                   | '(' E ')'
                   ;
-          "
+          ",
         )
         .unwrap();
         let follows = grm.follows();

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -10,7 +10,7 @@ use super::{
     firsts::YaccFirsts,
     follows::YaccFollows,
     parser::{YaccParser, YaccParserError},
-    YaccKind
+    YaccKind,
 };
 use crate::{PIdx, RIdx, SIdx, Symbol, TIdx};
 
@@ -23,7 +23,7 @@ pub type PrecedenceLevel = u64;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Precedence {
     pub level: PrecedenceLevel,
-    pub kind: AssocKind
+    pub kind: AssocKind,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -31,7 +31,7 @@ pub struct Precedence {
 pub enum AssocKind {
     Left,
     Right,
-    Nonassoc
+    Nonassoc,
 }
 
 /// Representation of a `YaccGrammar`. See the [top-level documentation](../../index.html) for the
@@ -81,7 +81,7 @@ pub struct YaccGrammar<StorageT = u32> {
     /// The actiontypes of rules (one per rule).
     actiontypes: Vec<Option<String>>,
     /// Tokens marked as %avoid_insert (if any).
-    avoid_insert: Option<Vob>
+    avoid_insert: Option<Vob>,
 }
 
 // Internally, we assume that a grammar's start rule has a single production. Since we manually
@@ -95,7 +95,7 @@ impl YaccGrammar<u32> {
 
 impl<StorageT: 'static + PrimInt + Unsigned> YaccGrammar<StorageT>
 where
-    usize: AsPrimitive<StorageT>
+    usize: AsPrimitive<StorageT>,
 {
     /// Takes as input a Yacc grammar of [`YaccKind`](enum.YaccKind.html) as a `String` `s` and returns a
     /// [`YaccGrammar`](grammar/struct.YaccGrammar.html) (or
@@ -337,7 +337,7 @@ where
             actions,
             programs: ast.programs,
             avoid_insert,
-            actiontypes
+            actiontypes,
         })
     }
 
@@ -415,11 +415,12 @@ where
 
     /// Return the index of the rule named `n` or `None` if it doesn't exist.
     pub fn rule_idx(&self, n: &str) -> Option<RIdx<StorageT>> {
-        self.rule_names.iter()
-                          .position(|x| x == n)
-                          // The call to as_() is safe because rule_names is guaranteed to be
-                          // small enough to fit into StorageT
-                          .map(|x| RIdx(x.as_()))
+        self.rule_names
+            .iter()
+            .position(|x| x == n)
+            // The call to as_() is safe because rule_names is guaranteed to be
+            // small enough to fit into StorageT
+            .map(|x| RIdx(x.as_()))
     }
 
     /// What is the index of the start rule? Note that cfgrammar will have inserted at least one
@@ -493,11 +494,12 @@ where
 
     /// Return the index of the token named `n` or `None` if it doesn't exist.
     pub fn token_idx(&self, n: &str) -> Option<TIdx<StorageT>> {
-        self.token_names.iter()
-                       .position(|x| x.as_ref().map_or(false, |x| x == n))
-                       // The call to as_() is safe because token_names is guaranteed to be small
-                       // enough to fit into StorageT
-                       .map(|x| TIdx(x.as_()))
+        self.token_names
+            .iter()
+            .position(|x| x.as_ref().map_or(false, |x| x == n))
+            // The call to as_() is safe because token_names is guaranteed to be small
+            // enough to fit into StorageT
+            .map(|x| TIdx(x.as_()))
     }
 
     /// Is the token `tidx` marked as `%avoid_insert`?
@@ -554,7 +556,7 @@ where
         for sym in self.prod(pidx) {
             let s = match sym {
                 Symbol::Token(tidx) => self.token_name(*tidx).unwrap(),
-                Symbol::Rule(ridx) => self.rule_name(*ridx)
+                Symbol::Rule(ridx) => self.rule_name(*ridx),
             };
             sprod.push_str(&format!(" \"{}\"", s));
         }
@@ -567,7 +569,7 @@ where
     /// tokens can have the same score. The simplest cost function is thus `|_| 1`.
     pub fn sentence_generator<F>(&self, token_cost: F) -> SentenceGenerator<StorageT>
     where
-        F: Fn(TIdx<StorageT>) -> u8
+        F: Fn(TIdx<StorageT>) -> u8,
     {
         SentenceGenerator::new(self, token_cost)
     }
@@ -607,16 +609,16 @@ pub struct SentenceGenerator<'a, StorageT> {
     grm: &'a YaccGrammar<StorageT>,
     rule_min_costs: RefCell<Option<Vec<u16>>>,
     rule_max_costs: RefCell<Option<Vec<u16>>>,
-    token_costs: Vec<u8>
+    token_costs: Vec<u8>,
 }
 
 impl<'a, StorageT: 'static + PrimInt + Unsigned> SentenceGenerator<'a, StorageT>
 where
-    usize: AsPrimitive<StorageT>
+    usize: AsPrimitive<StorageT>,
 {
     fn new<F>(grm: &'a YaccGrammar<StorageT>, token_cost: F) -> Self
     where
-        F: Fn(TIdx<StorageT>) -> u8
+        F: Fn(TIdx<StorageT>) -> u8,
     {
         let mut token_costs = Vec::with_capacity(usize::from(grm.tokens_len()));
         for tidx in grm.iter_tidxs() {
@@ -626,7 +628,7 @@ where
             grm,
             token_costs,
             rule_min_costs: RefCell::new(None),
-            rule_max_costs: RefCell::new(None)
+            rule_max_costs: RefCell::new(None),
         }
     }
 
@@ -665,7 +667,7 @@ where
                 for sym in self.grm.prod(pidx).iter() {
                     sc += match *sym {
                         Symbol::Rule(i) => self.min_sentence_cost(i),
-                        Symbol::Token(i) => u16::from(self.token_costs[usize::from(i)])
+                        Symbol::Token(i) => u16::from(self.token_costs[usize::from(i)]),
                     };
                 }
                 if low_sc.is_none() || sc < low_sc.unwrap() {
@@ -706,7 +708,7 @@ where
                 for sym in self.grm.prod(pidx).iter() {
                     sc += match *sym {
                         Symbol::Rule(s_ridx) => self.min_sentence_cost(s_ridx),
-                        Symbol::Token(s_tidx) => u16::from(self.token_costs[usize::from(s_tidx)])
+                        Symbol::Token(s_tidx) => u16::from(self.token_costs[usize::from(s_tidx)]),
                     };
                 }
                 if low_sc.is_none() || sc <= low_sc.unwrap() {
@@ -742,7 +744,7 @@ where
             for sym in prod {
                 match *sym {
                     Symbol::Rule(s_ridx) => ms.push(self.min_sentences(s_ridx)),
-                    Symbol::Token(s_tidx) => ms.push(vec![vec![s_tidx]])
+                    Symbol::Token(s_tidx) => ms.push(vec![vec![s_tidx]]),
                 }
             }
 
@@ -803,10 +805,10 @@ where
 #[allow(clippy::unnecessary_unwrap)]
 fn rule_min_costs<StorageT: 'static + PrimInt + Unsigned>(
     grm: &YaccGrammar<StorageT>,
-    token_costs: &[u8]
+    token_costs: &[u8],
 ) -> Vec<u16>
 where
-    usize: AsPrimitive<StorageT>
+    usize: AsPrimitive<StorageT>,
 {
     // We use a simple(ish) fixed-point algorithm to determine costs. We maintain two lists
     // "costs" and "done". An integer costs[i] starts at 0 and monotonically increments
@@ -892,10 +894,10 @@ where
 #[allow(clippy::unnecessary_unwrap)]
 fn rule_max_costs<StorageT: 'static + PrimInt + Unsigned>(
     grm: &YaccGrammar<StorageT>,
-    token_costs: &[u8]
+    token_costs: &[u8],
 ) -> Vec<u16>
 where
-    usize: AsPrimitive<StorageT>
+    usize: AsPrimitive<StorageT>,
 {
     let mut done = vec![];
     done.resize(usize::from(grm.rules_len()), false);
@@ -975,7 +977,7 @@ where
 #[derive(Debug)]
 pub enum YaccGrammarError {
     YaccParserError(YaccParserError),
-    GrammarValidationError(GrammarValidationError)
+    GrammarValidationError(GrammarValidationError),
 }
 
 impl Error for YaccGrammarError {}
@@ -996,7 +998,7 @@ impl fmt::Display for YaccGrammarError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             YaccGrammarError::YaccParserError(ref e) => e.fmt(f),
-            YaccGrammarError::GrammarValidationError(ref e) => e.fmt(f)
+            YaccGrammarError::GrammarValidationError(ref e) => e.fmt(f),
         }
     }
 }
@@ -1005,7 +1007,7 @@ impl fmt::Display for YaccGrammarError {
 mod test {
     use super::{
         super::{AssocKind, Precedence, YaccGrammar, YaccKind, YaccOriginalActionKind},
-        rule_max_costs, rule_min_costs, IMPLICIT_RULE, IMPLICIT_START_RULE
+        rule_max_costs, rule_min_costs, IMPLICIT_RULE, IMPLICIT_START_RULE,
     };
     use crate::{PIdx, RIdx, Symbol, TIdx};
     use std::collections::HashMap;
@@ -1014,7 +1016,7 @@ mod test {
     fn test_minimal() {
         let grm = YaccGrammar::new(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            "%start R %token T %% R: 'T';"
+            "%start R %token T %% R: 'T';",
         )
         .unwrap();
 
@@ -1045,7 +1047,7 @@ mod test {
     fn test_rule_ref() {
         let grm = YaccGrammar::new(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            "%start R %token T %% R : S; S: 'T';"
+            "%start R %token T %% R : S; S: 'T';",
         )
         .unwrap();
 
@@ -1113,7 +1115,7 @@ mod test {
             B: 'x';
             C: 'y'
              | 'z';
-          "
+          ",
         )
         .unwrap();
 
@@ -1322,7 +1324,7 @@ mod test {
             B: C | D;
             C: 'x' B | 'x';
             D: 'y' B | 'y' 'z';
-          "
+          ",
         )
         .unwrap();
 
@@ -1418,7 +1420,7 @@ mod test {
             B: 'a'
              | 'b';
             A: 'b';
-            "
+            ",
         )
         .unwrap();
 

--- a/cfgrammar/src/lib/yacc/mod.rs
+++ b/cfgrammar/src/lib/yacc/mod.rs
@@ -7,7 +7,7 @@ pub mod parser;
 pub use self::{
     ast::{GrammarValidationError, GrammarValidationErrorKind},
     grammar::{AssocKind, Precedence, SentenceGenerator, YaccGrammar, YaccGrammarError},
-    parser::{YaccParserError, YaccParserErrorKind}
+    parser::{YaccParserError, YaccParserErrorKind},
 };
 
 /// The particular Yacc variant this grammar makes use of.
@@ -20,7 +20,7 @@ pub enum YaccKind {
     /// own return type.
     Grmtools,
     /// The variant used in the [Eco language composition editor](http://soft-dev.org/src/eco/)
-    Eco
+    Eco,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -31,5 +31,5 @@ pub enum YaccOriginalActionKind {
     /// Automatically create a parse tree instead of user-specified actions.
     GenericParseTree,
     /// Do not do execute actions of any sort.
-    NoAction
+    NoAction,
 }

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -9,7 +9,7 @@ type YaccResult<T> = Result<T, YaccParserError>;
 
 use super::{
     ast::{GrammarAST, Symbol},
-    AssocKind, Precedence, YaccKind
+    AssocKind, Precedence, YaccKind,
 };
 
 /// The various different possible Yacc parser errors.
@@ -34,7 +34,7 @@ pub enum YaccParserErrorKind {
     DuplicateActiontypeDeclaration,
     DuplicateEPP,
     ReachedEOL,
-    InvalidString
+    InvalidString,
 }
 
 /// Any error from the Yacc parser returns an instance of this struct.
@@ -42,7 +42,7 @@ pub enum YaccParserErrorKind {
 pub struct YaccParserError {
     pub kind: YaccParserErrorKind,
     line: usize,
-    col: usize
+    col: usize,
 }
 
 impl Error for YaccParserError {}
@@ -77,7 +77,7 @@ impl fmt::Display for YaccParserError {
             YaccParserErrorKind::ReachedEOL => {
                 "Reached end of line without finding expected content"
             }
-            YaccParserErrorKind::InvalidString => "Invalid string"
+            YaccParserErrorKind::InvalidString => "Invalid string",
         };
         write!(f, "{} at line {} column {}", s, self.line, self.col)
     }
@@ -88,7 +88,7 @@ pub(crate) struct YaccParser {
     src: String,
     newlines: Vec<usize>,
     ast: GrammarAST,
-    global_actiontype: Option<String>
+    global_actiontype: Option<String>,
 }
 
 lazy_static! {
@@ -105,7 +105,7 @@ impl YaccParser {
             src,
             newlines: vec![0],
             ast: GrammarAST::new(),
-            global_actiontype: None
+            global_actiontype: None,
         }
     }
 
@@ -209,7 +209,7 @@ impl YaccParser {
                         if self.ast.implicit_tokens.as_ref().unwrap().contains(&n) {
                             return Err(self.mk_error(
                                 YaccParserErrorKind::DuplicateImplicitTokensDeclaration,
-                                i
+                                i,
                             ));
                         }
                         self.ast.implicit_tokens.as_mut().unwrap().insert(n);
@@ -243,7 +243,7 @@ impl YaccParser {
                     }
                     let prec = Precedence {
                         level: prec_level,
-                        kind
+                        kind,
                     };
                     self.ast.precs.insert(n, prec);
                     i = self.parse_ws(j, true)?;
@@ -359,7 +359,7 @@ impl YaccParser {
                 assert_eq!(m.start(), 0);
                 Ok((i + m.end(), self.src[i..i + m.end()].to_string()))
             }
-            None => Err(self.mk_error(YaccParserErrorKind::IllegalName, i))
+            None => Err(self.mk_error(YaccParserErrorKind::IllegalName, i)),
         }
     }
 
@@ -372,10 +372,10 @@ impl YaccParser {
                         debug_assert!('"'.len_utf8() == 1 && '\''.len_utf8() == 1);
                         Ok((i + m.end(), self.src[i + 1..i + m.end() - 1].to_string()))
                     }
-                    _ => Ok((i + m.end(), self.src[i..i + m.end()].to_string()))
+                    _ => Ok((i + m.end(), self.src[i..i + m.end()].to_string())),
                 }
             }
-            None => Err(self.mk_error(YaccParserErrorKind::IllegalString, i))
+            None => Err(self.mk_error(YaccParserErrorKind::IllegalString, i)),
         }
     }
 
@@ -394,7 +394,7 @@ impl YaccParser {
                 '\n' | '\r' => {
                     self.newlines.push(j + 1);
                 }
-                _ => ()
+                _ => (),
             };
             j += ch.len_utf8();
         }
@@ -429,7 +429,7 @@ impl YaccParser {
             let c = self.src[j..].chars().next().unwrap();
             match c {
                 '\n' | '\r' => break,
-                _ => j += c.len_utf8()
+                _ => j += c.len_utf8(),
             }
         }
         Ok((j, self.src[i..j].to_string()))
@@ -453,7 +453,7 @@ impl YaccParser {
                     self.newlines.push(i + 1);
                     j += c.len_utf8();
                 }
-                _ => j += c.len_utf8()
+                _ => j += c.len_utf8(),
             }
         }
         Err(self.mk_error(YaccParserErrorKind::ReachedEOL, j))
@@ -500,7 +500,7 @@ impl YaccParser {
                         }
                     }
                 }
-                _ => j += c.len_utf8()
+                _ => j += c.len_utf8(),
             }
         }
         Err(self.mk_error(YaccParserErrorKind::InvalidString, j))
@@ -554,7 +554,7 @@ impl YaccParser {
                                             self.newlines.push(i + 1);
                                         }
                                         '*' => (),
-                                        _ => continue
+                                        _ => continue,
                                     }
                                     if k < self.src.len() {
                                         let c = self.src[k..].chars().next().unwrap();
@@ -571,11 +571,11 @@ impl YaccParser {
                                     );
                                 }
                             }
-                            _ => break
+                            _ => break,
                         }
                     }
                 }
-                _ => break
+                _ => break,
             }
         }
         Ok(i)
@@ -599,7 +599,7 @@ impl YaccParser {
             let line_off = *self.newlines.iter().last().unwrap();
             return (
                 self.newlines.len(),
-                self.src[line_off..].chars().count() + 1
+                self.src[line_off..].chars().count() + 1,
             );
         }
         let (line_m1, &line_off) = self
@@ -622,9 +622,9 @@ mod test {
     use super::{
         super::{
             ast::{GrammarAST, Production, Symbol},
-            AssocKind, Precedence, YaccKind, YaccOriginalActionKind
+            AssocKind, Precedence, YaccKind, YaccOriginalActionKind,
         },
-        YaccParser, YaccParserError, YaccParserErrorKind
+        YaccParser, YaccParserError, YaccParserErrorKind,
     };
 
     fn parse(yacc_kind: YaccKind, s: &str) -> Result<GrammarAST, YaccParserError> {
@@ -662,7 +662,7 @@ mod test {
         .to_string();
         let grm = parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &src
+            &src,
         )
         .unwrap();
         assert_eq!(grm.get_rule("A").unwrap().pidxs, vec![0]);
@@ -686,7 +686,7 @@ mod test {
         .to_string();
         let grm = parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &src
+            &src,
         )
         .unwrap();
         assert_eq!(
@@ -718,7 +718,7 @@ mod test {
         .to_string();
         let grm = parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &src
+            &src,
         )
         .unwrap();
 
@@ -771,7 +771,7 @@ mod test {
         let src = "%%\nA : 'a';\n%%".to_string();
         parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &src
+            &src,
         )
         .unwrap();
     }
@@ -781,7 +781,7 @@ mod test {
         let src = "%%\nA : 'a' B;".to_string();
         let grm = parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &src
+            &src,
         )
         .unwrap();
         assert_eq!(
@@ -799,7 +799,7 @@ mod test {
         let src = "%%\nA : 'a' \"b\";".to_string();
         let grm = parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &src
+            &src,
         )
         .unwrap();
         assert_eq!(
@@ -817,7 +817,7 @@ mod test {
         let src = "%start   A\n%%\nA : a;".to_string();
         let grm = parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &src
+            &src,
         )
         .unwrap();
         assert_eq!(grm.start.unwrap(), "A");
@@ -828,7 +828,7 @@ mod test {
         let src = "%token   a\n%%\nA : a;".to_string();
         let grm = parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &src
+            &src,
         )
         .unwrap();
         assert!(grm.has_token("a"));
@@ -839,7 +839,7 @@ mod test {
         let src = "%token   'a'\n%%\nA : 'a';".to_string();
         let grm = parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &src
+            &src,
         )
         .unwrap();
         assert!(grm.has_token("a"));
@@ -850,7 +850,7 @@ mod test {
         let src = "%token   a b c 'd'\n%%\nA : a;".to_string();
         let grm = parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &src
+            &src,
         )
         .unwrap();
         assert!(grm.has_token("a"));
@@ -863,7 +863,7 @@ mod test {
         let src = "%%\nA : 'a';".to_string();
         let grm = parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &src
+            &src,
         )
         .unwrap();
         assert!(grm.has_token("a"));
@@ -874,7 +874,7 @@ mod test {
         let src = "%token T %%\nA : T;".to_string();
         let grm = parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &src
+            &src,
         )
         .unwrap();
         assert!(grm.has_token("T"));
@@ -893,7 +893,7 @@ mod test {
         let src = "%token '❤' %%\nA : '❤';".to_string();
         let grm = parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &src
+            &src,
         )
         .unwrap();
         assert!(grm.has_token("❤"));
@@ -904,15 +904,15 @@ mod test {
         let src = "%token '❤' ❤;".to_string();
         match parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &src
+            &src,
         ) {
             Ok(_) => panic!("Incorrect token parsed"),
             Err(YaccParserError {
                 kind: YaccParserErrorKind::IllegalString,
                 line: 1,
-                col: 12
+                col: 12,
             }) => (),
-            Err(e) => panic!("Incorrect error returned {}", e)
+            Err(e) => panic!("Incorrect error returned {}", e),
         }
     }
 
@@ -921,15 +921,15 @@ mod test {
         let src = "%token '❤'\n%%\nA : '❤' | ❤;".to_string();
         match parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &src
+            &src,
         ) {
             Ok(_) => panic!("Incorrect token parsed"),
             Err(YaccParserError {
                 kind: YaccParserErrorKind::IllegalString,
                 line: 3,
-                col: 11
+                col: 11,
             }) => (),
-            Err(e) => panic!("Incorrect error returned {}", e)
+            Err(e) => panic!("Incorrect error returned {}", e),
         }
     }
 
@@ -939,7 +939,7 @@ mod test {
         let src = "%fail x\n%%\nA : a".to_string();
         parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &src
+            &src,
         )
         .unwrap();
     }
@@ -950,7 +950,7 @@ mod test {
         let src = "".to_string();
         parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &src
+            &src,
         )
         .unwrap();
     }
@@ -960,15 +960,15 @@ mod test {
         let src = "%%A:".to_string();
         match parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &src
+            &src,
         ) {
             Ok(_) => panic!("Incomplete rule parsed"),
             Err(YaccParserError {
                 kind: YaccParserErrorKind::IncompleteRule,
                 line: 1,
-                col: 5
+                col: 5,
             }) => (),
-            Err(e) => panic!("Incorrect error returned {}", e)
+            Err(e) => panic!("Incorrect error returned {}", e),
         }
     }
 
@@ -979,15 +979,15 @@ A:"
         .to_string();
         match parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &src
+            &src,
         ) {
             Ok(_) => panic!("Incomplete rule parsed"),
             Err(YaccParserError {
                 kind: YaccParserErrorKind::IncompleteRule,
                 line: 2,
-                col: 3
+                col: 3,
             }) => (),
-            Err(e) => panic!("Incorrect error returned {}", e)
+            Err(e) => panic!("Incorrect error returned {}", e),
         }
     }
 
@@ -999,15 +999,15 @@ A:
         .to_string();
         match parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &src
+            &src,
         ) {
             Ok(_) => panic!("Incomplete rule parsed"),
             Err(YaccParserError {
                 kind: YaccParserErrorKind::IncompleteRule,
                 line: 3,
-                col: 1
+                col: 1,
             }) => (),
-            Err(e) => panic!("Incorrect error returned {}", e)
+            Err(e) => panic!("Incorrect error returned {}", e),
         }
     }
 
@@ -1019,15 +1019,15 @@ A:
             .to_string();
         match parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &src
+            &src,
         ) {
             Ok(_) => panic!("Incomplete rule parsed"),
             Err(YaccParserError {
                 kind: YaccParserErrorKind::UnknownDeclaration,
                 line: 3,
-                col: 9
+                col: 9,
             }) => (),
-            Err(e) => panic!("Incorrect error returned {}", e)
+            Err(e) => panic!("Incorrect error returned {}", e),
         }
     }
 
@@ -1036,15 +1036,15 @@ A:
         let src = "%%A x;".to_string();
         match parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &src
+            &src,
         ) {
             Ok(_) => panic!("Missing colon parsed"),
             Err(YaccParserError {
                 kind: YaccParserErrorKind::MissingColon,
                 line: 1,
-                col: 5
+                col: 5,
             }) => (),
-            Err(e) => panic!("Incorrect error returned {}", e)
+            Err(e) => panic!("Incorrect error returned {}", e),
         }
     }
 
@@ -1053,15 +1053,15 @@ A:
         let src = "%token x".to_string();
         match parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &src
+            &src,
         ) {
             Ok(_) => panic!("Incomplete rule parsed"),
             Err(YaccParserError {
                 kind: YaccParserErrorKind::PrematureEnd,
                 line: 1,
-                col: 8
+                col: 8,
             }) => (),
-            Err(e) => panic!("Incorrect error returned {}", e)
+            Err(e) => panic!("Incorrect error returned {}", e),
         }
     }
 
@@ -1072,15 +1072,15 @@ x"
         .to_string();
         match parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &src
+            &src,
         ) {
             Ok(_) => panic!("Incomplete rule parsed"),
             Err(YaccParserError {
                 kind: YaccParserErrorKind::ReachedEOL,
                 line: 1,
-                col: 7
+                col: 7,
             }) => (),
-            Err(e) => panic!("Incorrect error returned {}", e)
+            Err(e) => panic!("Incorrect error returned {}", e),
         }
     }
 
@@ -1176,7 +1176,7 @@ x"
         for src in srcs.iter() {
             match parse(
                 YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-                &src.to_string()
+                &src.to_string(),
             ) {
                 Ok(_) => panic!("Duplicate precedence parsed"),
                 Err(YaccParserError {
@@ -1184,7 +1184,7 @@ x"
                     line: 3,
                     ..
                 }) => (),
-                Err(e) => panic!("Incorrect error returned {}", e)
+                Err(e) => panic!("Incorrect error returned {}", e),
             }
         }
     }
@@ -1219,7 +1219,7 @@ x"
             &"
           %%
           S: 'A' %prec ;
-          "
+          ",
         ) {
             Ok(_) => panic!("Incorrect %prec parsed"),
             Err(YaccParserError {
@@ -1227,7 +1227,7 @@ x"
                 line: 3,
                 ..
             }) => (),
-            Err(e) => panic!("Incorrect error returned {}", e)
+            Err(e) => panic!("Incorrect error returned {}", e),
         }
 
         match parse(
@@ -1236,7 +1236,7 @@ x"
           %%
           S: 'A' %prec B;
           B: ;
-          "
+          ",
         ) {
             Ok(_) => panic!("Incorrect %prec parsed"),
             Err(YaccParserError {
@@ -1244,7 +1244,7 @@ x"
                 line: 3,
                 ..
             }) => (),
-            Err(e) => panic!("Incorrect error returned {}", e)
+            Err(e) => panic!("Incorrect error returned {}", e),
         }
     }
 
@@ -1257,7 +1257,7 @@ x"
           %start R
           %%
           R: 'a';
-          "
+          ",
         )
         .unwrap();
         assert_eq!(
@@ -1281,7 +1281,7 @@ x"
           %avoid_insert X
           %avoid_insert Y
           %%
-          "
+          ",
         )
         .unwrap();
         assert_eq!(
@@ -1298,7 +1298,7 @@ x"
           %avoid_insert X Y
           %avoid_insert Y
           %%
-          "
+          ",
         ) {
             Ok(_) => panic!(),
             Err(YaccParserError {
@@ -1306,7 +1306,7 @@ x"
                 line: 3,
                 ..
             }) => (),
-            Err(e) => panic!("Incorrect error returned {}", e)
+            Err(e) => panic!("Incorrect error returned {}", e),
         }
     }
 
@@ -1318,7 +1318,7 @@ x"
           %avoid_insert X
           %avoid_insert Y Y
           %%
-          "
+          ",
         ) {
             Ok(_) => panic!(),
             Err(YaccParserError {
@@ -1326,7 +1326,7 @@ x"
                 line: 3,
                 ..
             }) => (),
-            Err(e) => panic!("Incorrect error returned {}", e)
+            Err(e) => panic!("Incorrect error returned {}", e),
         }
     }
 
@@ -1337,7 +1337,7 @@ x"
             &"
           %implicit_tokens X
           %%
-          "
+          ",
         ) {
             Ok(_) => panic!(),
             Err(YaccParserError {
@@ -1345,7 +1345,7 @@ x"
                 line: 2,
                 ..
             }) => (),
-            Err(e) => panic!("Incorrect error returned {}", e)
+            Err(e) => panic!("Incorrect error returned {}", e),
         }
     }
 
@@ -1358,7 +1358,7 @@ x"
           %start R
           %%
           R: 'a';
-          "
+          ",
         )
         .unwrap();
         assert_eq!(
@@ -1382,7 +1382,7 @@ x"
           %implicit_tokens X
           %implicit_tokens Y
           %%
-          "
+          ",
         )
         .unwrap();
         assert_eq!(
@@ -1399,7 +1399,7 @@ x"
           %implicit_tokens X
           %implicit_tokens X Y
           %%
-          "
+          ",
         ) {
             Ok(_) => panic!(),
             Err(YaccParserError {
@@ -1407,7 +1407,7 @@ x"
                 line: 3,
                 ..
             }) => (),
-            Err(e) => panic!("Incorrect error returned {}", e)
+            Err(e) => panic!("Incorrect error returned {}", e),
         }
     }
 
@@ -1419,7 +1419,7 @@ x"
           %implicit_tokens X X
           %implicit_tokens Y
           %%
-          "
+          ",
         ) {
             Ok(_) => panic!(),
             Err(YaccParserError {
@@ -1427,7 +1427,7 @@ x"
                 line: 2,
                 ..
             }) => (),
-            Err(e) => panic!("Incorrect error returned {}", e)
+            Err(e) => panic!("Incorrect error returned {}", e),
         }
     }
 
@@ -1445,7 +1445,7 @@ x"
           %epp G \"a\\\"b\"
           %%
           R: 'A';
-          "
+          ",
         )
         .unwrap();
         assert_eq!(ast.epp.len(), 7);
@@ -1466,7 +1466,7 @@ x"
           %epp A \"a\"
           %epp A \"a\"
           %%
-          "
+          ",
         ) {
             Ok(_) => panic!(),
             Err(YaccParserError {
@@ -1474,7 +1474,7 @@ x"
                 line: 3,
                 ..
             }) => (),
-            Err(e) => panic!("Incorrect error returned {}", e)
+            Err(e) => panic!("Incorrect error returned {}", e),
         }
     }
 
@@ -1485,7 +1485,7 @@ x"
             &"
           %epp A \"a
           %%
-          "
+          ",
         ) {
             Ok(_) => panic!(),
             Err(YaccParserError {
@@ -1493,13 +1493,13 @@ x"
                 line: 2,
                 ..
             }) => (),
-            Err(e) => panic!("Incorrect error returned {}", e)
+            Err(e) => panic!("Incorrect error returned {}", e),
         }
 
         match parse(
             YaccKind::Eco,
             &"
-          %epp A \"a"
+          %epp A \"a",
         ) {
             Ok(_) => panic!(),
             Err(YaccParserError {
@@ -1507,7 +1507,7 @@ x"
                 line: 2,
                 ..
             }) => (),
-            Err(e) => panic!("Incorrect error returned {}", e)
+            Err(e) => panic!("Incorrect error returned {}", e),
         }
     }
 
@@ -1519,7 +1519,7 @@ x"
           %start X
           %start X
           %%
-          "
+          ",
         ) {
             Ok(_) => panic!(),
             Err(YaccParserError {
@@ -1527,7 +1527,7 @@ x"
                 line: 3,
                 ..
             }) => (),
-            Err(e) => panic!("Incorrect error returned {}", e)
+            Err(e) => panic!("Incorrect error returned {}", e),
         }
     }
 
@@ -1540,7 +1540,7 @@ x"
           R: ;
           R2: ;
           R3: ;
-          "
+          ",
         )
         .unwrap();
         assert_eq!(ast.start, Some("R".to_string()));
@@ -1557,7 +1557,7 @@ x"
           B: 'b' 'c' { add($1, $2); }
            | 'd'
            ;
-          "
+          ",
         )
         .unwrap();
         assert_eq!(
@@ -1579,7 +1579,7 @@ x"
          %%
          A: 'a';
          %%
-         fn foo() {}"
+         fn foo() {}",
         )
         .unwrap();
         assert_eq!(grm.programs, Some("fn foo() {}".to_string()));
@@ -1594,11 +1594,11 @@ x"
          A: 'a' { foo();
                   bar(); }
          ;
-         B: b';"
+         B: b';",
         ) {
             Ok(_) => panic!(),
             Err(YaccParserError { line: 6, .. }) => (),
-            Err(e) => panic!("Incorrect error returned {}", e)
+            Err(e) => panic!("Incorrect error returned {}", e),
         }
     }
 
@@ -1612,7 +1612,7 @@ x"
             A : a;";
         let grm = parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            src
+            src,
         )
         .unwrap();
         assert!(grm.has_token("a"));
@@ -1623,7 +1623,7 @@ x"
             /* An invalid comment * /
             %token   a
             %%\n
-            A : a;"
+            A : a;",
         ) {
             Ok(_) => panic!(),
             Err(YaccParserError {
@@ -1631,7 +1631,7 @@ x"
                 line: 2,
                 ..
             }) => (),
-            Err(e) => panic!("Incorrect error returned {}", e)
+            Err(e) => panic!("Incorrect error returned {}", e),
         }
 
         match parse(
@@ -1643,7 +1643,7 @@ x"
              * multi-line comment
              */
             /* An invalid comment * /
-            A : a;"
+            A : a;",
         ) {
             Ok(_) => panic!(),
             Err(YaccParserError {
@@ -1651,7 +1651,7 @@ x"
                 line: 7,
                 ..
             }) => (),
-            Err(e) => panic!("Incorrect error returned {}", e)
+            Err(e) => panic!("Incorrect error returned {}", e),
         }
 
         match parse(
@@ -1660,7 +1660,7 @@ x"
             %token   a
             %%
             // Valid comment
-            A : a"
+            A : a",
         ) {
             Ok(_) => panic!(),
             Err(YaccParserError {
@@ -1668,7 +1668,7 @@ x"
                 line: 5,
                 ..
             }) => (),
-            Err(e) => panic!("Incorrect error returned {}", e)
+            Err(e) => panic!("Incorrect error returned {}", e),
         }
     }
 
@@ -1681,7 +1681,7 @@ x"
          %%
          A: 'a';
          %%
-         fn foo() {}"
+         fn foo() {}",
         )
         .unwrap();
         assert_eq!(grm.rules["A"].actiont, Some("T".to_string()));
@@ -1695,7 +1695,7 @@ x"
          %actiontype T1
          %actiontype T2
          %%
-         A: 'a';"
+         A: 'a';",
         ) {
             Ok(_) => panic!(),
             Err(YaccParserError {
@@ -1703,7 +1703,7 @@ x"
                 kind: YaccParserErrorKind::DuplicateActiontypeDeclaration,
                 ..
             }) => (),
-            Err(e) => panic!("Incorrect error returned {}", e)
+            Err(e) => panic!("Incorrect error returned {}", e),
         }
     }
 }

--- a/lrlex/examples/calclex/src/main.rs
+++ b/lrlex/examples/calclex/src/main.rs
@@ -21,7 +21,7 @@ fn main() {
                 let lexer = lexerdef.lexer(l);
                 println!("{:?}", lexer.iter().collect::<Vec<_>>());
             }
-            _ => break
+            _ => break,
         }
     }
 }

--- a/lrlex/src/lib/builder.rs
+++ b/lrlex/src/lib/builder.rs
@@ -10,7 +10,7 @@ use std::{
     fs::{self, create_dir_all, read_to_string, File},
     hash::Hash,
     io::Write,
-    path::{Path, PathBuf}
+    path::{Path, PathBuf},
 };
 
 use lazy_static::lazy_static;
@@ -27,7 +27,7 @@ lazy_static! {
 }
 
 pub enum LexerKind {
-    LRNonStreamingLexer
+    LRNonStreamingLexer,
 }
 
 /// A `LexerBuilder` allows one to specify the criteria for building a statically generated
@@ -37,12 +37,12 @@ pub struct LexerBuilder<'a, StorageT = u32> {
     mod_name: Option<&'a str>,
     rule_ids_map: Option<HashMap<String, StorageT>>,
     allow_missing_terms_in_lexer: bool,
-    allow_missing_tokens_in_parser: bool
+    allow_missing_tokens_in_parser: bool,
 }
 
 impl<'a, StorageT> LexerBuilder<'a, StorageT>
 where
-    StorageT: Copy + Debug + Eq + Hash + PrimInt + TryFrom<usize> + Unsigned
+    StorageT: Copy + Debug + Eq + Hash + PrimInt + TryFrom<usize> + Unsigned,
 {
     /// Create a new `LexerBuilder`.
     ///
@@ -66,7 +66,7 @@ where
             mod_name: None,
             rule_ids_map: None,
             allow_missing_terms_in_lexer: false,
-            allow_missing_tokens_in_parser: true
+            allow_missing_tokens_in_parser: true,
         }
     }
 
@@ -101,7 +101,7 @@ where
     /// generated files.
     pub fn process_file_in_src(
         self,
-        srcp: &str
+        srcp: &str,
     ) -> Result<(Option<HashSet<String>>, Option<HashSet<String>>), Box<dyn Error>> {
         let mut inp = current_dir()?;
         inp.push("src");
@@ -141,11 +141,11 @@ where
     pub fn process_file<P, Q>(
         self,
         inp: P,
-        outp: Q
+        outp: Q,
     ) -> Result<(Option<HashSet<String>>, Option<HashSet<String>>), Box<dyn Error>>
     where
         P: AsRef<Path>,
-        Q: AsRef<Path>
+        Q: AsRef<Path>,
     {
         let mut lexerdef: Box<dyn LexerDef<StorageT>> = match self.lexerkind {
             LexerKind::LRNonStreamingLexer => {
@@ -162,11 +162,11 @@ where
                 match lexerdef.set_rule_ids(&owned_map) {
                     (x, y) => (
                         x.map(|a| a.iter().map(|&b| b.to_string()).collect::<HashSet<_>>()),
-                        y.map(|a| a.iter().map(|&b| b.to_string()).collect::<HashSet<_>>())
-                    )
+                        y.map(|a| a.iter().map(|&b| b.to_string()).collect::<HashSet<_>>()),
+                    ),
                 }
             }
-            None => (None, None)
+            None => (None, None),
         };
 
         if !self.allow_missing_terms_in_lexer {
@@ -216,8 +216,8 @@ where
         let (lexerdef_name, lexerdef_type) = match self.lexerkind {
             LexerKind::LRNonStreamingLexer => (
                 "LRNonStreamingLexerDef",
-                format!("LRNonStreamingLexerDef<{}>", type_name::<StorageT>())
-            )
+                format!("LRNonStreamingLexerDef<{}>", type_name::<StorageT>()),
+            ),
         };
 
         outs.push_str(&format!(
@@ -235,11 +235,11 @@ pub fn lexerdef() -> {lexerdef_type} {{
         for r in lexerdef.iter_rules() {
             let tok_id = match r.tok_id {
                 Some(ref t) => format!("Some({:?})", t),
-                None => "None".to_owned()
+                None => "None".to_owned(),
             };
             let n = match r.name {
                 Some(ref n) => format!("Some({:?}.to_string())", n),
-                None => "None".to_owned()
+                None => "None".to_owned(),
             };
             outs.push_str(&format!(
                 "

--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -2,7 +2,7 @@ use std::{
     collections::{HashMap, HashSet},
     hash::Hash,
     marker::PhantomData,
-    slice::Iter
+    slice::Iter,
 };
 
 use num_traits::{PrimInt, Unsigned};
@@ -24,7 +24,7 @@ pub struct Rule<StorageT> {
     /// create a lexeme).
     pub name: Option<String>,
     pub re_str: String,
-    pub re: Regex
+    pub re: Regex,
 }
 
 impl<StorageT> Rule<StorageT> {
@@ -34,7 +34,7 @@ impl<StorageT> Rule<StorageT> {
     pub fn new(
         tok_id: Option<StorageT>,
         name: Option<String>,
-        re_str: String
+        re_str: String,
     ) -> Result<Rule<StorageT>, regex::Error> {
         let re = RegexBuilder::new(&format!("\\A(?:{})", &re_str))
             .multi_line(true)
@@ -44,7 +44,7 @@ impl<StorageT> Rule<StorageT> {
             tok_id,
             name,
             re_str,
-            re
+            re,
         })
     }
 }
@@ -90,7 +90,7 @@ pub trait LexerDef<StorageT> {
     /// grammar where nothing the user can input will be parseable.
     fn set_rule_ids<'a>(
         &'a mut self,
-        rule_ids_map: &HashMap<&'a str, StorageT>
+        rule_ids_map: &HashMap<&'a str, StorageT>,
     ) -> (Option<HashSet<&'a str>>, Option<HashSet<&'a str>>);
 
     /// Returns an iterator over all rules in this AST.
@@ -100,7 +100,7 @@ pub trait LexerDef<StorageT> {
 /// This struct represents, in essence, a .l file in memory. From it one can produce an
 /// [LRNonStreamingLexer] which actually lexes inputs.
 pub struct LRNonStreamingLexerDef<StorageT> {
-    pub(crate) rules: Vec<Rule<StorageT>>
+    pub(crate) rules: Vec<Rule<StorageT>>,
 }
 
 impl<StorageT: Copy + Eq + Hash + PrimInt + TryFrom<usize> + Unsigned> LexerDef<StorageT>
@@ -132,7 +132,7 @@ impl<StorageT: Copy + Eq + Hash + PrimInt + TryFrom<usize> + Unsigned> LexerDef<
 
     fn set_rule_ids<'a>(
         &'a mut self,
-        rule_ids_map: &HashMap<&'a str, StorageT>
+        rule_ids_map: &HashMap<&'a str, StorageT>,
     ) -> (Option<HashSet<&'a str>>, Option<HashSet<&'a str>>) {
         // Because we have to iter_mut over self.rules, we can't easily store a reference to the
         // rule's name at the same time. Instead, we store the index of each such rule and
@@ -178,10 +178,10 @@ impl<StorageT: Copy + Eq + Hash + PrimInt + TryFrom<usize> + Unsigned> LexerDef<
                             .iter()
                             .filter(|x| x.name.is_some())
                             .map(|x| &**x.name.as_ref().unwrap())
-                            .collect::<HashSet<&str>>()
+                            .collect::<HashSet<&str>>(),
                     )
                     .cloned()
-                    .collect::<HashSet<&str>>()
+                    .collect::<HashSet<&str>>(),
             );
         }
 
@@ -200,7 +200,7 @@ impl<StorageT: Copy + Eq + Hash + PrimInt + TryFrom<usize> + Unsigned>
     /// [LRNonStreamingLexerDef].
     pub fn lexer<'lexer, 'input: 'lexer>(
         &'lexer self,
-        s: &'input str
+        s: &'input str,
     ) -> LRNonStreamingLexer<'lexer, 'input, StorageT> {
         LRNonStreamingLexer::new(self, s)
     }
@@ -213,7 +213,7 @@ pub struct LRNonStreamingLexer<'lexer, 'input: 'lexer, StorageT> {
     s: &'input str,
     lexemes: Vec<Result<Lexeme<StorageT>, LexError>>,
     newlines: Vec<usize>,
-    phantom: PhantomData<&'lexer ()>
+    phantom: PhantomData<&'lexer ()>,
 }
 
 impl<'lexer, 'input: 'lexer, StorageT: Copy + Eq + Hash + PrimInt + TryFrom<usize> + Unsigned>
@@ -221,7 +221,7 @@ impl<'lexer, 'input: 'lexer, StorageT: Copy + Eq + Hash + PrimInt + TryFrom<usiz
 {
     fn new(
         lexerdef: &'lexer LRNonStreamingLexerDef<StorageT>,
-        s: &'input str
+        s: &'input str,
     ) -> LRNonStreamingLexer<'lexer, 'input, StorageT> {
         let mut lexemes = vec![];
         let mut newlines = vec![];
@@ -247,7 +247,7 @@ impl<'lexer, 'input: 'lexer, StorageT: Copy + Eq + Hash + PrimInt + TryFrom<usiz
                         .chars()
                         .enumerate()
                         .filter(|&(_, c)| c == '\n')
-                        .map(|(j, _)| old_i + j + 1)
+                        .map(|(j, _)| old_i + j + 1),
                 );
                 let r = lexerdef.get_rule(longest_ridx).unwrap();
                 if r.name.is_some() {
@@ -272,7 +272,7 @@ impl<'lexer, 'input: 'lexer, StorageT: Copy + Eq + Hash + PrimInt + TryFrom<usiz
             s,
             lexemes,
             newlines,
-            phantom: PhantomData
+            phantom: PhantomData,
         }
     }
 }
@@ -311,7 +311,7 @@ impl<'lexer, 'input: 'lexer, StorageT: Copy + Eq + Hash + PrimInt + Unsigned>
 
         fn surrounding_line_off<StorageT>(
             lexer: &LRNonStreamingLexer<StorageT>,
-            i: usize
+            i: usize,
         ) -> (usize, usize) {
             if i > lexer.s.len() {
                 panic!("Offset {} exceeds known input length {}", i, lexer.s.len());
@@ -358,13 +358,13 @@ impl<'lexer, 'input: 'lexer, StorageT: Copy + Eq + Hash + PrimInt + Unsigned>
             }
             (
                 lexer.newlines.len() + 1,
-                i - lexer.newlines[lexer.newlines.len() - 1]
+                i - lexer.newlines[lexer.newlines.len() - 1],
             )
         }
 
         fn lc_char<StorageT: Copy + Eq + Hash + PrimInt + Unsigned>(
             lexer: &LRNonStreamingLexer<StorageT>,
-            i: usize
+            i: usize,
         ) -> (usize, usize) {
             let (line_idx, col_byte) = lc_byte(lexer, i);
             let line = lexer.span_lines_str(Span::new(i, i));

--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -19,7 +19,7 @@ mod parser;
 
 pub use crate::{
     builder::{LexerBuilder, LexerKind},
-    lexer::{LRNonStreamingLexer, LRNonStreamingLexerDef, LexerDef, Rule}
+    lexer::{LRNonStreamingLexer, LRNonStreamingLexerDef, LexerDef, Rule},
 };
 
 pub type LexBuildResult<T> = Result<T, LexBuildError>;
@@ -29,7 +29,7 @@ pub type LexBuildResult<T> = Result<T, LexBuildError>;
 pub struct LexBuildError {
     pub kind: LexErrorKind,
     line: usize,
-    col: usize
+    col: usize,
 }
 
 impl Error for LexBuildError {}
@@ -43,7 +43,7 @@ pub enum LexErrorKind {
     MissingSpace,
     InvalidName,
     DuplicateName,
-    RegexError
+    RegexError,
 }
 
 impl fmt::Display for LexBuildError {
@@ -56,7 +56,7 @@ impl fmt::Display for LexBuildError {
             LexErrorKind::MissingSpace => s = "Rule is missing a space",
             LexErrorKind::InvalidName => s = "Invalid rule name",
             LexErrorKind::DuplicateName => s = "Rule name already exists",
-            LexErrorKind::RegexError => s = "Invalid regular expression"
+            LexErrorKind::RegexError => s = "Invalid regular expression",
         }
         write!(f, "{} at line {} column {}", s, self.line, self.col)
     }
@@ -64,7 +64,7 @@ impl fmt::Display for LexBuildError {
 
 #[deprecated(since = "0.8.0", note = "Please use LRNonStreamingLexerDef::from_str")]
 pub fn build_lex<StorageT: Copy + Eq + Hash + PrimInt + TryFrom<usize> + Unsigned>(
-    s: &str
+    s: &str,
 ) -> Result<LRNonStreamingLexerDef<StorageT>, LexBuildError> {
     LRNonStreamingLexerDef::from_str(s)
 }

--- a/lrlex/src/lib/parser.rs
+++ b/lrlex/src/lib/parser.rs
@@ -5,7 +5,7 @@ use crate::{lexer::Rule, LexBuildError, LexBuildResult, LexErrorKind};
 pub struct LexParser<StorageT> {
     src: String,
     newlines: Vec<usize>,
-    pub(crate) rules: Vec<Rule<StorageT>>
+    pub(crate) rules: Vec<Rule<StorageT>>,
 }
 
 impl<StorageT: TryFrom<usize>> LexParser<StorageT> {
@@ -13,7 +13,7 @@ impl<StorageT: TryFrom<usize>> LexParser<StorageT> {
         let mut p = LexParser {
             src,
             newlines: vec![0],
-            rules: Vec::new()
+            rules: Vec::new(),
         };
         p.parse()?;
         Ok(p)
@@ -29,7 +29,7 @@ impl<StorageT: TryFrom<usize>> LexParser<StorageT> {
             let line_off = *self.newlines.iter().last().unwrap();
             return (
                 self.newlines.len(),
-                self.src[line_off..].chars().count() + 1
+                self.src[line_off..].chars().count() + 1,
             );
         }
         let (line_m1, &line_off) = self
@@ -98,7 +98,7 @@ impl<StorageT: TryFrom<usize>> LexParser<StorageT> {
         let line = self.src[i..i + line_len].trim_end();
         let rspace = match line.rfind(' ') {
             Some(j) => j,
-            None => return Err(self.mk_error(LexErrorKind::MissingSpace, i))
+            None => return Err(self.mk_error(LexErrorKind::MissingSpace, i)),
         };
 
         let name;
@@ -140,7 +140,7 @@ impl<StorageT: TryFrom<usize>> LexParser<StorageT> {
             match c {
                 ' ' | '\t' => (),
                 '\n' | '\r' => self.newlines.push(j + 1),
-                _ => break
+                _ => break,
             }
             j += c.len_utf8();
         }
@@ -220,9 +220,9 @@ mod test {
             Err(LexBuildError {
                 kind: LexErrorKind::MissingSpace,
                 line: 2,
-                col: 1
+                col: 1,
             }) => (),
-            Err(e) => panic!("Incorrect error returned {}", e)
+            Err(e) => panic!("Incorrect error returned {}", e),
         }
     }
 
@@ -237,9 +237,9 @@ mod test {
             Err(LexBuildError {
                 kind: LexErrorKind::MissingSpace,
                 line: 2,
-                col: 1
+                col: 1,
             }) => (),
-            Err(e) => panic!("Incorrect error returned {}", e)
+            Err(e) => panic!("Incorrect error returned {}", e),
         }
     }
 
@@ -254,9 +254,9 @@ mod test {
             Err(LexBuildError {
                 kind: LexErrorKind::InvalidName,
                 line: 2,
-                col: 7
+                col: 7,
             }) => (),
-            Err(e) => panic!("Incorrect error returned {}", e)
+            Err(e) => panic!("Incorrect error returned {}", e),
         }
     }
 
@@ -271,9 +271,9 @@ mod test {
             Err(LexBuildError {
                 kind: LexErrorKind::InvalidName,
                 line: 2,
-                col: 7
+                col: 7,
             }) => (),
-            Err(e) => panic!("Incorrect error returned {}", e)
+            Err(e) => panic!("Incorrect error returned {}", e),
         }
     }
 
@@ -288,9 +288,9 @@ mod test {
             Err(LexBuildError {
                 kind: LexErrorKind::DuplicateName,
                 line: 3,
-                col: 7
+                col: 7,
             }) => (),
-            Err(e) => panic!("Incorrect error returned {}", e)
+            Err(e) => panic!("Incorrect error returned {}", e),
         }
     }
 

--- a/lrlex/src/main.rs
+++ b/lrlex/src/main.rs
@@ -4,7 +4,7 @@ use std::{
     fs::File,
     io::{stderr, Read, Write},
     path::Path,
-    process
+    process,
 };
 
 use lrlex::{LRNonStreamingLexerDef, LexerDef};
@@ -14,7 +14,7 @@ fn usage(prog: &str, msg: &str) {
     let path = Path::new(prog);
     let leaf = match path.file_name() {
         Some(m) => m.to_str().unwrap(),
-        None => "lrpar"
+        None => "lrpar",
     };
     if !msg.is_empty() {
         writeln!(&mut stderr(), "{}", msg).ok();

--- a/lrpar/cttests/build.rs
+++ b/lrpar/cttests/build.rs
@@ -31,7 +31,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "Original(YaccOriginalActionKind::GenericParseTree)" => {
                     YaccKind::Original(YaccOriginalActionKind::GenericParseTree)
                 }
-                s => panic!("YaccKind '{}' not supported", s)
+                s => panic!("YaccKind '{}' not supported", s),
             };
 
             // The code below, in essence, replicates lrlex and lrpar's internal / undocumented

--- a/lrpar/cttests/src/lib.rs
+++ b/lrpar/cttests/src/lib.rs
@@ -54,7 +54,7 @@ fn test_basic_actions() {
     let lexer = lexerdef.lexer("2+3");
     match calc_actiontype_y::parse(&lexer) {
         (Some(Ok(5)), ref errs) if errs.is_empty() => (),
-        _ => unreachable!()
+        _ => unreachable!(),
     }
 }
 
@@ -68,11 +68,11 @@ fn test_error_recovery_and_actions() {
     let (r, errs) = calc_actiontype_y::parse(&lexer);
     match r {
         Some(Ok(5)) => (),
-        _ => unreachable!()
+        _ => unreachable!(),
     }
     match errs[0] {
         LexParseError::ParseError(..) => (),
-        _ => unreachable!()
+        _ => unreachable!(),
     }
 
     let lexer = lexerdef.lexer("2+3)");
@@ -81,7 +81,7 @@ fn test_error_recovery_and_actions() {
     assert_eq!(errs.len(), 1);
     match errs[0] {
         LexParseError::ParseError(..) => (),
-        _ => unreachable!()
+        _ => unreachable!(),
     }
 
     let lexer = lexerdef.lexer("2+3+18446744073709551616");
@@ -125,7 +125,7 @@ fn test_lexer_lifetime() {
         let l = lexer_def.lexer(input);
         match crate::lexer_lifetime_y::parse(&l) {
             (Option::Some(x), _) => Some(x),
-            _ => None
+            _ => None,
         }
     }
     parse_data("abc");
@@ -149,7 +149,7 @@ fn test_span() {
         {
             ()
         }
-        _ => unreachable!()
+        _ => unreachable!(),
     }
 
     let lexer = lexerdef.lexer("2 + 3");
@@ -167,7 +167,7 @@ fn test_span() {
         {
             ()
         }
-        _ => unreachable!()
+        _ => unreachable!(),
     }
 
     let lexer = lexerdef.lexer("2+3*4");
@@ -187,7 +187,7 @@ fn test_span() {
         {
             ()
         }
-        _ => unreachable!()
+        _ => unreachable!(),
     }
 
     let lexer = lexerdef.lexer("2++3");
@@ -205,7 +205,7 @@ fn test_span() {
         {
             ()
         }
-        _ => unreachable!()
+        _ => unreachable!(),
     }
 
     let lexer = lexerdef.lexer("(2)))");
@@ -223,7 +223,7 @@ fn test_span() {
         {
             ()
         }
-        _ => unreachable!()
+        _ => unreachable!(),
     }
 }
 
@@ -233,6 +233,6 @@ fn test_passthrough() {
     let lexer = lexerdef.lexer("101");
     match passthrough_y::parse(&lexer) {
         (Some(Ok(ref s)), _) if s == "$101" => (),
-        _ => unreachable!()
+        _ => unreachable!(),
     }
 }

--- a/lrpar/examples/calc_actions/src/main.rs
+++ b/lrpar/examples/calc_actions/src/main.rs
@@ -32,10 +32,10 @@ fn main() {
                 match res {
                     Some(Ok(r)) => println!("Result: {}", r),
                     Some(Err(e)) => eprintln!("{}", e),
-                    _ => eprintln!("Unable to evaluate expression.")
+                    _ => eprintln!("Unable to evaluate expression."),
                 }
             }
-            _ => break
+            _ => break,
         }
     }
 }

--- a/lrpar/examples/calc_ast/src/main.rs
+++ b/lrpar/examples/calc_ast/src/main.rs
@@ -47,7 +47,7 @@ fn main() {
                     }
                 }
             }
-            _ => break
+            _ => break,
         }
     }
 }
@@ -63,6 +63,6 @@ fn eval(lexer: &dyn NonStreamingLexer<u32>, e: Expr) -> Result<u64, (Span, &'sta
         Expr::Number { span } => lexer
             .span_str(span)
             .parse::<u64>()
-            .map_err(|_| (span, "cannot be represented as a u64"))
+            .map_err(|_| (span, "cannot be represented as a u64")),
     }
 }

--- a/lrpar/examples/calc_parsetree/src/main.rs
+++ b/lrpar/examples/calc_parsetree/src/main.rs
@@ -35,13 +35,13 @@ fn main() {
                     println!("Result: {}", Eval::new(l).eval(&pt));
                 }
             }
-            _ => break
+            _ => break,
         }
     }
 }
 
 struct Eval<'a> {
-    s: &'a str
+    s: &'a str,
 }
 
 impl<'a> Eval<'a> {
@@ -53,7 +53,7 @@ impl<'a> Eval<'a> {
         match *n {
             Node::Nonterm {
                 ridx: RIdx(ridx),
-                ref nodes
+                ref nodes,
             } if ridx == calc_y::R_EXPR => {
                 if nodes.len() == 1 {
                     self.eval(&nodes[0])
@@ -64,7 +64,7 @@ impl<'a> Eval<'a> {
             }
             Node::Nonterm {
                 ridx: RIdx(ridx),
-                ref nodes
+                ref nodes,
             } if ridx == calc_y::R_TERM => {
                 if nodes.len() == 1 {
                     self.eval(&nodes[0])
@@ -75,7 +75,7 @@ impl<'a> Eval<'a> {
             }
             Node::Nonterm {
                 ridx: RIdx(ridx),
-                ref nodes
+                ref nodes,
             } if ridx == calc_y::R_FACTOR => {
                 if nodes.len() == 1 {
                     if let Node::Term { lexeme } = nodes[0] {
@@ -90,7 +90,7 @@ impl<'a> Eval<'a> {
                     self.eval(&nodes[1])
                 }
             }
-            _ => unreachable!()
+            _ => unreachable!(),
         }
     }
 }

--- a/lrpar/src/lib/astar.rs
+++ b/lrpar/src/lib/astar.rs
@@ -2,7 +2,7 @@ use std::{fmt::Debug, hash::Hash};
 
 use indexmap::{
     indexmap,
-    map::{Entry, IndexMap}
+    map::{Entry, IndexMap},
 };
 
 /// Starting at `start_node`, return, in arbitrary order, all least-cost success nodes.
@@ -19,13 +19,13 @@ pub(crate) fn astar_all<N, FN, FM, FS>(
     start_node: N,
     neighbours: FN,
     merge: FM,
-    success: FS
+    success: FS,
 ) -> Vec<N>
 where
     N: Debug + Clone + Hash + Eq + PartialEq,
     FN: Fn(bool, &N, &mut Vec<(u16, u16, N)>) -> bool,
     FM: Fn(&mut N, N),
-    FS: Fn(&N) -> bool
+    FS: Fn(&N) -> bool,
 {
     // We tackle the problem in two phases. In the first phase we search for a success node, with
     // the cost monotonically increasing. All neighbouring nodes are stored for future inspection,
@@ -137,13 +137,13 @@ pub(crate) fn dijkstra<N, FM, FN, FS>(
     start_node: N,
     neighbours: FN,
     merge: FM,
-    success: FS
+    success: FS,
 ) -> Vec<N>
 where
     N: Debug + Clone + Hash + Eq + PartialEq,
     FN: Fn(bool, &N, &mut Vec<(u16, N)>) -> bool,
     FM: Fn(&mut N, N),
-    FS: Fn(&N) -> bool
+    FS: Fn(&N) -> bool,
 {
     let mut scs_nodes = Vec::new();
     let mut todo: Vec<IndexMap<N, N>> = vec![indexmap![start_node.clone() => start_node]];

--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -1,7 +1,7 @@
 use std::{
     fmt::Debug,
     hash::{Hash, Hasher},
-    time::Instant
+    time::Instant,
 };
 
 use cactus::Cactus;
@@ -14,7 +14,7 @@ use super::{
     lex::Lexeme,
     mf::{apply_repairs, rank_cnds, simplify_repairs},
     parser::{AStackType, ParseRepair, Parser, Recoverer},
-    Span
+    Span,
 };
 
 const PARSE_AT_LEAST: usize = 3; // N in Corchuelo et al.
@@ -26,14 +26,14 @@ enum Repair<StorageT> {
     /// Delete a symbol.
     Delete,
     /// Shift a symbol.
-    Shift
+    Shift,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 enum RepairMerge<StorageT> {
     Repair(Repair<StorageT>),
     Merge(Repair<StorageT>, Cactus<Cactus<RepairMerge<StorageT>>>),
-    Terminator
+    Terminator,
 }
 
 #[derive(Clone, Debug)]
@@ -41,7 +41,7 @@ struct PathFNode<StorageT> {
     pstack: Cactus<StIdx>,
     laidx: usize,
     repairs: Cactus<RepairMerge<StorageT>>,
-    cf: u16
+    cf: u16,
 }
 
 impl<StorageT: PrimInt + Unsigned> PathFNode<StorageT> {
@@ -49,7 +49,7 @@ impl<StorageT: PrimInt + Unsigned> PathFNode<StorageT> {
         match *self.repairs.val().unwrap() {
             RepairMerge::Repair(r) => Some(r),
             RepairMerge::Merge(x, _) => Some(x),
-            RepairMerge::Terminator => None
+            RepairMerge::Terminator => None,
         }
     }
 }
@@ -75,7 +75,7 @@ impl<StorageT: PrimInt + Unsigned> PartialEq for PathFNode<StorageT> {
         match (self.last_repair(), other.last_repair()) {
             (Some(Repair::Delete), Some(Repair::Delete)) => (),
             (Some(Repair::Delete), _) | (_, Some(Repair::Delete)) => return false,
-            (_, _) => ()
+            (_, _) => (),
         }
 
         let num_shifts = |c: &Cactus<RepairMerge<StorageT>>| {
@@ -85,7 +85,7 @@ impl<StorageT: PrimInt + Unsigned> PartialEq for PathFNode<StorageT> {
                     RepairMerge::Repair(Repair::Shift) | RepairMerge::Merge(Repair::Shift, _) => {
                         n += 1
                     }
-                    _ => break
+                    _ => break,
                 }
             }
             n
@@ -99,15 +99,15 @@ impl<StorageT: PrimInt + Unsigned> PartialEq for PathFNode<StorageT> {
 impl<StorageT: PrimInt + Unsigned> Eq for PathFNode<StorageT> {}
 
 struct CPCTPlus<'a, 'b: 'a, 'input: 'b, StorageT: 'static + Eq + Hash, ActionT: 'a> {
-    parser: &'a Parser<'a, 'b, 'input, StorageT, ActionT>
+    parser: &'a Parser<'a, 'b, 'input, StorageT, ActionT>,
 }
 
 pub(crate) fn recoverer<'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>(
-    parser: &'a Parser<StorageT, ActionT>
+    parser: &'a Parser<StorageT, ActionT>,
 ) -> Box<dyn Recoverer<StorageT, ActionT> + 'a>
 where
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>
+    u32: AsPrimitive<StorageT>,
 {
     Box::new(CPCTPlus { parser })
 }
@@ -117,11 +117,11 @@ impl<
         'b: 'a,
         'input: 'b,
         StorageT: 'static + Debug + Hash + PrimInt + Unsigned,
-        ActionT: 'a
+        ActionT: 'a,
     > Recoverer<StorageT, ActionT> for CPCTPlus<'a, 'b, 'input, StorageT, ActionT>
 where
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>
+    u32: AsPrimitive<StorageT>,
 {
     fn recover(
         &self,
@@ -130,7 +130,7 @@ where
         in_laidx: usize,
         mut in_pstack: &mut Vec<StIdx>,
         mut astack: &mut Vec<AStackType<ActionT, StorageT>>,
-        mut spans: &mut Vec<Span>
+        mut spans: &mut Vec<Span>,
     ) -> (usize, Vec<Vec<ParseRepair<StorageT>>>) {
         // This function implements a minor variant of the algorithm from "Repairing syntax errors
         // in LR parsers" by Rafael Corchuelo, Jose A. Perez, Antonio Ruiz, and Miguel Toro.
@@ -157,7 +157,7 @@ where
             pstack: start_cactus_pstack,
             laidx: in_laidx,
             repairs: Cactus::new().child(RepairMerge::Terminator),
-            cf: 0
+            cf: 0,
         };
         let astar_cnds = dijkstra(
             start_node,
@@ -197,7 +197,7 @@ where
                         RepairMerge::Merge(r, Cactus::new().child(new.repairs))
                     }
                     RepairMerge::Merge(r, ref v) => RepairMerge::Merge(r, v.child(new.repairs)),
-                    _ => unreachable!()
+                    _ => unreachable!(),
                 };
                 old.repairs = old.repairs.parent().unwrap().child(merge);
             },
@@ -218,9 +218,9 @@ where
                     .action(*n.pstack.val().unwrap(), parser.next_tidx(n.laidx))
                 {
                     Action::Accept => true,
-                    _ => false
+                    _ => false,
                 }
-            }
+            },
         );
 
         if astar_cnds.is_empty() {
@@ -239,7 +239,7 @@ where
             &mut in_pstack,
             &mut Some(&mut astack),
             &mut Some(&mut spans),
-            &rnk_rprs[0]
+            &rnk_rprs[0],
         );
 
         (laidx, rnk_rprs)
@@ -251,11 +251,11 @@ impl<
         'b: 'a,
         'input: 'b,
         StorageT: 'static + Debug + Hash + PrimInt + Unsigned,
-        ActionT: 'a
+        ActionT: 'a,
     > CPCTPlus<'a, 'b, 'input, StorageT, ActionT>
 where
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>
+    u32: AsPrimitive<StorageT>,
 {
     fn insert(&self, n: &PathFNode<StorageT>, nbrs: &mut Vec<(u16, PathFNode<StorageT>)>) {
         let laidx = n.laidx;
@@ -268,14 +268,14 @@ where
             let new_lexeme = Lexeme::new(
                 StorageT::from(u32::from(tidx)).unwrap(),
                 next_lexeme.span().start(),
-                None
+                None,
             );
             let (new_laidx, n_pstack) = self.parser.lr_cactus(
                 Some(new_lexeme),
                 laidx,
                 laidx + 1,
                 n.pstack.clone(),
-                &mut None
+                &mut None,
             );
             if new_laidx > laidx {
                 let nn = PathFNode {
@@ -287,7 +287,7 @@ where
                     cf: n
                         .cf
                         .checked_add(u16::from((self.parser.token_cost)(tidx)))
-                        .unwrap()
+                        .unwrap(),
                 };
                 nbrs.push((nn.cf, nn));
             }
@@ -305,7 +305,7 @@ where
             pstack: n.pstack.clone(),
             laidx: n.laidx + 1,
             repairs: n.repairs.child(RepairMerge::Repair(Repair::Delete)),
-            cf: n.cf.checked_add(u16::from(cost)).unwrap()
+            cf: n.cf.checked_add(u16::from(cost)).unwrap(),
         };
         nbrs.push((nn.cf, nn));
     }
@@ -348,7 +348,7 @@ where
                 pstack: n_pstack,
                 laidx: new_laidx,
                 repairs: n_repairs,
-                cf: n.cf
+                cf: n.cf,
             };
             nbrs.push((nn.cf, nn));
         }
@@ -358,10 +358,10 @@ where
     fn collect_repairs(
         &self,
         in_laidx: usize,
-        cnds: Vec<PathFNode<StorageT>>
+        cnds: Vec<PathFNode<StorageT>>,
     ) -> Vec<Vec<Vec<ParseRepair<StorageT>>>> {
         fn traverse<StorageT: PrimInt>(
-            rm: &Cactus<RepairMerge<StorageT>>
+            rm: &Cactus<RepairMerge<StorageT>>,
         ) -> Vec<Vec<Repair<StorageT>>> {
             let mut out = Vec::new();
             match *rm.val().unwrap() {
@@ -392,7 +392,7 @@ where
                         }
                     }
                 }
-                RepairMerge::Terminator => ()
+                RepairMerge::Terminator => (),
             }
             out
         }
@@ -403,7 +403,7 @@ where
                 traverse(&cnd.repairs)
                     .into_iter()
                     .map(|x| self.repair_to_parse_repair(in_laidx, &x))
-                    .collect::<Vec<_>>()
+                    .collect::<Vec<_>>(),
             );
         }
         all_rprs
@@ -412,7 +412,7 @@ where
     fn repair_to_parse_repair(
         &self,
         mut laidx: usize,
-        from: &[Repair<StorageT>]
+        from: &[Repair<StorageT>],
     ) -> Vec<ParseRepair<StorageT>> {
         from.iter()
             .map(|y| match *y {
@@ -434,14 +434,14 @@ where
 
 /// Do `repairs` end with enough Shift repairs to be considered a success node?
 fn ends_with_parse_at_least_shifts<StorageT: PrimInt + Unsigned>(
-    repairs: &Cactus<RepairMerge<StorageT>>
+    repairs: &Cactus<RepairMerge<StorageT>>,
 ) -> bool {
     let mut shfts = 0;
     for x in repairs.vals().take(PARSE_AT_LEAST) {
         match *x {
             RepairMerge::Repair(Repair::Shift) => shfts += 1,
             RepairMerge::Merge(Repair::Shift, _) => shfts += 1,
-            _ => return false
+            _ => return false,
         }
     }
     shfts == PARSE_AT_LEAST
@@ -456,15 +456,15 @@ mod test {
 
     use crate::{
         lex::Lexeme,
-        parser::{test::do_parse, LexParseError, ParseRepair, RecoveryKind}
+        parser::{test::do_parse, LexParseError, ParseRepair, RecoveryKind},
     };
 
     fn pp_repairs<StorageT: 'static + Hash + PrimInt + Unsigned>(
         grm: &YaccGrammar<StorageT>,
-        repairs: &[ParseRepair<StorageT>]
+        repairs: &[ParseRepair<StorageT>],
     ) -> String
     where
-        usize: AsPrimitive<StorageT>
+        usize: AsPrimitive<StorageT>,
     {
         let mut out = vec![];
         for r in repairs.iter() {
@@ -473,7 +473,7 @@ mod test {
                     out.push(format!("Insert \"{}\"", grm.token_epp(token_idx).unwrap()))
                 }
                 ParseRepair::Delete(_) => out.push("Delete".to_owned()),
-                ParseRepair::Shift(_) => out.push("Shift".to_owned())
+                ParseRepair::Shift(_) => out.push("Shift".to_owned()),
             }
         }
         out.join(", ")
@@ -482,9 +482,9 @@ mod test {
     fn check_all_repairs<StorageT: 'static + Debug + Hash + PrimInt + Unsigned>(
         grm: &YaccGrammar<StorageT>,
         err: &LexParseError<StorageT>,
-        expected: &[&str]
+        expected: &[&str],
     ) where
-        usize: AsPrimitive<StorageT>
+        usize: AsPrimitive<StorageT>,
     {
         match err {
             LexParseError::ParseError(e) => {
@@ -508,7 +508,7 @@ mod test {
                     }
                 }
             }
-            _ => unreachable!()
+            _ => unreachable!(),
         }
     }
 
@@ -571,7 +571,7 @@ E : 'N'
             LexParseError::ParseError(e) => {
                 assert_eq!(e.lexeme(), &Lexeme::new(err_tok_id, 2, Some(1)))
             }
-            _ => unreachable!()
+            _ => unreachable!(),
         }
         check_all_repairs(
             &grm,
@@ -579,8 +579,8 @@ E : 'N'
             &[
                 "Insert \")\", Insert \"+\"",
                 "Insert \")\", Delete",
-                "Insert \"+\", Shift, Insert \")\""
-            ]
+                "Insert \"+\", Shift, Insert \")\"",
+            ],
         );
 
         let (grm, pr) = do_parse(RecoveryKind::CPCTPlus, &lexs, &grms, "n)+n+n+n)");
@@ -621,8 +621,8 @@ U: 'd';
             &[
                 "Insert \"a\", Insert \"d\"",
                 "Insert \"b\", Insert \"d\"",
-                "Insert \"c\", Insert \"d\""
-            ]
+                "Insert \"c\", Insert \"d\"",
+            ],
         );
     }
 }

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -11,13 +11,13 @@ use std::{
     hash::Hash,
     io::{self, Write},
     marker::PhantomData,
-    path::{Path, PathBuf}
+    path::{Path, PathBuf},
 };
 
 use bincode::{deserialize, serialize_into};
 use cfgrammar::{
     yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
-    RIdx, Symbol
+    RIdx, Symbol,
 };
 use filetime::FileTime;
 use lazy_static::lazy_static;
@@ -47,14 +47,14 @@ lazy_static! {
 struct CTConflictsError<StorageT: Eq + Hash> {
     pub grm: YaccGrammar<StorageT>,
     pub sgraph: StateGraph<StorageT>,
-    pub stable: StateTable<StorageT>
+    pub stable: StateTable<StorageT>,
 }
 
 impl<StorageT> fmt::Display for CTConflictsError<StorageT>
 where
     StorageT: 'static + Debug + Hash + PrimInt + Serialize + Unsigned,
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>
+    u32: AsPrimitive<StorageT>,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let conflicts = self.stable.conflicts().unwrap();
@@ -71,7 +71,7 @@ impl<StorageT> fmt::Debug for CTConflictsError<StorageT>
 where
     StorageT: 'static + Debug + Hash + PrimInt + Serialize + Unsigned,
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>
+    u32: AsPrimitive<StorageT>,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let conflicts = self.stable.conflicts().unwrap();
@@ -88,7 +88,7 @@ impl<StorageT> Error for CTConflictsError<StorageT>
 where
     StorageT: 'static + Debug + Hash + PrimInt + Serialize + Unsigned,
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>
+    u32: AsPrimitive<StorageT>,
 {
 }
 
@@ -96,7 +96,7 @@ where
 /// parser.
 pub struct CTParserBuilder<'a, StorageT = u32>
 where
-    StorageT: Eq + Hash
+    StorageT: Eq + Hash,
 {
     // Anything stored in here (except `conflicts` and `error_on_conflict`) almost certainly needs
     // to be included as part of the rebuild_cache function below so that, if it's changed, the
@@ -108,9 +108,9 @@ where
     conflicts: Option<(
         YaccGrammar<StorageT>,
         StateGraph<StorageT>,
-        StateTable<StorageT>
+        StateTable<StorageT>,
     )>,
-    phantom: PhantomData<StorageT>
+    phantom: PhantomData<StorageT>,
 }
 
 impl<'a> CTParserBuilder<'a, u32> {
@@ -132,7 +132,7 @@ impl<'a, StorageT> CTParserBuilder<'a, StorageT>
 where
     StorageT: 'static + Debug + Hash + PrimInt + Serialize + Unsigned,
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>
+    u32: AsPrimitive<StorageT>,
 {
     /// Create a new `CTParserBuilder`.
     ///
@@ -159,7 +159,7 @@ where
             yacckind: None,
             error_on_conflicts: true,
             conflicts: None,
-            phantom: PhantomData
+            phantom: PhantomData,
         }
     }
 
@@ -194,12 +194,12 @@ where
     /// and pretty print them; otherwise returns `None`. Note: The conflicts feature is currently
     /// unstable and may change in the future.
     pub fn conflicts(
-        &self
+        &self,
     ) -> Option<(
         &YaccGrammar<StorageT>,
         &StateGraph<StorageT>,
         &StateTable<StorageT>,
-        &Conflicts<StorageT>
+        &Conflicts<StorageT>,
     )> {
         if let Some((grm, sgraph, stable)) = &self.conflicts {
             return Some((grm, sgraph, stable, &stable.conflicts().unwrap()));
@@ -215,7 +215,7 @@ where
     /// generated files.
     pub fn process_file_in_src(
         &mut self,
-        srcp: &str
+        srcp: &str,
     ) -> Result<HashMap<String, StorageT>, Box<dyn Error>> {
         let mut inp = current_dir()?;
         inp.push("src");
@@ -273,17 +273,17 @@ where
     pub fn process_file<P, Q>(
         &mut self,
         inp: P,
-        outp: Q
+        outp: Q,
     ) -> Result<HashMap<String, StorageT>, Box<dyn Error>>
     where
         P: AsRef<Path>,
-        Q: AsRef<Path>
+        Q: AsRef<Path>,
     {
         let yk = match self.yacckind {
             None => panic!("yacckind must be specified before processing."),
             Some(YaccKind::Original(x)) => YaccKind::Original(x),
             Some(YaccKind::Grmtools) => YaccKind::Grmtools,
-            Some(YaccKind::Eco) => panic!("Eco compile-time grammar generation not supported.")
+            Some(YaccKind::Eco) => panic!("Eco compile-time grammar generation not supported."),
         };
         let inc = read_to_string(&inp).unwrap();
         let grm = YaccGrammar::<StorageT>::new_with_storaget(yk, &inc)?;
@@ -328,7 +328,7 @@ where
             return Err(Box::new(CTConflictsError {
                 grm,
                 sgraph,
-                stable
+                stable,
             }));
         }
 
@@ -364,14 +364,14 @@ where
         stable: &StateTable<StorageT>,
         mod_name: &str,
         outp_rs: P,
-        cache: &str
+        cache: &str,
     ) -> Result<(), Box<dyn Error>> {
         let mut outs = String::new();
         // Header
         outs.push_str(&format!("mod {} {{\n", mod_name));
         outs.push_str(
             "    #![allow(clippy::type_complexity)]
-"
+",
         );
 
         outs.push_str(&self.gen_parse_function(grm, sgraph, stable)?);
@@ -384,7 +384,7 @@ where
             }
             YaccKind::Original(YaccOriginalActionKind::NoAction)
             | YaccKind::Original(YaccOriginalActionKind::GenericParseTree) => (),
-            _ => unreachable!()
+            _ => unreachable!(),
         }
         outs.push_str("}\n\n");
 
@@ -425,7 +425,7 @@ where
         for tidx in grm.iter_tidxs() {
             let n = match grm.token_name(tidx) {
                 Some(n) => format!("'{}'", n),
-                None => "<unknown>".to_string()
+                None => "<unknown>".to_string(),
             };
             cache.push_str(&format!("   {} {}\n", usize::from(tidx), n));
         }
@@ -439,7 +439,7 @@ where
         &self,
         grm: &YaccGrammar<StorageT>,
         sgraph: &StateGraph<StorageT>,
-        stable: &StateTable<StorageT>
+        stable: &StateTable<StorageT>,
     ) -> Result<String, Box<dyn Error>> {
         let mut outs = String::new();
 
@@ -482,7 +482,7 @@ where
                     storaget = type_name::<StorageT>()
                 ));
             }
-            YaccKind::Eco => unreachable!()
+            YaccKind::Eco => unreachable!(),
         };
 
         outs.push_str(&format!(
@@ -496,7 +496,7 @@ where
             RecoveryKind::CPCTPlus => "CPCTPlus",
             RecoveryKind::MF => "MF",
             RecoveryKind::Panic => "Panic",
-            RecoveryKind::None => "None"
+            RecoveryKind::None => "None",
         };
         match self.yacckind.unwrap() {
             YaccKind::Original(YaccOriginalActionKind::UserAction) | YaccKind::Grmtools => {
@@ -551,7 +551,7 @@ where
                     recoverer
                 ));
             }
-            YaccKind::Eco => unreachable!()
+            YaccKind::Eco => unreachable!(),
         };
 
         outs.push_str("\n    }\n\n");
@@ -578,7 +578,7 @@ where
         for tidx in grm.iter_tidxs() {
             match grm.token_epp(tidx) {
                 Some(n) => tidxs.push(format!("Some(\"{}\")", str_escape(n))),
-                None => tidxs.push("None".to_string())
+                None => tidxs.push("None".to_string()),
             }
         }
         format!(
@@ -793,7 +793,7 @@ where
                         } else if pre_action[last + off..].starts_with("$lexer") {
                             outs.push_str(&pre_action[last..last + off]);
                             outs.push_str(
-                                format!("{prefix}lexer", prefix = ACTION_PREFIX).as_str()
+                                format!("{prefix}lexer", prefix = ACTION_PREFIX).as_str(),
                             );
                             last = last + off + "$lexer".len();
                         } else if pre_action[last + off..].starts_with("$span") {
@@ -832,7 +832,7 @@ where
         debug_assert_eq!(grm.prod(grm.start_prod()).len(), 1);
         match grm.prod(grm.start_prod())[0] {
             Symbol::Rule(ridx) => ridx,
-            _ => unreachable!()
+            _ => unreachable!(),
         }
     }
 }
@@ -848,11 +848,11 @@ fn str_escape(s: &str) -> String {
 pub fn _reconstitute<StorageT: DeserializeOwned + Hash + PrimInt + Unsigned>(
     grm_buf: &[u8],
     sgraph_buf: &[u8],
-    stable_buf: &[u8]
+    stable_buf: &[u8],
 ) -> (
     YaccGrammar<StorageT>,
     StateGraph<StorageT>,
-    StateTable<StorageT>
+    StateTable<StorageT>,
 ) {
     let grm = deserialize(grm_buf).unwrap();
     let sgraph = deserialize(sgraph_buf).unwrap();
@@ -863,7 +863,7 @@ pub fn _reconstitute<StorageT: DeserializeOwned + Hash + PrimInt + Unsigned>(
 fn serialize_bin_output<T: Serialize + ?Sized>(
     ser: &T,
     name: &str,
-    buffer: &mut String
+    buffer: &mut String,
 ) -> Result<(), Box<dyn Error>> {
     let mut w = ArrayWriter::new(name);
     serialize_into(&mut w, ser)?;
@@ -874,13 +874,13 @@ fn serialize_bin_output<T: Serialize + ?Sized>(
 
 /// Makes formatting bytes into a rust array relatively painless.
 struct ArrayWriter {
-    buffer: String
+    buffer: String,
 }
 impl ArrayWriter {
     /// create a new array with the specified name
     fn new(name: &str) -> Self {
         Self {
-            buffer: format!(r#"#[allow(dead_code)] const {}: &[u8] = &["#, name)
+            buffer: format!(r#"#[allow(dead_code)] const {}: &[u8] = &["#, name),
         }
     }
 
@@ -925,7 +925,7 @@ mod test {
 A : 'a' 'b' | B 'b';
 B : 'a' | C;
 C : 'a';"
-                .as_bytes()
+                .as_bytes(),
         );
 
         let mut ct = CTParserBuilder::new()
@@ -938,7 +938,7 @@ C : 'a';"
                 assert_eq!(conflicts.sr_len(), 1);
                 assert_eq!(conflicts.rr_len(), 1);
             }
-            None => panic!("Expected error data")
+            None => panic!("Expected error data"),
         }
     }
 
@@ -954,7 +954,7 @@ C : 'a';"
 A : 'a' 'b' | B 'b';
 B : 'a' | C;
 C : 'a';"
-                .as_bytes()
+                .as_bytes(),
         );
 
         match CTParserBuilder::new()

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -876,6 +876,7 @@ fn serialize_bin_output<T: Serialize + ?Sized>(
 struct ArrayWriter {
     buffer: String,
 }
+
 impl ArrayWriter {
     /// create a new array with the specified name
     fn new(name: &str) -> Self {
@@ -890,6 +891,7 @@ impl ArrayWriter {
         self.buffer
     }
 }
+
 impl Write for ArrayWriter {
     #[allow(dead_code)]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {

--- a/lrpar/src/lib/lex.rs
+++ b/lrpar/src/lib/lex.rs
@@ -10,7 +10,7 @@ use crate::Span;
 /// A Lexing error.
 #[derive(Copy, Clone, Debug)]
 pub struct LexError {
-    span: Span
+    span: Span,
 }
 
 impl LexError {
@@ -83,7 +83,7 @@ pub struct Lexeme<StorageT> {
     // still fitting into 2 64-bit words.
     start: usize,
     len: u32,
-    tok_id: StorageT
+    tok_id: StorageT,
 }
 
 impl<StorageT: Copy> Lexeme<StorageT> {

--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -6,7 +6,7 @@ use std::{
     iter::FromIterator,
     marker::PhantomData,
     mem,
-    time::Instant
+    time::Instant,
 };
 
 use cactus::Cactus;
@@ -20,7 +20,7 @@ use crate::{
     astar::astar_all,
     lex::Lexeme,
     parser::{AStackType, ParseRepair, Parser, Recoverer},
-    Span
+    Span,
 };
 
 const PARSE_AT_LEAST: usize = 3; // N in Corchuelo et al.
@@ -33,14 +33,14 @@ enum Repair<StorageT> {
     /// Delete a symbol.
     Delete,
     /// Shift a symbol.
-    Shift
+    Shift,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 enum RepairMerge<StorageT> {
     Repair(Repair<StorageT>),
     Merge(Repair<StorageT>, Cactus<Cactus<RepairMerge<StorageT>>>),
-    Terminator
+    Terminator,
 }
 
 #[derive(Clone, Debug)]
@@ -49,7 +49,7 @@ struct PathFNode<StorageT> {
     laidx: usize,
     repairs: Cactus<RepairMerge<StorageT>>,
     cf: u16,
-    cg: u16
+    cg: u16,
 }
 
 impl<StorageT: PrimInt + Unsigned> PathFNode<StorageT> {
@@ -57,7 +57,7 @@ impl<StorageT: PrimInt + Unsigned> PathFNode<StorageT> {
         match *self.repairs.val().unwrap() {
             RepairMerge::Repair(r) => Some(r),
             RepairMerge::Merge(x, _) => Some(x),
-            RepairMerge::Terminator => None
+            RepairMerge::Terminator => None,
         }
     }
 }
@@ -83,7 +83,7 @@ impl<StorageT: PrimInt + Unsigned> PartialEq for PathFNode<StorageT> {
         match (self.last_repair(), other.last_repair()) {
             (Some(Repair::Delete), Some(Repair::Delete)) => (),
             (Some(Repair::Delete), _) | (_, Some(Repair::Delete)) => return false,
-            (_, _) => ()
+            (_, _) => (),
         }
 
         let num_shifts = |c: &Cactus<RepairMerge<StorageT>>| {
@@ -93,7 +93,7 @@ impl<StorageT: PrimInt + Unsigned> PartialEq for PathFNode<StorageT> {
                     RepairMerge::Repair(Repair::Shift) | RepairMerge::Merge(Repair::Shift, _) => {
                         n += 1
                     }
-                    _ => break
+                    _ => break,
                 }
             }
             n
@@ -108,7 +108,7 @@ impl<StorageT: PrimInt + Unsigned> Eq for PathFNode<StorageT> {}
 
 struct MF<'a, 'b: 'a, 'input: 'b, StorageT: 'static + Eq + Hash, ActionT: 'a> {
     dist: Dist<StorageT>,
-    parser: &'a Parser<'a, 'b, 'input, StorageT, ActionT>
+    parser: &'a Parser<'a, 'b, 'input, StorageT, ActionT>,
 }
 
 pub(crate) fn recoverer<
@@ -116,19 +116,19 @@ pub(crate) fn recoverer<
     'b: 'a,
     'input: 'b,
     StorageT: 'static + Debug + Hash + PrimInt + Unsigned,
-    ActionT: 'a
+    ActionT: 'a,
 >(
-    parser: &'a Parser<'a, 'b, 'input, StorageT, ActionT>
+    parser: &'a Parser<'a, 'b, 'input, StorageT, ActionT>,
 ) -> Box<dyn Recoverer<StorageT, ActionT> + 'a>
 where
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>
+    u32: AsPrimitive<StorageT>,
 {
     let dist = Dist::new(
         parser.grm,
         parser.sgraph,
         parser.stable,
-        parser.token_cost.as_ref()
+        parser.token_cost.as_ref(),
     );
     Box::new(MF { dist, parser })
 }
@@ -138,11 +138,11 @@ impl<
         'b: 'a,
         'input: 'b,
         StorageT: 'static + Debug + Hash + PrimInt + Unsigned,
-        ActionT: 'a
+        ActionT: 'a,
     > Recoverer<StorageT, ActionT> for MF<'a, 'b, 'input, StorageT, ActionT>
 where
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>
+    u32: AsPrimitive<StorageT>,
 {
     fn recover(
         &self,
@@ -151,7 +151,7 @@ where
         in_laidx: usize,
         mut in_pstack: &mut Vec<StIdx>,
         mut astack: &mut Vec<AStackType<ActionT, StorageT>>,
-        mut span: &mut Vec<Span>
+        mut span: &mut Vec<Span>,
     ) -> (usize, Vec<Vec<ParseRepair<StorageT>>>) {
         let mut start_cactus_pstack = Cactus::new();
         for st in in_pstack.iter() {
@@ -163,7 +163,7 @@ where
             laidx: in_laidx,
             repairs: Cactus::new().child(RepairMerge::Terminator),
             cf: 0,
-            cg: 0
+            cg: 0,
         };
 
         let astar_cnds = astar_all(
@@ -205,7 +205,7 @@ where
                         RepairMerge::Merge(r, Cactus::new().child(new.repairs))
                     }
                     RepairMerge::Merge(r, ref v) => RepairMerge::Merge(r, v.child(new.repairs)),
-                    _ => unreachable!()
+                    _ => unreachable!(),
                 };
                 old.repairs = old.repairs.parent().unwrap().child(merge);
             },
@@ -226,9 +226,9 @@ where
                     .action(*n.pstack.val().unwrap(), parser.next_tidx(n.laidx))
                 {
                     Action::Accept => true,
-                    _ => false
+                    _ => false,
                 }
-            }
+            },
         );
 
         if astar_cnds.is_empty() {
@@ -247,7 +247,7 @@ where
             &mut in_pstack,
             &mut Some(&mut astack),
             &mut Some(&mut span),
-            &rnk_rprs[0]
+            &rnk_rprs[0],
         );
 
         (laidx, rnk_rprs)
@@ -259,11 +259,11 @@ impl<
         'b: 'a,
         'input: 'b,
         StorageT: 'static + Debug + Hash + PrimInt + Unsigned,
-        ActionT: 'a
+        ActionT: 'a,
     > MF<'a, 'b, 'input, StorageT, ActionT>
 where
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>
+    u32: AsPrimitive<StorageT>,
 {
     fn insert(&self, n: &PathFNode<StorageT>, nbrs: &mut Vec<(u16, u16, PathFNode<StorageT>)>) {
         let top_pstack = *n.pstack.val().unwrap();
@@ -274,7 +274,7 @@ where
 
             let t_stidx = match self.parser.stable.action(top_pstack, tidx) {
                 Action::Shift(stidx) => stidx,
-                _ => unreachable!()
+                _ => unreachable!(),
             };
             let n_repairs = n
                 .repairs
@@ -289,7 +289,7 @@ where
                         .cf
                         .checked_add(u16::from((self.parser.token_cost)(tidx)))
                         .unwrap(),
-                    cg: d
+                    cg: d,
                 };
                 nbrs.push((nn.cf, nn.cg, nn));
             }
@@ -344,7 +344,7 @@ where
                         laidx: n.laidx,
                         repairs: n.repairs.clone(),
                         cf: n.cf,
-                        cg: d
+                        cg: d,
                     };
                     nbrs.push((nn.cf, nn.cg, nn));
                 }
@@ -366,7 +366,7 @@ where
                 laidx: n.laidx + 1,
                 repairs: n_repairs,
                 cf: n.cf.checked_add(u16::from(cost)).unwrap(),
-                cg: d
+                cg: d,
             };
             nbrs.push((nn.cf, nn.cg, nn));
         }
@@ -384,7 +384,7 @@ where
                     laidx: new_laidx,
                     repairs: n_repairs,
                     cf: n.cf,
-                    cg: d
+                    cg: d,
                 };
                 nbrs.push((nn.cf, nn.cg, nn));
             }
@@ -395,10 +395,10 @@ where
     fn collect_repairs(
         &self,
         in_laidx: usize,
-        cnds: Vec<PathFNode<StorageT>>
+        cnds: Vec<PathFNode<StorageT>>,
     ) -> Vec<Vec<Vec<ParseRepair<StorageT>>>> {
         fn traverse<StorageT: PrimInt + Unsigned>(
-            rm: &Cactus<RepairMerge<StorageT>>
+            rm: &Cactus<RepairMerge<StorageT>>,
         ) -> Vec<Vec<Repair<StorageT>>> {
             let mut out = Vec::new();
             match *rm.val().unwrap() {
@@ -429,7 +429,7 @@ where
                         }
                     }
                 }
-                RepairMerge::Terminator => ()
+                RepairMerge::Terminator => (),
             }
             out
         }
@@ -440,7 +440,7 @@ where
                 traverse(&cnd.repairs)
                     .into_iter()
                     .map(|x| self.repair_to_parse_repair(in_laidx, &x))
-                    .collect::<Vec<_>>()
+                    .collect::<Vec<_>>(),
             );
         }
         all_rprs
@@ -449,7 +449,7 @@ where
     fn repair_to_parse_repair(
         &self,
         mut laidx: usize,
-        from: &[Repair<StorageT>]
+        from: &[Repair<StorageT>],
     ) -> Vec<ParseRepair<StorageT>> {
         from.iter()
             .map(|y| match *y {
@@ -474,7 +474,7 @@ where
         &self,
         repairs: &Cactus<RepairMerge<StorageT>>,
         stidx: StIdx,
-        laidx: usize
+        laidx: usize,
     ) -> Option<u16> {
         // This function is very different than anything in KimYi: it estimates the distance to a
         // success node based in part on dynamic properties of the input as well as static
@@ -535,7 +535,7 @@ fn ends_with_parse_at_least_shifts<StorageT>(repairs: &Cactus<RepairMerge<Storag
         match x {
             RepairMerge::Repair(Repair::Shift) => shfts += 1,
             RepairMerge::Merge(Repair::Shift, _) => shfts += 1,
-            _ => return false
+            _ => return false,
         }
     }
     shfts == PARSE_AT_LEAST
@@ -551,11 +551,11 @@ pub(crate) fn rank_cnds<'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigne
     finish_by: Instant,
     in_laidx: usize,
     in_pstack: &[StIdx],
-    in_cnds: Vec<Vec<Vec<ParseRepair<StorageT>>>>
+    in_cnds: Vec<Vec<Vec<ParseRepair<StorageT>>>>,
 ) -> Vec<Vec<ParseRepair<StorageT>>>
 where
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>
+    u32: AsPrimitive<StorageT>,
 {
     let mut cnds = Vec::new();
     let mut furthest = 0;
@@ -570,7 +570,7 @@ where
             &mut pstack,
             &mut None,
             &mut None,
-            &rpr_seqs[0]
+            &rpr_seqs[0],
         );
         laidx = parser.lr_upto(
             None,
@@ -578,7 +578,7 @@ where
             in_laidx + TRY_PARSE_AT_MOST,
             &mut pstack,
             &mut None,
-            &mut None
+            &mut None,
         );
         if laidx >= furthest {
             furthest = laidx;
@@ -600,18 +600,18 @@ where
 pub(crate) fn apply_repairs<
     'a,
     StorageT: 'static + Debug + Hash + PrimInt + Unsigned,
-    ActionT: 'a
+    ActionT: 'a,
 >(
     parser: &Parser<StorageT, ActionT>,
     mut laidx: usize,
     mut pstack: &mut Vec<StIdx>,
     mut astack: &mut Option<&mut Vec<AStackType<ActionT, StorageT>>>,
     mut spans: &mut Option<&mut Vec<Span>>,
-    repairs: &[ParseRepair<StorageT>]
+    repairs: &[ParseRepair<StorageT>],
 ) -> usize
 where
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>
+    u32: AsPrimitive<StorageT>,
 {
     for r in repairs.iter() {
         match *r {
@@ -620,7 +620,7 @@ where
                 let new_lexeme = Lexeme::new(
                     StorageT::from(u32::from(tidx)).unwrap(),
                     next_lexeme.span().start(),
-                    None
+                    None,
                 );
                 parser.lr_upto(
                     Some(new_lexeme),
@@ -628,7 +628,7 @@ where
                     laidx + 1,
                     &mut pstack,
                     &mut astack,
-                    &mut spans
+                    &mut spans,
                 );
             }
             ParseRepair::Delete(_) => {
@@ -646,9 +646,9 @@ where
 /// Simplifies repair sequences, removes duplicates, and sorts them into order.
 pub(crate) fn simplify_repairs<StorageT: 'static + Hash + PrimInt + Unsigned, ActionT>(
     parser: &Parser<StorageT, ActionT>,
-    all_rprs: &mut Vec<Vec<ParseRepair<StorageT>>>
+    all_rprs: &mut Vec<Vec<ParseRepair<StorageT>>>,
 ) where
-    usize: AsPrimitive<StorageT>
+    usize: AsPrimitive<StorageT>,
 {
     for rprs in &mut all_rprs.iter_mut() {
         // Remove shifts from the end of repairs
@@ -697,22 +697,22 @@ pub(crate) struct Dist<StorageT> {
     tokens_len: TIdx<StorageT>,
     table: PackedVec<u16>,
     infinity: u16,
-    phantom: PhantomData<StorageT>
+    phantom: PhantomData<StorageT>,
 }
 
 impl<StorageT: 'static + Hash + PrimInt + Unsigned> Dist<StorageT>
 where
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>
+    u32: AsPrimitive<StorageT>,
 {
     pub(crate) fn new<F>(
         grm: &YaccGrammar<StorageT>,
         sgraph: &StateGraph<StorageT>,
         stable: &StateTable<StorageT>,
-        token_cost: F
+        token_cost: F,
     ) -> Dist<StorageT>
     where
-        F: Fn(TIdx<StorageT>) -> u8
+        F: Fn(TIdx<StorageT>) -> u8,
     {
         // This is an extension of dist from the KimYi paper: it also takes into account reductions
         // and gotos in the distances it reports back. Note that it is conservative, sometimes
@@ -798,13 +798,13 @@ where
             table
                 .iter()
                 .map(|&x| if x == u16::max_value() { m } else { x })
-                .collect()
+                .collect(),
         );
         Dist {
             tokens_len: grm.tokens_len(),
             infinity: m,
             table,
-            phantom: PhantomData
+            phantom: PhantomData,
         }
     }
 
@@ -826,7 +826,7 @@ where
         let mut rev_edges = Vec::with_capacity(usize::from(states_len));
         rev_edges.resize(
             usize::from(states_len),
-            Vob::from_elem(usize::from(sgraph.all_states_len()), false)
+            Vob::from_elem(usize::from(sgraph.all_states_len()), false),
         );
         for stidx in sgraph.iter_stidxs() {
             for (_, &sym_stidx) in sgraph.edges(stidx).iter() {
@@ -841,7 +841,7 @@ where
     fn goto_states(
         grm: &YaccGrammar<StorageT>,
         sgraph: &StateGraph<StorageT>,
-        stable: &StateTable<StorageT>
+        stable: &StateTable<StorageT>,
     ) -> Vec<Vob> {
         let rev_edges = Dist::rev_edges(sgraph);
         let states_len = usize::from(sgraph.all_states_len());
@@ -898,7 +898,7 @@ mod test {
     use cactus::Cactus;
     use cfgrammar::{
         yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
-        Symbol
+        Symbol,
     };
     use lrtable::{from_yacc, Minimiser, StIdx, StIdxStorageT};
     use num_traits::{AsPrimitive, PrimInt, ToPrimitive, Unsigned, Zero};
@@ -907,18 +907,18 @@ mod test {
         lex::Lexeme,
         parser::{
             test::{do_parse, do_parse_with_costs},
-            LexParseError, ParseRepair, RecoveryKind
-        }
+            LexParseError, ParseRepair, RecoveryKind,
+        },
     };
 
     use super::{ends_with_parse_at_least_shifts, Dist, Repair, RepairMerge, PARSE_AT_LEAST};
 
     fn pp_repairs<StorageT: 'static + Hash + PrimInt + Unsigned>(
         grm: &YaccGrammar<StorageT>,
-        repairs: &[ParseRepair<StorageT>]
+        repairs: &[ParseRepair<StorageT>],
     ) -> String
     where
-        usize: AsPrimitive<StorageT>
+        usize: AsPrimitive<StorageT>,
     {
         let mut out = vec![];
         for r in repairs.iter() {
@@ -927,7 +927,7 @@ mod test {
                     out.push(format!("Insert \"{}\"", grm.token_epp(token_idx).unwrap()))
                 }
                 ParseRepair::Delete(_) => out.push("Delete".to_owned()),
-                ParseRepair::Shift(_) => out.push("Shift".to_owned())
+                ParseRepair::Shift(_) => out.push("Shift".to_owned()),
             }
         }
         out.join(", ")
@@ -1178,9 +1178,9 @@ W: 'b' ;
     fn check_some_repairs<StorageT: 'static + Hash + PrimInt + Unsigned>(
         grm: &YaccGrammar<StorageT>,
         err: &LexParseError<StorageT>,
-        expected: &[&str]
+        expected: &[&str],
     ) where
-        usize: AsPrimitive<StorageT>
+        usize: AsPrimitive<StorageT>,
     {
         match err {
             LexParseError::ParseError(e) => {
@@ -1194,16 +1194,16 @@ W: 'b' ;
                     }
                 }
             }
-            _ => unreachable!()
+            _ => unreachable!(),
         }
     }
 
     fn check_all_repairs<StorageT: 'static + Debug + Hash + PrimInt + Unsigned>(
         grm: &YaccGrammar<StorageT>,
         err: &LexParseError<StorageT>,
-        expected: &[&str]
+        expected: &[&str],
     ) where
-        usize: AsPrimitive<StorageT>
+        usize: AsPrimitive<StorageT>,
     {
         match err {
             LexParseError::ParseError(e) => {
@@ -1227,7 +1227,7 @@ W: 'b' ;
                     }
                 }
             }
-            _ => unreachable!()
+            _ => unreachable!(),
         }
     }
 
@@ -1368,7 +1368,7 @@ E: '(' E ')'
             LexParseError::ParseError(e) => {
                 assert_eq!(e.lexeme(), &Lexeme::new(err_tok_id, 2, None))
             }
-            _ => unreachable!()
+            _ => unreachable!(),
         }
         check_all_repairs(
             &grm,
@@ -1376,7 +1376,7 @@ E: '(' E ')'
             &vec![
                 "Insert \"A\", Insert \")\", Insert \")\"",
                 "Insert \"B\", Insert \")\", Insert \")\"",
-            ]
+            ],
         );
     }
 
@@ -1417,8 +1417,8 @@ Factor: '(' Expr ')'
                 "Insert \")\", Insert \"*\"",
                 "Insert \")\", Delete",
                 "Insert \"+\", Shift, Insert \")\"",
-                "Insert \"*\", Shift, Insert \")\""
-            ]
+                "Insert \"*\", Shift, Insert \")\"",
+            ],
         );
 
         let us = "(+++++)";
@@ -1427,7 +1427,7 @@ Factor: '(' Expr ')'
         check_some_repairs(
             &grm,
             &errs[0],
-            &["Insert \"INT\", Delete, Delete, Delete, Delete, Delete"]
+            &["Insert \"INT\", Delete, Delete, Delete, Delete, Delete"],
         );
     }
 
@@ -1526,8 +1526,8 @@ U: 'd';
             &[
                 "Insert \"a\", Insert \"d\"",
                 "Insert \"b\", Insert \"d\"",
-                "Insert \"c\", Insert \"d\""
-            ]
+                "Insert \"c\", Insert \"d\"",
+            ],
         );
     }
 
@@ -1615,7 +1615,7 @@ A: 'c' 'd';
         check_all_repairs(
             &grm,
             &errs[0],
-            &["Insert \"c\", Insert \"d\", Insert \"c\", Insert \"d\", Insert \"a\""]
+            &["Insert \"c\", Insert \"d\", Insert \"c\", Insert \"d\", Insert \"a\""],
         );
     }
 
@@ -1639,7 +1639,7 @@ A: 'c' 'd';
         check_all_repairs(
             &grm,
             &errs[0],
-            &["Insert \"c\", Insert \"d\", Insert \"c\", Insert \"d\", Insert \"a\""]
+            &["Insert \"c\", Insert \"d\", Insert \"c\", Insert \"d\", Insert \"a\""],
         );
     }
 
@@ -1667,8 +1667,8 @@ D: 'd';
             &errs[0],
             &[
                 "Insert \"c\", Insert \"d\", Insert \"a\"",
-                "Insert \"d\", Insert \"c\", Insert \"b\""
-            ]
+                "Insert \"d\", Insert \"c\", Insert \"b\"",
+            ],
         );
     }
 

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -189,7 +189,7 @@ mod panic;
 pub mod parser;
 pub use crate::{
     ctbuilder::CTParserBuilder,
-    parser::{LexParseError, Node, ParseError, ParseRepair, RTParserBuilder, RecoveryKind}
+    parser::{LexParseError, Node, ParseError, ParseRepair, RTParserBuilder, RecoveryKind},
 };
 mod mf;
 
@@ -210,7 +210,7 @@ pub use cfgrammar::RIdx;
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Span {
     start: usize,
-    end: usize
+    end: usize,
 }
 
 impl Span {

--- a/lrpar/src/lib/panic.rs
+++ b/lrpar/src/lib/panic.rs
@@ -5,17 +5,17 @@ use num_traits::{AsPrimitive, PrimInt, Unsigned};
 
 use crate::{
     parser::{AStackType, ParseRepair, Parser, Recoverer},
-    Span
+    Span,
 };
 
 struct Panic;
 
 pub(crate) fn recoverer<'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>(
-    _: &'a Parser<StorageT, ActionT>
+    _: &'a Parser<StorageT, ActionT>,
 ) -> Box<dyn Recoverer<StorageT, ActionT> + 'a>
 where
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>
+    u32: AsPrimitive<StorageT>,
 {
     Box::new(Panic)
 }
@@ -24,7 +24,7 @@ impl<'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT: 'a>
     Recoverer<StorageT, ActionT> for Panic
 where
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>
+    u32: AsPrimitive<StorageT>,
 {
     fn recover(
         &self,
@@ -33,7 +33,7 @@ where
         in_laidx: usize,
         in_pstack: &mut Vec<StIdx>,
         _: &mut Vec<AStackType<ActionT, StorageT>>,
-        _: &mut Vec<Span>
+        _: &mut Vec<Span>,
     ) -> (usize, Vec<Vec<ParseRepair<StorageT>>>) {
         // This recoverer is based on that in Compiler Design in C by Allen I. Holub p.348.
         //

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -4,7 +4,7 @@ use std::{
     hash::Hash,
     marker::PhantomData,
     time::{Duration, Instant},
-    vec
+    vec,
 };
 
 use cactus::Cactus;
@@ -15,7 +15,7 @@ use num_traits::{AsPrimitive, PrimInt, Unsigned, Zero};
 use crate::{
     cpctplus,
     lex::{LexError, Lexeme, NonStreamingLexer},
-    mf, panic, Span
+    mf, panic, Span,
 };
 
 #[cfg(test)]
@@ -31,13 +31,13 @@ pub enum Node<StorageT> {
     /// Nonterminals reference a rule and have zero or more `Node`s as children.
     Nonterm {
         ridx: RIdx<StorageT>,
-        nodes: Vec<Node<StorageT>>
-    }
+        nodes: Vec<Node<StorageT>>,
+    },
 }
 
 impl<StorageT: 'static + PrimInt + Unsigned> Node<StorageT>
 where
-    usize: AsPrimitive<StorageT>
+    usize: AsPrimitive<StorageT>,
 {
     /// Return a pretty-printed version of this node.
     pub fn pp(&self, grm: &YaccGrammar<StorageT>, input: &str) -> String {
@@ -73,13 +73,13 @@ pub(crate) type ActionFn<'a, 'b, 'input, StorageT, ActionT> = &'a dyn Fn(
     RIdx<StorageT>,
     &'b dyn NonStreamingLexer<'input, StorageT>,
     Span,
-    vec::Drain<AStackType<ActionT, StorageT>>
+    vec::Drain<AStackType<ActionT, StorageT>>,
 ) -> ActionT;
 
 #[derive(Debug)]
 pub enum AStackType<ActionT, StorageT> {
     ActionType(ActionT),
-    Lexeme(Lexeme<StorageT>)
+    Lexeme(Lexeme<StorageT>),
 }
 
 pub struct Parser<'a, 'b: 'a, 'input: 'b, StorageT: 'static + Eq + Hash, ActionT: 'a> {
@@ -92,14 +92,14 @@ pub struct Parser<'a, 'b: 'a, 'input: 'b, StorageT: 'static + Eq + Hash, ActionT
     // In the long term, we should remove the `lexemes` field entirely, as the `NonStreamingLexer` API is
     // powerful enough to allow us to incrementally obtain lexemes and buffer them when necessary.
     pub(crate) lexemes: Vec<Lexeme<StorageT>>,
-    actions: &'a [ActionFn<'a, 'b, 'input, StorageT, ActionT>]
+    actions: &'a [ActionFn<'a, 'b, 'input, StorageT, ActionT>],
 }
 
 impl<'a, 'b: 'a, 'input: 'b, StorageT: 'static + Debug + Hash + PrimInt + Unsigned>
     Parser<'a, 'b, 'input, StorageT, Node<StorageT>>
 where
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>
+    u32: AsPrimitive<StorageT>,
 {
     fn parse_generictree(
         rcvry_kind: RecoveryKind,
@@ -108,7 +108,7 @@ where
         sgraph: &StateGraph<StorageT>,
         stable: &StateTable<StorageT>,
         lexer: &'b dyn NonStreamingLexer<'input, StorageT>,
-        lexemes: Vec<Lexeme<StorageT>>
+        lexemes: Vec<Lexeme<StorageT>>,
     ) -> (Option<Node<StorageT>>, Vec<LexParseError<StorageT>>) {
         for tidx in grm.iter_tidxs() {
             assert!(token_cost(tidx) > 0);
@@ -123,7 +123,7 @@ where
             stable,
             lexer,
             lexemes,
-            actions: actions.as_slice()
+            actions: actions.as_slice(),
         };
         let mut pstack = vec![StIdx::from(StIdxStorageT::zero())];
         let mut astack = Vec::new();
@@ -137,13 +137,13 @@ where
         ridx: RIdx<StorageT>,
         _lexer: &dyn NonStreamingLexer<StorageT>,
         _span: Span,
-        astack: vec::Drain<AStackType<Node<StorageT>, StorageT>>
+        astack: vec::Drain<AStackType<Node<StorageT>, StorageT>>,
     ) -> Node<StorageT> {
         let mut nodes = Vec::with_capacity(astack.len());
         for a in astack {
             nodes.push(match a {
                 AStackType::ActionType(n) => n,
-                AStackType::Lexeme(lexeme) => Node::Term { lexeme }
+                AStackType::Lexeme(lexeme) => Node::Term { lexeme },
             });
         }
         Node::Nonterm { ridx, nodes }
@@ -154,7 +154,7 @@ impl<'a, 'b: 'a, 'input: 'b, StorageT: 'static + Debug + Hash + PrimInt + Unsign
     Parser<'a, 'b, 'input, StorageT, ()>
 where
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>
+    u32: AsPrimitive<StorageT>,
 {
     fn parse_noaction(
         rcvry_kind: RecoveryKind,
@@ -163,7 +163,7 @@ where
         sgraph: &StateGraph<StorageT>,
         stable: &StateTable<StorageT>,
         lexer: &'b dyn NonStreamingLexer<'input, StorageT>,
-        lexemes: Vec<Lexeme<StorageT>>
+        lexemes: Vec<Lexeme<StorageT>>,
     ) -> Vec<LexParseError<StorageT>> {
         for tidx in grm.iter_tidxs() {
             assert!(token_cost(tidx) > 0);
@@ -178,7 +178,7 @@ where
             stable,
             lexer,
             lexemes,
-            actions: actions.as_slice()
+            actions: actions.as_slice(),
         };
         let mut pstack = vec![StIdx::from(StIdxStorageT::zero())];
         let mut astack = Vec::new();
@@ -192,7 +192,7 @@ where
         _ridx: RIdx<StorageT>,
         _lexer: &dyn NonStreamingLexer<StorageT>,
         _span: Span,
-        _astack: vec::Drain<AStackType<(), StorageT>>
+        _astack: vec::Drain<AStackType<(), StorageT>>,
     ) {
     }
 }
@@ -202,11 +202,11 @@ impl<
         'b: 'a,
         'input: 'b,
         StorageT: 'static + Debug + Hash + PrimInt + Unsigned,
-        ActionT: 'a
+        ActionT: 'a,
     > Parser<'a, 'b, 'input, StorageT, ActionT>
 where
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>
+    u32: AsPrimitive<StorageT>,
 {
     fn parse_actions(
         rcvry_kind: RecoveryKind,
@@ -216,7 +216,7 @@ where
         stable: &'a StateTable<StorageT>,
         lexer: &'b dyn NonStreamingLexer<'input, StorageT>,
         lexemes: Vec<Lexeme<StorageT>>,
-        actions: &'a [ActionFn<'a, 'b, 'input, StorageT, ActionT>]
+        actions: &'a [ActionFn<'a, 'b, 'input, StorageT, ActionT>],
     ) -> (Option<ActionT>, Vec<LexParseError<StorageT>>) {
         for tidx in grm.iter_tidxs() {
             assert!(token_cost(tidx) > 0);
@@ -229,7 +229,7 @@ where
             stable,
             lexer,
             lexemes,
-            actions
+            actions,
         };
         let mut pstack = vec![StIdx::from(StIdxStorageT::zero())];
         let mut astack = Vec::new();
@@ -258,7 +258,7 @@ where
         pstack: &mut PStack,
         astack: &mut Vec<AStackType<ActionT, StorageT>>,
         errors: &mut Vec<LexParseError<StorageT>>,
-        spans: &mut Vec<Span>
+        spans: &mut Vec<Span>,
     ) -> Option<ActionT> {
         let mut recoverer = None;
         let mut recovery_budget = Duration::from_millis(RECOVERY_TIME_BUDGET);
@@ -290,7 +290,7 @@ where
                         ridx,
                         self.lexer,
                         span,
-                        astack.drain(pop_idx - 1..)
+                        astack.drain(pop_idx - 1..),
                     ));
                     astack.push(v);
                 }
@@ -307,7 +307,7 @@ where
                     debug_assert_eq!(astack.len(), 1);
                     match astack.drain(..).next().unwrap() {
                         AStackType::ActionType(v) => return Some(v),
-                        _ => unreachable!()
+                        _ => unreachable!(),
                     }
                 }
                 Action::Error => {
@@ -322,9 +322,9 @@ where
                                     ParseError {
                                         stidx,
                                         lexeme: la_lexeme,
-                                        repairs: vec![]
+                                        repairs: vec![],
                                     }
-                                    .into()
+                                    .into(),
                                 );
                                 return None;
                             }
@@ -348,9 +348,9 @@ where
                         ParseError {
                             stidx,
                             lexeme: la_lexeme,
-                            repairs
+                            repairs,
                         }
-                        .into()
+                        .into(),
                     );
                     if !keep_going {
                         return None;
@@ -372,7 +372,7 @@ where
         end_laidx: usize,
         pstack: &mut PStack,
         astack: &mut Option<&mut Vec<AStackType<ActionT, StorageT>>>,
-        spans: &mut Option<&mut Vec<Span>>
+        spans: &mut Option<&mut Vec<Span>>,
     ) -> usize {
         assert!(lexeme_prefix.is_none() || end_laidx == laidx + 1);
         while laidx != end_laidx && laidx <= self.lexemes.len() {
@@ -394,12 +394,12 @@ where
                             } else if pop_idx - 1 < spans_uw.len() {
                                 Span::new(
                                     spans_uw[pop_idx - 1].start(),
-                                    spans_uw[spans_uw.len() - 1].end()
+                                    spans_uw[spans_uw.len() - 1].end(),
                                 )
                             } else {
                                 Span::new(
                                     spans_uw[spans_uw.len() - 1].start(),
-                                    spans_uw[spans_uw.len() - 1].end()
+                                    spans_uw[spans_uw.len() - 1].end(),
                                 )
                             };
                             spans_uw.truncate(pop_idx - 1);
@@ -409,7 +409,7 @@ where
                                 ridx,
                                 self.lexer,
                                 span,
-                                astack_uw.drain(pop_idx - 1..)
+                                astack_uw.drain(pop_idx - 1..),
                             ));
                             astack_uw.push(v);
                         } else {
@@ -467,7 +467,7 @@ where
             Lexeme::new(
                 StorageT::from(u32::from(self.grm.eof_token_idx())).unwrap(),
                 last_la_end,
-                None
+                None,
             )
         }
     }
@@ -497,7 +497,7 @@ where
         mut laidx: usize,
         end_laidx: usize,
         mut pstack: Cactus<StIdx>,
-        tstack: &mut Option<&mut Vec<Node<StorageT>>>
+        tstack: &mut Option<&mut Vec<Node<StorageT>>>,
     ) -> (usize, Cactus<StIdx>) {
         assert!(lexeme_prefix.is_none() || end_laidx == laidx + 1);
         while laidx != end_laidx {
@@ -561,7 +561,7 @@ pub trait Recoverer<StorageT: Hash + PrimInt + Unsigned, ActionT> {
         in_laidx: usize,
         in_pstack: &mut PStack,
         astack: &mut Vec<AStackType<ActionT, StorageT>>,
-        spans: &mut Vec<Span>
+        spans: &mut Vec<Span>,
     ) -> (usize, Vec<Vec<ParseRepair<StorageT>>>);
 }
 
@@ -578,7 +578,7 @@ pub enum RecoveryKind {
     #[doc(hidden)]
     Panic,
     /// Don't use error recovery: return as soon as the first syntax error is encountered.
-    None
+    None,
 }
 
 /// A lexing or parsing error. Although the two are quite distinct in terms of what can be reported
@@ -587,7 +587,7 @@ pub enum RecoveryKind {
 #[derive(Debug)]
 pub enum LexParseError<StorageT: Hash> {
     LexError(LexError),
-    ParseError(ParseError<StorageT>)
+    ParseError(ParseError<StorageT>),
 }
 
 impl<StorageT: Hash + PrimInt + Unsigned> LexParseError<StorageT> {
@@ -610,7 +610,7 @@ impl<StorageT: Hash + PrimInt + Unsigned> LexParseError<StorageT> {
     pub fn pp<'a>(
         &self,
         lexer: &dyn NonStreamingLexer<StorageT>,
-        epp: &dyn Fn(TIdx<StorageT>) -> Option<&'a str>
+        epp: &dyn Fn(TIdx<StorageT>) -> Option<&'a str>,
     ) -> String {
         match self {
             LexParseError::LexError(e) => {
@@ -659,7 +659,7 @@ impl<StorageT: Debug + Hash> fmt::Display for LexParseError<StorageT> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             LexParseError::LexError(ref e) => Display::fmt(e, f),
-            LexParseError::ParseError(ref e) => Display::fmt(e, f)
+            LexParseError::ParseError(ref e) => Display::fmt(e, f),
         }
     }
 }
@@ -685,19 +685,19 @@ pub struct RTParserBuilder<'a, StorageT: Eq + Hash> {
     stable: &'a StateTable<StorageT>,
     recoverer: RecoveryKind,
     term_costs: &'a dyn Fn(TIdx<StorageT>) -> u8,
-    phantom: PhantomData<StorageT>
+    phantom: PhantomData<StorageT>,
 }
 
 impl<'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned> RTParserBuilder<'a, StorageT>
 where
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>
+    u32: AsPrimitive<StorageT>,
 {
     /// Create a new run-time parser from a `YaccGrammar`, a `StateGraph`, and a `StateTable`.
     pub fn new(
         grm: &'a YaccGrammar<StorageT>,
         sgraph: &'a StateGraph<StorageT>,
-        stable: &'a StateTable<StorageT>
+        stable: &'a StateTable<StorageT>,
     ) -> Self {
         RTParserBuilder {
             grm,
@@ -705,7 +705,7 @@ where
             stable,
             recoverer: RecoveryKind::CPCTPlus,
             term_costs: &|_| 1,
-            phantom: PhantomData
+            phantom: PhantomData,
         }
     }
 
@@ -724,13 +724,13 @@ where
     /// [`parse_actions`](#method.parse_actions) for more details about the return value.
     pub fn parse_generictree(
         &self,
-        lexer: &dyn NonStreamingLexer<StorageT>
+        lexer: &dyn NonStreamingLexer<StorageT>,
     ) -> (Option<Node<StorageT>>, Vec<LexParseError<StorageT>>) {
         let mut lexemes = vec![];
         for e in lexer.iter().collect::<Vec<_>>() {
             match e {
                 Ok(l) => lexemes.push(l),
-                Err(e) => return (None, vec![e.into()])
+                Err(e) => return (None, vec![e.into()]),
             }
         }
         Parser::<StorageT, Node<StorageT>>::parse_generictree(
@@ -740,7 +740,7 @@ where
             self.sgraph,
             self.stable,
             lexer,
-            lexemes
+            lexemes,
         )
     }
 
@@ -748,13 +748,13 @@ where
     /// [`parse_actions`](#method.parse_actions) for more details about the return value.
     pub fn parse_noaction(
         &self,
-        lexer: &dyn NonStreamingLexer<StorageT>
+        lexer: &dyn NonStreamingLexer<StorageT>,
     ) -> Vec<LexParseError<StorageT>> {
         let mut lexemes = vec![];
         for e in lexer.iter().collect::<Vec<_>>() {
             match e {
                 Ok(l) => lexemes.push(l),
-                Err(e) => return vec![e.into()]
+                Err(e) => return vec![e.into()],
             }
         }
         Parser::<StorageT, ()>::parse_noaction(
@@ -764,7 +764,7 @@ where
             self.sgraph,
             self.stable,
             lexer,
-            lexemes
+            lexemes,
         )
     }
 
@@ -777,13 +777,13 @@ where
     pub fn parse_actions<'b: 'a, 'input: 'b, ActionT: 'a>(
         &self,
         lexer: &'b dyn NonStreamingLexer<'input, StorageT>,
-        actions: &'a [ActionFn<'a, 'b, 'input, StorageT, ActionT>]
+        actions: &'a [ActionFn<'a, 'b, 'input, StorageT, ActionT>],
     ) -> (Option<ActionT>, Vec<LexParseError<StorageT>>) {
         let mut lexemes = vec![];
         for e in lexer.iter().collect::<Vec<_>>() {
             match e {
                 Ok(l) => lexemes.push(l),
-                Err(e) => return (None, vec![e.into()])
+                Err(e) => return (None, vec![e.into()]),
             }
         }
         Parser::parse_actions(
@@ -794,7 +794,7 @@ where
             self.stable,
             lexer,
             lexemes,
-            actions
+            actions,
         )
     }
 }
@@ -808,7 +808,7 @@ pub enum ParseRepair<StorageT: Hash> {
     /// Delete a symbol.
     Delete(Lexeme<StorageT>),
     /// Shift a symbol.
-    Shift(Lexeme<StorageT>)
+    Shift(Lexeme<StorageT>),
 }
 
 /// Records a single parse error.
@@ -816,7 +816,7 @@ pub enum ParseRepair<StorageT: Hash> {
 pub struct ParseError<StorageT: Hash> {
     stidx: StIdx,
     lexeme: Lexeme<StorageT>,
-    repairs: Vec<Vec<ParseRepair<StorageT>>>
+    repairs: Vec<Vec<ParseRepair<StorageT>>>,
 }
 
 impl<StorageT: Debug + Hash> Display for ParseError<StorageT> {
@@ -857,17 +857,17 @@ pub(crate) mod test {
     use super::*;
     use crate::{
         lex::{Lexeme, Lexer},
-        Span
+        Span,
     };
 
     pub(crate) fn do_parse(
         rcvry_kind: RecoveryKind,
         lexs: &str,
         grms: &str,
-        input: &str
+        input: &str,
     ) -> (
         YaccGrammar<u16>,
-        Result<Node<u16>, (Option<Node<u16>>, Vec<LexParseError<u16>>)>
+        Result<Node<u16>, (Option<Node<u16>>, Vec<LexParseError<u16>>)>,
     ) {
         do_parse_with_costs(rcvry_kind, lexs, grms, input, &HashMap::new())
     }
@@ -877,14 +877,14 @@ pub(crate) mod test {
         lexs: &str,
         grms: &str,
         input: &str,
-        costs: &HashMap<&str, u8>
+        costs: &HashMap<&str, u8>,
     ) -> (
         YaccGrammar<u16>,
-        Result<Node<u16>, (Option<Node<u16>>, Vec<LexParseError<u16>>)>
+        Result<Node<u16>, (Option<Node<u16>>, Vec<LexParseError<u16>>)>,
     ) {
         let grm = YaccGrammar::<u16>::new_with_storaget(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            grms
+            grms,
         )
         .unwrap();
         let (sgraph, stable) = from_yacc(&grm, Minimiser::Pager).unwrap();
@@ -923,7 +923,7 @@ pub(crate) mod test {
     //   * The initial "%%" isn't needed, and only "'" is valid as a rule name delimiter.
     //   * "Unnamed" rules aren't allowed (e.g. you can't have a rule which discards whitespaces).
     struct SmallLexer<StorageT> {
-        lexemes: Vec<Lexeme<StorageT>>
+        lexemes: Vec<Lexeme<StorageT>>,
     }
 
     impl<StorageT: Hash + PrimInt + Unsigned> Lexer<StorageT> for SmallLexer<StorageT> {
@@ -957,7 +957,7 @@ pub(crate) mod test {
             let re = &l[..i - 1].trim();
             rules.push((
                 ids_map[name],
-                Regex::new(&format!("\\A(?:{})", re)).unwrap()
+                Regex::new(&format!("\\A(?:{})", re)).unwrap(),
             ));
         }
         rules
@@ -1006,7 +1006,7 @@ T: 'ID';
  E
   T
    ID b
-"
+",
         );
     }
 
@@ -1022,7 +1022,7 @@ L: 'ID'
         check_parse_output(
             &lexs, &grms, "", "S
  L
-"
+",
         );
 
         check_parse_output(
@@ -1032,7 +1032,7 @@ L: 'ID'
             "S
  L
   ID x
-"
+",
         );
     }
 
@@ -1064,7 +1064,7 @@ Factor : 'INT';";
    Term
     Factor
      INT 4
-"
+",
         );
         check_parse_output(
             &lexs,
@@ -1083,7 +1083,7 @@ Factor : 'INT';";
   Term
    Factor
     INT 4
-"
+",
         );
     }
 
@@ -1104,7 +1104,7 @@ Call: 'ID' '(' ')';";
  ID f
  ( (
  ) )
-"
+",
         );
 
         let (grm, pr) = do_parse(RecoveryKind::MF, &lexs, &grms, "f(");
@@ -1116,7 +1116,7 @@ Call: 'ID' '(' ')';";
                 assert_eq!(e.lexeme(), &Lexeme::new(err_tok_id, 2, None));
                 assert!(e.lexeme().inserted());
             }
-            _ => unreachable!()
+            _ => unreachable!(),
         }
 
         let (grm, pr) = do_parse(RecoveryKind::MF, &lexs, &grms, "f(f(");
@@ -1128,7 +1128,7 @@ Call: 'ID' '(' ')';";
                 assert_eq!(e.lexeme(), &Lexeme::new(err_tok_id, 2, Some(1)));
                 assert!(!e.lexeme().inserted());
             }
-            _ => unreachable!()
+            _ => unreachable!(),
         }
     }
 }

--- a/lrtable/src/lib/itemset.rs
+++ b/lrtable/src/lib/itemset.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::hash_map::{Entry, HashMap},
-    hash::{BuildHasherDefault, Hash}
+    hash::{BuildHasherDefault, Hash},
 };
 
 use cfgrammar::{yacc::YaccGrammar, PIdx, SIdx, Symbol};
@@ -18,17 +18,17 @@ pub type Ctx = Vob;
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Itemset<StorageT: Eq + Hash> {
-    pub items: HashMap<(PIdx<StorageT>, SIdx<StorageT>), Ctx, BuildHasherDefault<FnvHasher>>
+    pub items: HashMap<(PIdx<StorageT>, SIdx<StorageT>), Ctx, BuildHasherDefault<FnvHasher>>,
 }
 
 impl<StorageT: 'static + Hash + PrimInt + Unsigned> Itemset<StorageT>
 where
-    usize: AsPrimitive<StorageT>
+    usize: AsPrimitive<StorageT>,
 {
     /// Create a blank Itemset.
     pub fn new(_: &YaccGrammar<StorageT>) -> Self {
         Itemset {
-            items: HashMap::with_hasher(BuildHasherDefault::<FnvHasher>::default())
+            items: HashMap::with_hasher(BuildHasherDefault::<FnvHasher>::default()),
         }
     }
 
@@ -88,7 +88,7 @@ where
                             // Since zero_todos.len() == grm.prods_len, the call to as_ is safe.
                             pidx = PIdx(i.as_())
                         }
-                        None => break
+                        None => break,
                     }
                     dot = SIdx(StorageT::zero());
                     zero_todos.set(pidx.into(), false);
@@ -159,7 +159,7 @@ where
 mod test {
     use cfgrammar::{
         yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
-        SIdx, Symbol
+        SIdx, Symbol,
     };
     use vob::Vob;
 
@@ -210,7 +210,7 @@ mod test {
           C: D A;
           D: 'd' | ;
           F: C D 'f';
-          "
+          ",
         )
         .unwrap()
     }
@@ -257,7 +257,7 @@ mod test {
           %%
           S: S 'b' | 'b' A 'a';
           A: 'a' S 'c' | 'a' | 'a' S 'b';
-          "
+          ",
         )
         .unwrap()
     }

--- a/lrtable/src/lib/mod.rs
+++ b/lrtable/src/lib/mod.rs
@@ -16,7 +16,7 @@ pub mod statetable;
 
 pub use crate::{
     stategraph::StateGraph,
-    statetable::{Action, StateTable, StateTableError, StateTableErrorKind}
+    statetable::{Action, StateTable, StateTableError, StateTableErrorKind},
 };
 use cfgrammar::yacc::YaccGrammar;
 
@@ -57,16 +57,16 @@ impl From<StIdx> for StIdxStorageT {
 
 #[derive(Clone, Copy)]
 pub enum Minimiser {
-    Pager
+    Pager,
 }
 
 pub fn from_yacc<StorageT: 'static + Hash + PrimInt + Unsigned>(
     grm: &YaccGrammar<StorageT>,
-    m: Minimiser
+    m: Minimiser,
 ) -> Result<(StateGraph<StorageT>, StateTable<StorageT>), StateTableError<StorageT>>
 where
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>
+    u32: AsPrimitive<StorageT>,
 {
     match m {
         Minimiser::Pager => {

--- a/lrtable/src/lib/pager.rs
+++ b/lrtable/src/lib/pager.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{hash_map::HashMap, HashSet},
-    hash::Hash
+    hash::Hash,
 };
 
 use cfgrammar::{yacc::YaccGrammar, SIdx, Symbol};
@@ -114,10 +114,10 @@ fn vob_intersect(v1: &Vob, v2: &Vob) -> bool {
 
 /// Create a `StateGraph` from 'grm'.
 pub fn pager_stategraph<StorageT: 'static + Hash + PrimInt + Unsigned>(
-    grm: &YaccGrammar<StorageT>
+    grm: &YaccGrammar<StorageT>,
 ) -> StateGraph<StorageT>
 where
-    usize: AsPrimitive<StorageT>
+    usize: AsPrimitive<StorageT>,
 {
     // This function can be seen as a modified version of items() from Chen's dissertation.
 
@@ -170,7 +170,7 @@ where
             .position(Option::is_none)
         {
             Some(i) => todo_off + i,
-            None => closed_states.iter().position(Option::is_none).unwrap()
+            None => closed_states.iter().position(Option::is_none).unwrap(),
         };
         todo_off = state_i + 1;
         todo -= 1;
@@ -211,7 +211,7 @@ where
                 // Try and compatible match for this state.
                 let cnd_states = match sym {
                     Symbol::Rule(s_ridx) => &cnd_rule_weaklies[usize::from(s_ridx)],
-                    Symbol::Token(s_tidx) => &cnd_token_weaklies[usize::from(s_tidx)]
+                    Symbol::Token(s_tidx) => &cnd_token_weaklies[usize::from(s_tidx)],
                 };
                 // First of all see if any of the candidate states are exactly the same as the
                 // new state, in which case we only need to add an edge to the candidate
@@ -286,7 +286,7 @@ where
             .drain(..)
             .zip(closed_states.drain(..).map(Option::unwrap))
             .collect(),
-        edges
+        edges,
     );
     StateGraph::new(gc_states, gc_edges)
 }
@@ -295,10 +295,10 @@ where
 /// with unused states and their corresponding edges removed.
 fn gc<StorageT: Eq + Hash + PrimInt>(
     mut states: Vec<(Itemset<StorageT>, Itemset<StorageT>)>,
-    mut edges: Vec<HashMap<Symbol<StorageT>, StIdx>>
+    mut edges: Vec<HashMap<Symbol<StorageT>, StIdx>>,
 ) -> (
     Vec<(Itemset<StorageT>, Itemset<StorageT>)>,
-    Vec<HashMap<Symbol<StorageT>, StIdx>>
+    Vec<HashMap<Symbol<StorageT>, StIdx>>,
 ) {
     // First of all, do a simple pass over all states. All state indexes reachable from the
     // start state will be inserted into the 'seen' set.
@@ -315,7 +315,7 @@ fn gc<StorageT: Eq + Hash + PrimInt>(
         todo.extend(
             edges[usize::from(state_i)]
                 .values()
-                .filter(|x| !seen.contains(x))
+                .filter(|x| !seen.contains(x)),
         );
     }
 
@@ -374,7 +374,7 @@ fn gc<StorageT: Eq + Hash + PrimInt>(
             st_edges
                 .iter()
                 .map(|(&k, &v)| (k, offsets[usize::from(v)]))
-                .collect()
+                .collect(),
         );
     }
 
@@ -388,7 +388,7 @@ mod test {
     use crate::{pager::pager_stategraph, stategraph::state_exists, StIdx};
     use cfgrammar::{
         yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
-        SIdx, Symbol
+        SIdx, Symbol,
     };
 
     use super::vob_intersect;
@@ -434,7 +434,7 @@ mod test {
           %%
           S: S 'b' | 'b' A 'a';
           A: 'a' S 'c' | 'a' | 'a' S 'b';
-          "
+          ",
         )
         .unwrap()
     }
@@ -516,7 +516,7 @@ mod test {
              T : 'u' X 'a';
              W : 'u' V;
              V : ;
-          "
+          ",
         )
         .unwrap()
     }

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -14,16 +14,16 @@ pub struct StateGraph<StorageT: Eq + Hash> {
     /// A vector of `(core_states, closed_states)` tuples.
     states: Vec<(Itemset<StorageT>, Itemset<StorageT>)>,
     /// For each state in `states`, edges is a hashmap from symbols to state offsets.
-    edges: Vec<HashMap<Symbol<StorageT>, StIdx>>
+    edges: Vec<HashMap<Symbol<StorageT>, StIdx>>,
 }
 
 impl<StorageT: 'static + Hash + PrimInt + Unsigned> StateGraph<StorageT>
 where
-    usize: AsPrimitive<StorageT>
+    usize: AsPrimitive<StorageT>,
 {
     pub(crate) fn new(
         states: Vec<(Itemset<StorageT>, Itemset<StorageT>)>,
-        edges: Vec<HashMap<Symbol<StorageT>, StIdx>>
+        edges: Vec<HashMap<Symbol<StorageT>, StIdx>>,
     ) -> Self {
         // states.len() needs to fit into StIdxStorageT; however we don't need to worry about
         // edges.len() (which merely needs to fit in a usize)
@@ -46,7 +46,7 @@ where
 
     /// Return an iterator over all closed states in this `StateGraph`.
     pub fn iter_closed_states<'a>(
-        &'a self
+        &'a self,
     ) -> Box<dyn Iterator<Item = &'a Itemset<StorageT>> + 'a> {
         Box::new(self.states.iter().map(|x| &x.1))
     }
@@ -100,14 +100,14 @@ where
 
         fn fmt_sym<StorageT: 'static + PrimInt + Unsigned>(
             grm: &YaccGrammar<StorageT>,
-            sym: Symbol<StorageT>
+            sym: Symbol<StorageT>,
         ) -> String
         where
-            usize: AsPrimitive<StorageT>
+            usize: AsPrimitive<StorageT>,
         {
             match sym {
                 Symbol::Rule(ridx) => grm.rule_name(ridx).to_string(),
-                Symbol::Token(tidx) => format!("'{}'", grm.token_name(tidx).unwrap_or(""))
+                Symbol::Token(tidx) => format!("'{}'", grm.token_name(tidx).unwrap_or("")),
             }
         }
 
@@ -198,9 +198,9 @@ pub fn state_exists<StorageT: 'static + Hash + PrimInt + Unsigned>(
     nt: &str,
     prod_off: usize,
     dot: SIdx<StorageT>,
-    la: Vec<&str>
+    la: Vec<&str>,
 ) where
-    usize: AsPrimitive<StorageT>
+    usize: AsPrimitive<StorageT>,
 {
     let ab_prod_off = grm.rule_to_prods(grm.rule_idx(nt).unwrap())[prod_off];
     let ctx = &is.items[&(ab_prod_off, dot)];
@@ -239,7 +239,7 @@ mod test {
     use crate::{pager::pager_stategraph, StIdx};
     use cfgrammar::{
         yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
-        Symbol
+        Symbol,
     };
 
     #[test]

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -3,7 +3,7 @@ use std::{
     fs::File,
     io::{stderr, Read, Write},
     path::Path,
-    process
+    process,
 };
 
 use cfgrammar::yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind};
@@ -17,7 +17,7 @@ fn usage(prog: &str, msg: &str) -> ! {
     let path = Path::new(prog);
     let leaf = match path.file_name() {
         Some(m) => m.to_str().unwrap(),
-        None => "lrpar"
+        None => "lrpar",
     };
     if !msg.is_empty() {
         writeln!(&mut stderr(), "{}", msg).ok();
@@ -54,18 +54,18 @@ fn main() {
             "r",
             "recoverer",
             "Recoverer to be used (default: cpctplus)",
-            "cpctplus|none"
+            "cpctplus|none",
         )
         .optopt(
             "y",
             "yaccvariant",
             "Yacc variant to be parsed (default: Original)",
-            "Eco|Original|Grmtools"
+            "Eco|Original|Grmtools",
         )
         .parse(&args[1..])
     {
         Ok(m) => m,
-        Err(f) => usage(prog, f.to_string().as_str())
+        Err(f) => usage(prog, f.to_string().as_str()),
     };
 
     if matches.opt_present("h") {
@@ -81,8 +81,8 @@ fn main() {
             "mf" => RecoveryKind::MF,
             "panic" => RecoveryKind::Panic,
             "none" => RecoveryKind::None,
-            _ => usage(prog, &format!("Unknown recoverer '{}'.", s))
-        }
+            _ => usage(prog, &format!("Unknown recoverer '{}'.", s)),
+        },
     };
 
     let yacckind = match matches.opt_str("y") {
@@ -91,8 +91,8 @@ fn main() {
             "eco" => YaccKind::Eco,
             "grmtools" => YaccKind::Grmtools,
             "original" => YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            _ => usage(prog, &format!("Unknown Yacc variant '{}'.", s))
-        }
+            _ => usage(prog, &format!("Unknown Yacc variant '{}'.", s)),
+        },
     };
 
     if matches.free.len() != 3 {
@@ -169,7 +169,7 @@ fn main() {
     let (pt, errs) = pb.parse_generictree(&lexer);
     match pt {
         Some(pt) => println!("{}", pt.pp(&grm, &input)),
-        None => println!("Unable to repair input sufficiently to produce parse tree.\n")
+        None => println!("Unable to repair input sufficiently to produce parse tree.\n"),
     }
     for e in &errs {
         println!("{}", e.pp(&lexer, &|t| grm.token_epp(t)));


### PR DESCRIPTION
This PR is mostly about using the stable version of rustfmt (https://github.com/softdevteam/grmtools/commit/87fc3c91e77880059b6655bcfe401a20cda1f3c3) which is an entirely mechanical diff. I've also fixed a couple of manual formatting issues as well (https://github.com/softdevteam/grmtools/commit/450c5c74c1fed0e0be3648852422d7ab6db214b7)