### PR TITLE
Remove the pervasive assumption that the start state is 0.

### DIFF
--- a/lrpar/src/lib/mf.rs
+++ b/lrpar/src/lib/mf.rs
@@ -900,8 +900,8 @@ mod test {
         yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
         Symbol,
     };
-    use lrtable::{from_yacc, Minimiser, StIdx, StIdxStorageT};
-    use num_traits::{AsPrimitive, PrimInt, ToPrimitive, Unsigned, Zero};
+    use lrtable::{from_yacc, Minimiser};
+    use num_traits::{AsPrimitive, PrimInt, ToPrimitive, Unsigned};
 
     use crate::{
         lex::Lexeme,
@@ -947,7 +947,7 @@ A: '(' A ')'
         let grm = YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), grms).unwrap();
         let (sgraph, stable) = from_yacc(&grm, Minimiser::Pager).unwrap();
         let d = Dist::new(&grm, &sgraph, &stable, |_| 1);
-        let s0 = StIdx::from(StIdxStorageT::zero());
+        let s0 = sgraph.start_state();
         assert_eq!(d.dist(s0, grm.token_idx("(").unwrap()), 0);
         assert_eq!(d.dist(s0, grm.token_idx(")").unwrap()), 1);
         assert_eq!(d.dist(s0, grm.token_idx("a").unwrap()), 0);
@@ -1014,7 +1014,7 @@ U: 'B';
         // This only tests a subset of all the states and distances but, I believe, it tests all
         // more interesting edge cases that the example from the Kim/Yi paper.
 
-        let s0 = StIdx::from(StIdxStorageT::zero());
+        let s0 = sgraph.start_state();
         assert_eq!(d.dist(s0, grm.token_idx("A").unwrap()), 0);
         assert_eq!(d.dist(s0, grm.token_idx("B").unwrap()), 1);
         assert_eq!(d.dist(s0, grm.token_idx("C").unwrap()), 2);
@@ -1072,7 +1072,7 @@ Factor: '(' Expr ')'
         // This only tests a subset of all the states and distances but, I believe, it tests all
         // more interesting edge cases that the example from the Kim/Yi paper.
 
-        let s0 = StIdx::from(StIdxStorageT::zero());
+        let s0 = sgraph.start_state();
         assert_eq!(d.dist(s0, grm.token_idx("+").unwrap()), 1);
         assert_eq!(d.dist(s0, grm.token_idx("*").unwrap()), 1);
         assert_eq!(d.dist(s0, grm.token_idx("(").unwrap()), 0);
@@ -1134,7 +1134,7 @@ W: 'b' ;
         let (sgraph, stable) = from_yacc(&grm, Minimiser::Pager).unwrap();
         let d = Dist::new(&grm, &sgraph, &stable, |_| 1);
 
-        let s0 = StIdx::from(StIdxStorageT::zero());
+        let s0 = sgraph.start_state();
         assert_eq!(d.dist(s0, grm.token_idx("a").unwrap()), 0);
         assert_eq!(d.dist(s0, grm.token_idx("b").unwrap()), 1);
         assert_eq!(d.dist(s0, grm.eof_token_idx()), 0);

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -9,8 +9,8 @@ use std::{
 
 use cactus::Cactus;
 use cfgrammar::{yacc::YaccGrammar, RIdx, TIdx};
-use lrtable::{Action, StIdx, StIdxStorageT, StateGraph, StateTable};
-use num_traits::{AsPrimitive, PrimInt, Unsigned, Zero};
+use lrtable::{Action, StIdx, StateGraph, StateTable};
+use num_traits::{AsPrimitive, PrimInt, Unsigned};
 
 use crate::{
     cpctplus,
@@ -125,7 +125,7 @@ where
             lexemes,
             actions: actions.as_slice(),
         };
-        let mut pstack = vec![StIdx::from(StIdxStorageT::zero())];
+        let mut pstack = vec![sgraph.start_state()];
         let mut astack = Vec::new();
         let mut errors = Vec::new();
         let mut spans = Vec::new();
@@ -180,7 +180,7 @@ where
             lexemes,
             actions: actions.as_slice(),
         };
-        let mut pstack = vec![StIdx::from(StIdxStorageT::zero())];
+        let mut pstack = vec![sgraph.start_state()];
         let mut astack = Vec::new();
         let mut errors = Vec::new();
         let mut spans = Vec::new();
@@ -231,7 +231,7 @@ where
             lexemes,
             actions,
         };
