### PR TITLE
Produce a better error message when an integer is inserted.

### DIFF
--- a/lrpar/examples/calc_actions/src/calc.y
+++ b/lrpar/examples/calc_actions/src/calc.y
@@ -19,7 +19,7 @@ Factor -> Result<u64, Box<dyn Error>>:
       '(' Expr ')' { $2 }
     | 'INT'
       {
-          parse_int($lexer.span_str($1?.span()))
+          parse_int($lexer.span_str($1.map_err(|_| "<evaluation aborted>")?.span()))
       }
     ;
 %%


### PR DESCRIPTION
If an integer was inserted by error recovery, the error message that was printed to the user was the `Debug` rendering of a `Lexeme`:

```
  >>> 2 +
  Parsing error at line 1 column 4. Repair sequences found:
     1: Insert INT
  Lexeme[3..3]
```

which is not very informative. This commit changes this so that the user is explicitly informed that evaluation was aborted:

```
  >>> 2 +
  Parsing error at line 1 column 4. Repair sequences found:
     1: Insert INT
  <evaluation aborted>
```