### PR TITLE
Prepare a 0.8.1 release.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,14 @@
+# grmtools 0.8.1 (2020-06-11)
+
+* The modules generated for compile-time parsing by lrlex and lrpar have
+  private visibility by default. Changing this previously required a manual
+  alias. The `visibility` function in lrlex and lrpar's compile-time builders
+  allows a different visibility to be set (e.g.
+  `visibility(Visibility::Public)`. Rust has a [number of visibility
+  settings](https://doc.rust-lang.org/reference/visibility-and-privacy.html#pubin-path-pubcrate-pubsuper-and-pubself)
+  and the `Visibility` `enum`s in lrlex and lrpar reflect this.
+
+
 # grmtools 0.8.0 (2020-05-28)
 
 ## Breaking changes

--- a/cfgrammar/Cargo.toml
+++ b/cfgrammar/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cfgrammar"
 description = "Grammar manipulation"
 repository = "https://github.com/softdevteam/grmtools"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Laurence Tratt <http://tratt.net/laurie/>"]
 edition = "2018"
 readme = "README.md"

--- a/lrlex/Cargo.toml
+++ b/lrlex/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lrlex"
 description = "Simple lexer generator"
 repository = "https://github.com/softdevteam/grmtools"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Laurence Tratt <http://tratt.net/laurie/>"]
 edition = "2018"
 readme = "README.md"

--- a/lrpar/Cargo.toml
+++ b/lrpar/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lrpar"
 description = "Yacc-compatible parser generator"
 repository = "https://github.com/softdevteam/grmtools"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Lukas Diekmann <http://lukasdiekmann.com/>", "Laurence Tratt <http://tratt.net/laurie/>"]
 edition = "2018"
 readme = "README.md"

--- a/lrtable/Cargo.toml
+++ b/lrtable/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lrtable"
 description = "LR grammar table generation"
 repository = "https://github.com/softdevteam/grmtools"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Lukas Diekmann <http://lukasdiekmann.com/>", "Laurence Tratt <http://tratt.net/laurie/>"]
 edition = "2018"
 readme = "README.md"

--- a/nimbleparse/Cargo.toml
+++ b/nimbleparse/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "nimbleparse"
-version = "0.8.0"
+description = "Simple Yacc grammar debugging tool"
+repository = "https://github.com/softdevteam/grmtools"
+version = "0.8.1"
 authors = ["Laurence Tratt <http://tratt.net/laurie/>"]
 edition = "2018"
+readme = "README.md"
 license = "Apache-2.0/MIT"
+categories = ["parsing"]
 
 [[bin]]
 doc = false


### PR DESCRIPTION
Note that the intention is to make a release of nimbleparse on crates.io for the first time, so I've tentatively added the fields that I think crates.io will require. Guessing these in advance is always a bit random for me, so I might have got them wrong.