-        let mut pstack = vec![StIdx::from(StIdxStorageT::zero())];
+        let mut pstack = vec![sgraph.start_state()];
         let mut astack = Vec::new();
         let mut errors = Vec::new();
         let mut spans = Vec::new();

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -120,6 +120,7 @@ pub struct StateTable<StorageT> {
     actions: SparseVec<usize>,
     state_actions: Vob,
     gotos: SparseVec<usize>,
+    start_state: StIdx,
     core_reduces: Vob,
     state_shifts: Vob,
     reduce_states: Vob,
@@ -350,6 +351,7 @@ where
             actions: actions_sv,
             state_actions,
             gotos: gotos_sv,
+            start_state: sg.start_state(),
             state_shifts,
             core_reduces,
             reduce_states,
@@ -461,6 +463,11 @@ where
             Some(i) => Some(StIdx((i - 1) as StIdxStorageT)),
             None => unreachable!(),
         }
+    }
+
+    /// Return this state table's start state.
+    pub fn start_state(&self) -> StIdx {
+        self.start_state
     }
 
     /// Return a struct containing all conflicts or `None` if there aren't any.
@@ -602,7 +609,7 @@ mod test {
         let sg = pager_stategraph(&grm);
         assert_eq!(sg.all_states_len(), StIdx(9));
 
-        let s0 = StIdx(0);
+        let s0 = sg.start_state();
         let s1 = sg.edge(s0, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
         let s2 = sg.edge(s0, Symbol::Rule(grm.rule_idx("Term").unwrap())).unwrap();
         let s3 = sg.edge(s0, Symbol::Rule(grm.rule_idx("Factor").unwrap())).unwrap();
@@ -685,7 +692,7 @@ mod test {
         assert_eq!(st.actions.len(), len);
 
         // We only extract the states necessary to test those rules affected by the reduce/reduce.
-        let s0 = StIdx(0);
+        let s0 = sg.start_state();
         let s4 = sg.edge(s0, Symbol::Token(grm.token_idx("a").unwrap())).unwrap();
 
         assert_eq!(st.action(s4, grm.token_idx("x").unwrap()),
@@ -707,7 +714,7 @@ mod test {
         let len = usize::from(grm.tokens_len()) * usize::from(sg.all_states_len());
         assert_eq!(st.actions.len(), len);
 
-        let s0 = StIdx(0);
+        let s0 = sg.start_state();
         let s1 = sg.edge(s0, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
         let s3 = sg.edge(s1, Symbol::Token(grm.token_idx("+").unwrap())).unwrap();
         let s4 = sg.edge(s1, Symbol::Token(grm.token_idx("*").unwrap())).unwrap();
@@ -737,7 +744,7 @@ mod test {
             ").unwrap();
         let sg = pager_stategraph(&grm);
         let st = StateTable::new(&grm, &sg).unwrap();
-        let s0 = StIdx(0);
+        let s0 = sg.start_state();
         let s1 = sg.edge(s0, Symbol::Token(grm.token_idx("a").unwrap())).unwrap();
         let s2 = sg.edge(s0, Symbol::Token(grm.token_idx("b").unwrap())).unwrap();
 
@@ -764,7 +771,7 @@ mod test {
         let len = usize::from(grm.tokens_len()) * usize::from(sg.all_states_len());
         assert_eq!(st.actions.len(), len);
 
-        let s0 = StIdx(0);
+        let s0 = sg.start_state();
         let s1 = sg.edge(s0, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
         let s3 = sg.edge(s1, Symbol::Token(grm.token_idx("+").unwrap())).unwrap();
         let s4 = sg.edge(s1, Symbol::Token(grm.token_idx("*").unwrap())).unwrap();
@@ -805,7 +812,7 @@ mod test {
         let len = usize::from(grm.tokens_len()) * usize::from(sg.all_states_len());
         assert_eq!(st.actions.len(), len);
 
-        let s0 = StIdx(0);
+        let s0 = sg.start_state();
         let s1 = sg.edge(s0, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
         let s3 = sg.edge(s1, Symbol::Token(grm.token_idx("+").unwrap())).unwrap();
         let s4 = sg.edge(s1, Symbol::Token(grm.token_idx("*").unwrap())).unwrap();
@@ -863,7 +870,7 @@ mod test {
         let len = usize::from(grm.tokens_len()) * usize::from(sg.all_states_len());
         assert_eq!(st.actions.len(), len);
 
-        let s0 = StIdx(0);
+        let s0 = sg.start_state();
         let s1 = sg.edge(s0, Symbol::Rule(grm.rule_idx("Expr").unwrap())).unwrap();
         let s3 = sg.edge(s1, Symbol::Token(grm.token_idx("+").unwrap())).unwrap();
         let s4 = sg.edge(s1, Symbol::Token(grm.token_idx("*").unwrap())).unwrap();


### PR DESCRIPTION
There's no good reason for us exposing an assumption about which state in the 
stategraph/statetable is the start state, and it may reduce our flexibility later. This commit abstracts this assumption away such that the start state is specified concretely just once (in pager::pager_stategraph), thus giving us a single place to consider if we ever do want to change this assumption.

This addresses one small part of https://github.com/softdevteam/grmtools/issues/191.