### PR TITLE
Terms and factors

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ And where the definitions for the parser can be found in `src/calc.y`:
 %avoid_insert "INT"
 %%
 Expr -> Result<u64, ()>:
-      Term '+' Expr { Ok($1? + $3?) }
+      Expr '+' Term { Ok($1? + $3?) }
     | Term { $1 }
     ;
 
 Term -> Result<u64, ()>:
-      Factor '*' Term { Ok($1? * $3?) }
+      Term '*' Factor { Ok($1? * $3?) }
     | Factor { $1 }
     ;
 

--- a/doc/src/ast_example.md
+++ b/doc/src/ast_example.md
@@ -15,16 +15,16 @@ guide](quickstart.md). However the `calc.y` file is change as follows:
 %avoid_insert "INT"
 %%
 Expr -> Result<Expr, ()>:
-      Factor '+' Expr { Ok(Expr::Add{ span: $span, lhs: Box::new($1?), rhs: Box::new($3?) }) }
-    | Factor { $1 }
-    ;
-
-Factor -> Result<Expr, ()>:
-      Term '*' Factor { Ok(Expr::Mul{ span: $span, lhs: Box::new($1?), rhs: Box::new($3?) }) }
+      Term '+' Expr { Ok(Expr::Add{ span: $span, lhs: Box::new($1?), rhs: Box::new($3?) }) }
     | Term { $1 }
     ;
 
 Term -> Result<Expr, ()>:
+      Factor '*' Term { Ok(Expr::Mul{ span: $span, lhs: Box::new($1?), rhs: Box::new($3?) }) }
+    | Factor { $1 }
+    ;
+
+Factor -> Result<Expr, ()>:
       '(' Expr ')' { $2 }
     | 'INT' { Ok(Expr::Number{ span: $span }) }
     ;

--- a/doc/src/ast_example.md
+++ b/doc/src/ast_example.md
@@ -15,12 +15,12 @@ guide](quickstart.md). However the `calc.y` file is change as follows:
 %avoid_insert "INT"
 %%
 Expr -> Result<Expr, ()>:
-      Term '+' Expr { Ok(Expr::Add{ span: $span, lhs: Box::new($1?), rhs: Box::new($3?) }) }
+      Expr '+' Term { Ok(Expr::Add{ span: $span, lhs: Box::new($1?), rhs: Box::new($3?) }) }
     | Term { $1 }
     ;
 
 Term -> Result<Expr, ()>:
-      Factor '*' Term { Ok(Expr::Mul{ span: $span, lhs: Box::new($1?), rhs: Box::new($3?) }) }
+      Term '*' Factor { Ok(Expr::Mul{ span: $span, lhs: Box::new($1?), rhs: Box::new($3?) }) }
     | Factor { $1 }
     ;
 

--- a/doc/src/errorrecovery.md
+++ b/doc/src/errorrecovery.md
@@ -52,12 +52,12 @@ A simple calculator grammar looks as follows:
 %start Expr
 %%
 Expr -> u64:
-      Term 'PLUS' Expr { $1 + $3 }
+      Expr 'PLUS' Term { $1 + $3 }
     | Term { $1 }
     ;
 
 Term -> u64:
-      Factor 'MUL' Term { $1 * $3 }
+      Term 'MUL' Factor { $1 * $3 }
     | Factor { $1 }
     ;
 
@@ -166,12 +166,12 @@ occurring:
 %start Expr
 %%
 Expr -> Result<u64, ()>:
-      Term 'PLUS' Expr { Ok($1? + $3?) }
+      Expr 'PLUS' Term { Ok($1? + $3?) }
     | Term { $1 }
     ;
 
 Term -> Result<u64, ()>:
-      Factor 'MUL' Term { Ok($1? * $3?) }
+      Term 'MUL' Factor { Ok($1? * $3?) }
     | Factor { $1 }
     ;
 

