### PR TITLE
Fix factor/Term names

### DIFF
--- a/doc/src/ast_example.md
+++ b/doc/src/ast_example.md
@@ -15,16 +15,16 @@ guide](quickstart.md). However the `calc.y` file is change as follows:
 %avoid_insert "INT"
 %%
 Expr -> Result<Expr, ()>:
-      Term '+' Expr { Ok(Expr::Add{ span: $span, lhs: Box::new($1?), rhs: Box::new($3?) }) }
-    | Term { $1 }
-    ;
-
-Term -> Result<Expr, ()>:
-      Factor '*' Term { Ok(Expr::Mul{ span: $span, lhs: Box::new($1?), rhs: Box::new($3?) }) }
+      Factor '+' Expr { Ok(Expr::Add{ span: $span, lhs: Box::new($1?), rhs: Box::new($3?) }) }
     | Factor { $1 }
     ;
 
 Factor -> Result<Expr, ()>:
+      Term '*' Factor { Ok(Expr::Mul{ span: $span, lhs: Box::new($1?), rhs: Box::new($3?) }) }
+    | Term { $1 }
+    ;
+
+Term -> Result<Expr, ()>:
       '(' Expr ')' { $2 }
     | 'INT' { Ok(Expr::Number{ span: $span }) }
     ;

--- a/doc/src/errorrecovery.md
+++ b/doc/src/errorrecovery.md
@@ -52,16 +52,16 @@ A simple calculator grammar looks as follows:
 %start Expr
 %%
 Expr -> u64:
-      Term 'PLUS' Expr { $1 + $3 }
-    | Term { $1 }
-    ;
-
-Term -> u64:
-      Factor 'MUL' Term { $1 * $3 }
+      Factor 'PLUS' Expr { $1 + $3 }
     | Factor { $1 }
     ;
 
 Factor -> u64:
+      Term 'MUL' Factor { $1 * $3 }
+    | Term { $1 }
+    ;
+
+Term -> u64:
       'LBRACK' Expr 'RBRACK' { $2 }
     | 'INT' { parse_int($lexer.span_str($1.unwrap().unwrap())) }
     ;
@@ -166,16 +166,16 @@ occurring:
 %start Expr
 %%
 Expr -> Result<u64, ()>:
-      Term 'PLUS' Expr { Ok($1? + $3?) }
-    | Term { $1 }
-    ;
-
-Term -> Result<u64, ()>:
-      Factor 'MUL' Term { Ok($1? * $3?) }
+      Factor 'PLUS' Expr { Ok($1? + $3?) }
     | Factor { $1 }
     ;
 
 Factor -> Result<u64, ()>:
+      Term 'MUL' Factor { Ok($1? * $3?) }
+    | Term { $1 }
+    ;
+
+Term -> Result<u64, ()>:
       'LBRACK' Expr 'RBRACK' { $2 }
     | 'INT' { parse_int($lexer.span_str($1.map_err(|_| ())?.span())) }
     ;
@@ -194,7 +194,7 @@ The basic idea here is that every action returns an instance of `Result<u64,
 ()>`: if we receive `Ok(u64)` we successfully evaluated the expression, but if
 we received `Err(())` we were not able to evaluate the expression. If we
 encounter an integer lexeme which is the result of error recovery, then the
-`INT` lexeme in the second `Factor` action will be `Err(<lexeme>)`. By writing
+`INT` lexeme in the second `Term` action will be `Err(<lexeme>)`. By writing
 `$1.map_err(|_| ())?` we’re saying “if the integer lexeme was created by error
 recovery, percolate `Err(())` upwards”. We then have to tweak a couple of other
 actions to percolate errors upwards, but this is a trivial change.

--- a/doc/src/parsing_idioms.md
+++ b/doc/src/parsing_idioms.md
@@ -143,24 +143,24 @@ possible sources of error:
 %avoid_insert "INT"
 %%
 Expr -> Result<u64, Box<dyn Error>>:
-      Term '+' Expr
+      Factor '+' Expr
       {
           Ok($1?.checked_add($3?)
-              .ok_or(Box::<dyn Error>::from("Overflow detected."))?)
-      }
-    | Term { $1 }
-    ;
-
-Term -> Result<u64, Box<dyn Error>>:
-      Factor '*' Term
-      {
-          Ok($1?.checked_mul($3?)
               .ok_or(Box::<dyn Error>::from("Overflow detected."))?)
       }
     | Factor { $1 }
     ;
 
 Factor -> Result<u64, Box<dyn Error>>:
+      Term '*' Factor
+      {
+          Ok($1?.checked_mul($3?)
+              .ok_or(Box::<dyn Error>::from("Overflow detected."))?)
+      }
+    | Term { $1 }
+    ;
+
+Term -> Result<u64, Box<dyn Error>>:
       '(' Expr ')' { $2 }
     | 'INT'
       {

--- a/doc/src/quickstart.md
+++ b/doc/src/quickstart.md
@@ -106,16 +106,16 @@ Our initial version of calc.y looks as follows:
 %start Expr
 %%
 Expr -> Result<u64, ()>:
-      Term 'PLUS' Expr { Ok($1? + $3?) }
-    | Term { $1 }
-    ;
-
-Term -> Result<u64, ()>:
-      Factor 'MUL' Term { Ok($1? * $3?) }
+      Factor 'PLUS' Expr { Ok($1? + $3?) }
     | Factor { $1 }
     ;
 
 Factor -> Result<u64, ()>:
+      Term 'MUL' Factor { Ok($1? * $3?) }
+    | Term { $1 }
+    ;
+
+Term -> Result<u64, ()>:
       'LBRACK' Expr 'RBRACK' { $2 }
     | 'INT'
       {
@@ -144,7 +144,7 @@ start rule (`%start Expr`).
 
 The second part is the [Yacc
 grammar](http://dinosaur.compilertools.net/yacc/index.html). It consists of 3
-rules (`Expr`, `Term`, and `Factor`) and 6 productions (2 for each rule,
+rules (`Expr`, `Factor`, and `Term`) and 6 productions (2 for each rule,
 separated by `|` characters). Because we are using the `Grmtools` Yacc variant,
 each rule has a Rust type associated with it (after `->`) which specifies the
 type that each production’s action must return. A production (sometimes called an “alternative”)

--- a/lrpar/cttests/src/calc_actiontype.test
+++ b/lrpar/cttests/src/calc_actiontype.test
@@ -5,15 +5,15 @@ grammar: |
     %actiontype Result<u64, ()>
     %avoid_insert 'INT'
     %%
-    Expr: Term '+' Expr { Ok($1? + $3?) }
-        | Term { $1 }
-        ;
-
-    Term: Factor '*' Term { Ok($1? * $3?) }
+    Expr: Factor '+' Expr { Ok($1? + $3?) }
         | Factor { $1 }
         ;
 
-    Factor: '(' Expr ')' { $2 }
+    Factor: Term '*' Factor { Ok($1? * $3?) }
+        | Term { $1 }
+        ;
+
+    Term: '(' Expr ')' { $2 }
           | 'INT' {
                 let l = $1.map_err(|_| ())?;
                 match $lexer.span_str(l.span()).parse::<u64>() {

--- a/lrpar/cttests/src/calc_multitypes.test
+++ b/lrpar/cttests/src/calc_multitypes.test
@@ -5,16 +5,16 @@ grammar: |
     %avoid_insert "INT"
     %%
     Expr -> Result<u64, ()>:
-          Term '+' Expr { Ok($1? + $3?) }
-        | Term { $1 }
-        ;
-
-    Term -> Result<u64, ()>:
-          Factor '*' Term { Ok($1? * $3?) }
+          Factor '+' Expr { Ok($1? + $3?) }
         | Factor { $1 }
         ;
 
     Factor -> Result<u64, ()>:
+          Term '*' Factor { Ok($1? * $3?) }
+        | Term { $1 }
+        ;
+
+    Term -> Result<u64, ()>:
           '(' Expr ')' { $2 }
         | 'INT'
           {

--- a/lrpar/cttests/src/calc_noactions.test
+++ b/lrpar/cttests/src/calc_noactions.test
@@ -4,15 +4,15 @@ grammar: |
     %start Expr
     %avoid_insert 'INT'
     %%
-    Expr: Term '+' Expr
-        | Term
-        ;
-
-    Term: Factor '*' Term
+    Expr: Factor '+' Expr
         | Factor
         ;
 
-    Factor: '(' Expr ')'
+    Factor: Term '*' Factor
+        | Term
+        ;
+
+    Term: '(' Expr ')'
           | 'INT'
           ;
 

--- a/lrpar/cttests/src/span.test
+++ b/lrpar/cttests/src/span.test
@@ -5,21 +5,7 @@ grammar: |
     %avoid_insert "INT"
     %%
     Expr -> Vec<::lrpar::Span>:
-          Term '+' Expr {
-              let mut spans = $1;
-              spans.extend($3);
-              spans.push($span);
-              spans
-          }
-        | Term {
-              let mut spans = $1;
-              spans.push($span);
-              spans
-          }
-        ;
-
-    Term -> Vec<::lrpar::Span>:
-          Factor '*' Term {
+          Factor '+' Expr {
               let mut spans = $1;
               spans.extend($3);
               spans.push($span);
@@ -33,6 +19,20 @@ grammar: |
         ;
 
     Factor -> Vec<::lrpar::Span>:
+          Term '*' Factor {
+              let mut spans = $1;
+              spans.extend($3);
+              spans.push($span);
+              spans
+          }
+        | Term {
+              let mut spans = $1;
+              spans.push($span);
+              spans
+          }
+        ;
+
+    Term -> Vec<::lrpar::Span>:
           '(' Expr ')' {
               let mut spans = $2;
               spans.push($span);

--- a/lrpar/examples/calc_actions/Cargo.toml
+++ b/lrpar/examples/calc_actions/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "actions"
+name = "calc_actions"
 version = "0.1.0"
 authors = ["Laurence Tratt <http://tratt.net/laurie/>"]
 edition = "2018"
@@ -7,7 +7,7 @@ license = "Apache-2.0/MIT"
 
 [[bin]]
 doc = false
-name = "actions"
+name = "calc_actions"
 
 [build-dependencies]
 cfgrammar = { path="../../../cfgrammar" }

--- a/lrpar/examples/calc_actions/src/calc.y
+++ b/lrpar/examples/calc_actions/src/calc.y
@@ -2,20 +2,20 @@
 %avoid_insert "INT"
 %%
 Expr -> Result<u64, Box<dyn Error>>:
-      Term '+' Expr { Ok($1?.checked_add($3?)
+      Factor '+' Expr { Ok($1?.checked_add($3?)
                             .ok_or_else(|| Box::<dyn Error>::from("Overflow detected."))?)
                     }
-    | Term { $1 }
-    ;
-
-Term -> Result<u64, Box<dyn Error>>:
-      Factor '*' Term { Ok($1?.checked_mul($3?)
-                              .ok_or_else(|| Box::<dyn Error>::from("Overflow detected."))?)
-                      }
     | Factor { $1 }
     ;
 
 Factor -> Result<u64, Box<dyn Error>>:
+      Term '*' Factor { Ok($1?.checked_mul($3?)
+                              .ok_or_else(|| Box::<dyn Error>::from("Overflow detected."))?)
+                      }
+    | Term { $1 }
+    ;
+
+Term -> Result<u64, Box<dyn Error>>:
       '(' Expr ')' { $2 }
     | 'INT'
       {

--- a/lrpar/examples/calc_ast/src/calc.y
+++ b/lrpar/examples/calc_ast/src/calc.y
@@ -2,16 +2,16 @@
 %avoid_insert "INT"
 %%
 Expr -> Result<Expr, ()>:
-      Term '+' Expr { Ok(Expr::Add{ span: $span, lhs: Box::new($1?), rhs: Box::new($3?) }) }
-    | Term { $1 }
-    ;
-
-Term -> Result<Expr, ()>:
-      Factor '*' Term { Ok(Expr::Mul{ span: $span, lhs: Box::new($1?), rhs: Box::new($3?) }) }
+      Factor '+' Expr { Ok(Expr::Add{ span: $span, lhs: Box::new($1?), rhs: Box::new($3?) }) }
     | Factor { $1 }
     ;
 
 Factor -> Result<Expr, ()>:
+      Term '*' Factor { Ok(Expr::Mul{ span: $span, lhs: Box::new($1?), rhs: Box::new($3?) }) }
+    | Term { $1 }
+    ;
+
+Term -> Result<Expr, ()>:
       '(' Expr ')' { $2 }
     | 'INT' { Ok(Expr::Number{ span: $span }) }
     ;

--- a/lrpar/examples/calc_parsetree/Cargo.toml
+++ b/lrpar/examples/calc_parsetree/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "calcparse"
+name = "calc_parsetree"
 version = "0.1.0"
 authors = ["Laurence Tratt <http://tratt.net/laurie/>"]
 edition = "2018"
@@ -7,7 +7,7 @@ license = "Apache-2.0/MIT"
 
 [[bin]]
 doc = false
-name = "calcparse"
+name = "calc_parsetree"
 
 [build-dependencies]
 cfgrammar = { path="../../../cfgrammar" }

--- a/lrpar/examples/calc_parsetree/src/calc.y
+++ b/lrpar/examples/calc_parsetree/src/calc.y
@@ -1,11 +1,11 @@
 %start Expr
 %avoid_insert "INT"
 %%
-Expr: Term 'PLUS' Expr
-    | Term ;
-
-Term: Factor 'MUL' Term
+Expr: Factor 'PLUS' Expr
     | Factor ;
 
-Factor: 'LBRACK' Expr 'RBRACK'
+Factor: Term 'MUL' Factor
+    | Term ;
+
+Term: 'LBRACK' Expr 'RBRACK'
       | 'INT';

--- a/lrpar/examples/calc_parsetree/src/main.rs
+++ b/lrpar/examples/calc_parsetree/src/main.rs
@@ -65,7 +65,7 @@ impl<'a> Eval<'a> {
             Node::Nonterm {
                 ridx: RIdx(ridx),
                 ref nodes,
-            } if ridx == calc_y::R_TERM => {
+            } if ridx == calc_y::R_FACTOR => {
                 if nodes.len() == 1 {
                     self.eval(&nodes[0])
                 } else {
@@ -76,7 +76,7 @@ impl<'a> Eval<'a> {
             Node::Nonterm {
                 ridx: RIdx(ridx),
                 ref nodes,
-            } if ridx == calc_y::R_FACTOR => {
+            } if ridx == calc_y::R_TERM => {
                 if nodes.len() == 1 {
                     if let Node::Term { lexeme } = nodes[0] {
                         self.s[lexeme.span().start()..lexeme.span().end()]


### PR DESCRIPTION
Copy and paste, and a lack of thought, are dangerous bedfellows. As soon as I thought about what "factor" and "term" mean, I realised that we've got them the wrong way around! ["Factor" are the things either side of "*"; "Term" is "terminal".] Mea culpa!