--- a/doc/src/errorrecovery.md
+++ b/doc/src/errorrecovery.md
@@ -52,16 +52,16 @@ A simple calculator grammar looks as follows:
 %start Expr
 %%
 Expr -> u64:
-      Factor 'PLUS' Expr { $1 + $3 }
-    | Factor { $1 }
-    ;
-
-Factor -> u64:
-      Term 'MUL' Factor { $1 * $3 }
+      Term 'PLUS' Expr { $1 + $3 }
     | Term { $1 }
     ;
 
 Term -> u64:
+      Factor 'MUL' Term { $1 * $3 }
+    | Factor { $1 }
+    ;
+
+Factor -> u64:
       'LBRACK' Expr 'RBRACK' { $2 }
     | 'INT' { parse_int($lexer.span_str($1.unwrap().unwrap())) }
     ;
@@ -166,16 +166,16 @@ occurring:
 %start Expr
 %%
 Expr -> Result<u64, ()>:
-      Factor 'PLUS' Expr { Ok($1? + $3?) }
-    | Factor { $1 }
-    ;
-
-Factor -> Result<u64, ()>:
-      Term 'MUL' Factor { Ok($1? * $3?) }
+      Term 'PLUS' Expr { Ok($1? + $3?) }
     | Term { $1 }
     ;
 
 Term -> Result<u64, ()>:
+      Factor 'MUL' Term { Ok($1? * $3?) }
+    | Factor { $1 }
+    ;
+
+Factor -> Result<u64, ()>:
       'LBRACK' Expr 'RBRACK' { $2 }
     | 'INT' { parse_int($lexer.span_str($1.map_err(|_| ())?.span())) }
     ;
@@ -194,7 +194,7 @@ The basic idea here is that every action returns an instance of `Result<u64,
 ()>`: if we receive `Ok(u64)` we successfully evaluated the expression, but if
 we received `Err(())` we were not able to evaluate the expression. If we
 encounter an integer lexeme which is the result of error recovery, then the
-`INT` lexeme in the second `Term` action will be `Err(<lexeme>)`. By writing
+`INT` lexeme in the second `Factor` action will be `Err(<lexeme>)`. By writing
 `$1.map_err(|_| ())?` we’re saying “if the integer lexeme was created by error
 recovery, percolate `Err(())` upwards”. We then have to tweak a couple of other
 actions to percolate errors upwards, but this is a trivial change.

--- a/doc/src/parsing_idioms.md
+++ b/doc/src/parsing_idioms.md
@@ -143,24 +143,24 @@ possible sources of error:
 %avoid_insert "INT"
 %%
 Expr -> Result<u64, Box<dyn Error>>:
-      Factor '+' Expr
+      Term '+' Expr
       {
           Ok($1?.checked_add($3?)
-              .ok_or(Box::<dyn Error>::from("Overflow detected."))?)
-      }
-    | Factor { $1 }
-    ;
-
-Factor -> Result<u64, Box<dyn Error>>:
-      Term '*' Factor
-      {
-          Ok($1?.checked_mul($3?)
               .ok_or(Box::<dyn Error>::from("Overflow detected."))?)
       }
     | Term { $1 }
     ;
 
 Term -> Result<u64, Box<dyn Error>>:
+      Factor '*' Term
+      {
+          Ok($1?.checked_mul($3?)
+              .ok_or(Box::<dyn Error>::from("Overflow detected."))?)
+      }
+    | Factor { $1 }
+    ;
+
+Factor -> Result<u64, Box<dyn Error>>:
       '(' Expr ')' { $2 }
     | 'INT'
       {

--- a/doc/src/parsing_idioms.md
+++ b/doc/src/parsing_idioms.md
@@ -143,7 +143,7 @@ possible sources of error:
 %avoid_insert "INT"
 %%
 Expr -> Result<u64, Box<dyn Error>>:
-      Term '+' Expr
+      Expr '+' Term
       {
           Ok($1?.checked_add($3?)
               .ok_or(Box::<dyn Error>::from("Overflow detected."))?)
@@ -152,7 +152,7 @@ Expr -> Result<u64, Box<dyn Error>>:
     ;
 
 Term -> Result<u64, Box<dyn Error>>:
-      Factor '*' Term
+      Term '*' Factor
       {
           Ok($1?.checked_mul($3?)
               .ok_or(Box::<dyn Error>::from("Overflow detected."))?)

--- a/doc/src/quickstart.md
+++ b/doc/src/quickstart.md
@@ -106,16 +106,16 @@ Our initial version of calc.y looks as follows:
 %start Expr
 %%
 Expr -> Result<u64, ()>:
-      Factor 'PLUS' Expr { Ok($1? + $3?) }
-    | Factor { $1 }
-    ;
-
-Factor -> Result<u64, ()>:
-      Term 'MUL' Factor { Ok($1? * $3?) }
+      Term 'PLUS' Expr { Ok($1? + $3?) }
     | Term { $1 }
     ;
 
 Term -> Result<u64, ()>:
+      Factor 'MUL' Term { Ok($1? * $3?) }
+    | Factor { $1 }
+    ;
+
+Factor -> Result<u64, ()>:
       'LBRACK' Expr 'RBRACK' { $2 }
     | 'INT'
       {
@@ -144,7 +144,7 @@ start rule (`%start Expr`).
 
 The second part is the [Yacc
 grammar](http://dinosaur.compilertools.net/yacc/index.html). It consists of 3
-rules (`Expr`, `Factor`, and `Term`) and 6 productions (2 for each rule,
+rules (`Expr`, `Term`, and `Factor`) and 6 productions (2 for each rule,
 separated by `|` characters). Because we are using the `Grmtools` Yacc variant,
 each rule has a Rust type associated with it (after `->`) which specifies the
 type that each production’s action must return. A production (sometimes called an “alternative”)

--- a/doc/src/quickstart.md
+++ b/doc/src/quickstart.md
@@ -106,12 +106,12 @@ Our initial version of calc.y looks as follows:
 %start Expr
 %%
 Expr -> Result<u64, ()>:
-      Term 'PLUS' Expr { Ok($1? + $3?) }
+      Expr 'PLUS' Term { Ok($1? + $3?) }
     | Term { $1 }
     ;
 
 Term -> Result<u64, ()>:
-      Factor 'MUL' Term { Ok($1? * $3?) }
+      Term 'MUL' Factor { Ok($1? * $3?) }
     | Factor { $1 }
     ;
 

--- a/lrpar/README.md
+++ b/lrpar/README.md
@@ -51,12 +51,12 @@ and `src/calc.y` is as follows:
 %avoid_insert "INT"
 %%
 Expr -> Result<u64, ()>:
-      Term '+' Expr { Ok($1? + $3?) }
+      Expr '+' Term { Ok($1? + $3?) }
     | Term { $1 }
     ;
 
 Term -> Result<u64, ()>:
-      Factor '*' Term { Ok($1? * $3?) }
+      Term '*' Factor { Ok($1? * $3?) }
     | Factor { $1 }
     ;
 

--- a/lrpar/cttests/src/calc_actiontype.test
+++ b/lrpar/cttests/src/calc_actiontype.test
@@ -5,15 +5,15 @@ grammar: |
     %actiontype Result<u64, ()>
     %avoid_insert 'INT'
     %%
-    Expr: Factor '+' Expr { Ok($1? + $3?) }
-        | Factor { $1 }
-        ;
-
-    Factor: Term '*' Factor { Ok($1? * $3?) }
+    Expr: Term '+' Expr { Ok($1? + $3?) }
         | Term { $1 }
         ;
 
-    Term: '(' Expr ')' { $2 }
+    Term: Factor '*' Term { Ok($1? * $3?) }
+        | Factor { $1 }
+        ;
+
+    Factor: '(' Expr ')' { $2 }
           | 'INT' {
                 let l = $1.map_err(|_| ())?;
                 match $lexer.span_str(l.span()).parse::<u64>() {

--- a/lrpar/cttests/src/calc_actiontype.test
+++ b/lrpar/cttests/src/calc_actiontype.test
@@ -5,11 +5,11 @@ grammar: |
     %actiontype Result<u64, ()>
     %avoid_insert 'INT'
     %%
-    Expr: Term '+' Expr { Ok($1? + $3?) }
+    Expr: Expr '+' Term { Ok($1? + $3?) }
         | Term { $1 }
         ;
 
-    Term: Factor '*' Term { Ok($1? * $3?) }
+    Term: Term '*' Factor { Ok($1? * $3?) }
         | Factor { $1 }
         ;
 

--- a/lrpar/cttests/src/calc_multitypes.test
+++ b/lrpar/cttests/src/calc_multitypes.test
@@ -5,12 +5,12 @@ grammar: |
     %avoid_insert "INT"
     %%
     Expr -> Result<u64, ()>:
-          Term '+' Expr { Ok($1? + $3?) }
+          Expr '+' Term { Ok($1? + $3?) }
         | Term { $1 }
         ;
 
     Term -> Result<u64, ()>:
-          Factor '*' Term { Ok($1? * $3?) }
+          Term '*' Factor { Ok($1? * $3?) }
         | Factor { $1 }
         ;
 

--- a/lrpar/cttests/src/calc_multitypes.test
+++ b/lrpar/cttests/src/calc_multitypes.test
@@ -5,16 +5,16 @@ grammar: |
     %avoid_insert "INT"
     %%
     Expr -> Result<u64, ()>:
-          Factor '+' Expr { Ok($1? + $3?) }
-        | Factor { $1 }
-        ;
-
-    Factor -> Result<u64, ()>:
-          Term '*' Factor { Ok($1? * $3?) }
+          Term '+' Expr { Ok($1? + $3?) }
         | Term { $1 }
         ;
 
     Term -> Result<u64, ()>:
+          Factor '*' Term { Ok($1? * $3?) }
+        | Factor { $1 }
+        ;
+
+    Factor -> Result<u64, ()>:
           '(' Expr ')' { $2 }
         | 'INT'
           {

--- a/lrpar/cttests/src/calc_noactions.test
+++ b/lrpar/cttests/src/calc_noactions.test
@@ -4,11 +4,11 @@ grammar: |
     %start Expr
     %avoid_insert 'INT'
     %%
-    Expr: Term '+' Expr
+    Expr: Expr '+' Term
         | Term
         ;
 
-    Term: Factor '*' Term
+    Term: Term '*' Factor
         | Factor
         ;
 

--- a/lrpar/cttests/src/calc_noactions.test
+++ b/lrpar/cttests/src/calc_noactions.test
@@ -4,15 +4,15 @@ grammar: |
     %start Expr
     %avoid_insert 'INT'
     %%
-    Expr: Factor '+' Expr
-        | Factor
-        ;
-
-    Factor: Term '*' Factor
+    Expr: Term '+' Expr
         | Term
         ;
 
-    Term: '(' Expr ')'
+    Term: Factor '*' Term
+        | Factor
+        ;
+
+    Factor: '(' Expr ')'
           | 'INT'
           ;
 

--- a/lrpar/cttests/src/lib.rs
+++ b/lrpar/cttests/src/lib.rs
@@ -141,7 +141,7 @@ fn test_span() {
                 == &vec![
                     Span::new(0, 1),
                     Span::new(0, 1),
-                    Span::new(2, 3),
+                    Span::new(0, 1),
                     Span::new(2, 3),
                     Span::new(2, 3),
                     Span::new(0, 3),
@@ -159,7 +159,7 @@ fn test_span() {
                 == &vec![
                     Span::new(0, 1),
                     Span::new(0, 1),
-                    Span::new(4, 5),
+                    Span::new(0, 1),
                     Span::new(4, 5),
                     Span::new(4, 5),
                     Span::new(0, 5),
@@ -177,10 +177,10 @@ fn test_span() {
                 == &vec![
                     Span::new(0, 1),
                     Span::new(0, 1),
+                    Span::new(0, 1),
+                    Span::new(2, 3),
                     Span::new(2, 3),
                     Span::new(4, 5),
-                    Span::new(4, 5),
-                    Span::new(2, 5),
                     Span::new(2, 5),
                     Span::new(0, 5),
                 ] =>
@@ -197,7 +197,7 @@ fn test_span() {
                 == &vec![
                     Span::new(0, 1),
                     Span::new(0, 1),
-                    Span::new(3, 4),
+                    Span::new(0, 1),
                     Span::new(3, 4),
                     Span::new(3, 4),
                     Span::new(0, 4),
@@ -209,7 +209,7 @@ fn test_span() {
     }
 
     let lexer = lexerdef.lexer("(2)))");
-    match span_y::parse(&lexer) {
+    match dbg!(span_y::parse(&lexer)) {
         (Some(ref spans), _)
             if spans
                 == &vec![

--- a/lrpar/cttests/src/span.test
+++ b/lrpar/cttests/src/span.test
@@ -5,7 +5,7 @@ grammar: |
     %avoid_insert "INT"
     %%
     Expr -> Vec<::lrpar::Span>:
-          Term '+' Expr {
+          Expr '+' Term {
               let mut spans = $1;
               spans.extend($3);
               spans.push($span);
@@ -19,7 +19,7 @@ grammar: |
         ;
 
     Term -> Vec<::lrpar::Span>:
-          Factor '*' Term {
+          Term '*' Factor {
               let mut spans = $1;
               spans.extend($3);
               spans.push($span);

--- a/lrpar/cttests/src/span.test
+++ b/lrpar/cttests/src/span.test
@@ -5,21 +5,7 @@ grammar: |
     %avoid_insert "INT"
     %%
     Expr -> Vec<::lrpar::Span>:
-          Factor '+' Expr {
-              let mut spans = $1;
-              spans.extend($3);
-              spans.push($span);
-              spans
-          }
-        | Factor {
-              let mut spans = $1;
-              spans.push($span);
-              spans
-          }
-        ;
-
-    Factor -> Vec<::lrpar::Span>:
-          Term '*' Factor {
+          Term '+' Expr {
               let mut spans = $1;
               spans.extend($3);
               spans.push($span);
@@ -33,6 +19,20 @@ grammar: |
         ;
 
     Term -> Vec<::lrpar::Span>:
+          Factor '*' Term {
+              let mut spans = $1;
+              spans.extend($3);
+              spans.push($span);
+              spans
+          }
+        | Factor {
+              let mut spans = $1;
+              spans.push($span);
+              spans
+          }
+        ;
+
+    Factor -> Vec<::lrpar::Span>:
           '(' Expr ')' {
               let mut spans = $2;
               spans.push($span);

--- a/lrpar/examples/calc_actions/src/calc.y
+++ b/lrpar/examples/calc_actions/src/calc.y
@@ -2,20 +2,20 @@
 %avoid_insert "INT"
 %%
 Expr -> Result<u64, Box<dyn Error>>:
-      Factor '+' Expr { Ok($1?.checked_add($3?)
+      Term '+' Expr { Ok($1?.checked_add($3?)
                             .ok_or_else(|| Box::<dyn Error>::from("Overflow detected."))?)
                     }
-    | Factor { $1 }
-    ;
-
-Factor -> Result<u64, Box<dyn Error>>:
-      Term '*' Factor { Ok($1?.checked_mul($3?)
-                              .ok_or_else(|| Box::<dyn Error>::from("Overflow detected."))?)
-                      }
     | Term { $1 }
     ;
 
 Term -> Result<u64, Box<dyn Error>>:
+      Factor '*' Term { Ok($1?.checked_mul($3?)
+                              .ok_or_else(|| Box::<dyn Error>::from("Overflow detected."))?)
+                      }
+    | Factor { $1 }
+    ;
+
+Factor -> Result<u64, Box<dyn Error>>:
       '(' Expr ')' { $2 }
     | 'INT'
       {

--- a/lrpar/examples/calc_actions/src/calc.y
+++ b/lrpar/examples/calc_actions/src/calc.y
@@ -2,14 +2,14 @@
 %avoid_insert "INT"
 %%
 Expr -> Result<u64, Box<dyn Error>>:
-      Term '+' Expr { Ok($1?.checked_add($3?)
+      Expr '+' Term { Ok($1?.checked_add($3?)
                             .ok_or_else(|| Box::<dyn Error>::from("Overflow detected."))?)
                     }
     | Term { $1 }
     ;
 
 Term -> Result<u64, Box<dyn Error>>:
-      Factor '*' Term { Ok($1?.checked_mul($3?)
+      Term '*' Factor { Ok($1?.checked_mul($3?)
                               .ok_or_else(|| Box::<dyn Error>::from("Overflow detected."))?)
                       }
     | Factor { $1 }

--- a/lrpar/examples/calc_ast/src/calc.y
+++ b/lrpar/examples/calc_ast/src/calc.y
@@ -2,16 +2,16 @@
 %avoid_insert "INT"
 %%
 Expr -> Result<Expr, ()>:
-      Factor '+' Expr { Ok(Expr::Add{ span: $span, lhs: Box::new($1?), rhs: Box::new($3?) }) }
-    | Factor { $1 }
-    ;
-
-Factor -> Result<Expr, ()>:
-      Term '*' Factor { Ok(Expr::Mul{ span: $span, lhs: Box::new($1?), rhs: Box::new($3?) }) }
+      Term '+' Expr { Ok(Expr::Add{ span: $span, lhs: Box::new($1?), rhs: Box::new($3?) }) }
     | Term { $1 }
     ;
 
 Term -> Result<Expr, ()>:
+      Factor '*' Term { Ok(Expr::Mul{ span: $span, lhs: Box::new($1?), rhs: Box::new($3?) }) }
+    | Factor { $1 }
+    ;
+
+Factor -> Result<Expr, ()>:
       '(' Expr ')' { $2 }
     | 'INT' { Ok(Expr::Number{ span: $span }) }
     ;

--- a/lrpar/examples/calc_ast/src/calc.y
+++ b/lrpar/examples/calc_ast/src/calc.y
@@ -2,12 +2,12 @@
 %avoid_insert "INT"
 %%
 Expr -> Result<Expr, ()>:
-      Term '+' Expr { Ok(Expr::Add{ span: $span, lhs: Box::new($1?), rhs: Box::new($3?) }) }
+      Expr '+' Term { Ok(Expr::Add{ span: $span, lhs: Box::new($1?), rhs: Box::new($3?) }) }
     | Term { $1 }
     ;
 
 Term -> Result<Expr, ()>:
-      Factor '*' Term { Ok(Expr::Mul{ span: $span, lhs: Box::new($1?), rhs: Box::new($3?) }) }
+      Term '*' Factor { Ok(Expr::Mul{ span: $span, lhs: Box::new($1?), rhs: Box::new($3?) }) }
     | Factor { $1 }
     ;
 

--- a/lrpar/examples/calc_parsetree/src/calc.y
+++ b/lrpar/examples/calc_parsetree/src/calc.y
@@ -1,10 +1,10 @@
 %start Expr
 %avoid_insert "INT"
 %%
-Expr: Term 'PLUS' Expr
+Expr: Expr 'PLUS' Term
     | Term ;
 
-Term: Factor 'MUL' Term
+Term: Term 'MUL' Factor
     | Factor ;
 
 Factor: 'LBRACK' Expr 'RBRACK'

--- a/lrpar/examples/calc_parsetree/src/calc.y
+++ b/lrpar/examples/calc_parsetree/src/calc.y
@@ -1,11 +1,11 @@
 %start Expr
 %avoid_insert "INT"
 %%
-Expr: Factor 'PLUS' Expr
-    | Factor ;
-
-Factor: Term 'MUL' Factor
+Expr: Term 'PLUS' Expr
     | Term ;
 
-Term: 'LBRACK' Expr 'RBRACK'
+Term: Factor 'MUL' Term
+    | Factor ;
+
+Factor: 'LBRACK' Expr 'RBRACK'
       | 'INT';

--- a/lrpar/examples/calc_parsetree/src/main.rs
+++ b/lrpar/examples/calc_parsetree/src/main.rs
@@ -65,7 +65,7 @@ impl<'a> Eval<'a> {
             Node::Nonterm {
                 ridx: RIdx(ridx),
                 ref nodes,
-            } if ridx == calc_y::R_FACTOR => {
+            } if ridx == calc_y::R_TERM => {
                 if nodes.len() == 1 {
                     self.eval(&nodes[0])
                 } else {
@@ -76,7 +76,7 @@ impl<'a> Eval<'a> {
             Node::Nonterm {
                 ridx: RIdx(ridx),
                 ref nodes,
-            } if ridx == calc_y::R_TERM => {
+            } if ridx == calc_y::R_FACTOR => {
                 if nodes.len() == 1 {
                     if let Node::Term { lexeme } = nodes[0] {
                         self.s[lexeme.span().start()..lexeme.span().end()]

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -57,12 +57,12 @@
 //! %avoid_insert "INT"
 //! %%
 //! Expr -> Result<u64, ()>:
-//!       Term '+' Expr { Ok($1? + $3?) }
+//!       Expr '+' Term { Ok($1? + $3?) }
 //!     | Term { $1 }
 //!     ;
 //!
 //! Term -> Result<u64, ()>:
-//!       Factor '*' Term { Ok($1? * $3?) }
+//!       Term '*' Factor { Ok($1? * $3?) }
 //!     | Factor { $1 }
 //!     ;
 //!

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -1019,8 +1019,8 @@ L: 'ID'
                     [0-9]+ 'INT'";
         let grms = "%start Expr
 %%
-Expr : Term '+' Expr | Term;
-Term : Factor '*' Term | Factor;
+Expr : Expr '+' Term | Term;
+Term : Term '*' Factor | Factor;
 Factor : 'INT';";
 
         check_parse_output(
@@ -1028,18 +1028,18 @@ Factor : 'INT';";
             &grms,
             "2+3*4",
             "Expr
- Term
-  Factor
-   INT 2
- + +
  Expr
   Term
    Factor
+    INT 2
+ + +
+ Term
+  Term
+   Factor
     INT 3
-   * *
-   Term
-    Factor
-     INT 4
+  * *
+  Factor
+   INT 4
 ",
         );
         check_parse_output(
@@ -1047,18 +1047,18 @@ Factor : 'INT';";
             &grms,
             "2*3+4",
             "Expr
- Term
-  Factor
-   INT 2
-  * *
+ Expr
   Term
+   Term
+    Factor
+     INT 2
+   * *
    Factor
     INT 3
  + +
- Expr
-  Term
-   Factor
-    INT 4
+ Term
+  Factor
+   INT 4
 ",
         );
     }


### PR DESCRIPTION
This PR first reverts the mistake I made in https://github.com/softdevteam/grmtools/pull/206: `Factor` and `Term` do not mean what I temporarily thought they meant.

It then makes all but one instances of the expression grammar left associative (https://github.com/softdevteam/grmtools/commit/bb9fb0c92c4846b7e003175a7b02a7e832c96de9).

If ever a PR showed me to be a moron, it is this PR!