### PR TITLE
cfgrammar: initial parsing/syntax for the %parse_param.

### DIFF
--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -20,6 +20,8 @@ pub struct GrammarAST {
     pub precs: HashMap<String, Precedence>,
     pub avoid_insert: Option<HashSet<String>>,
     pub implicit_tokens: Option<HashSet<String>>,
+    pub parse_param_bindings: Option<Vec<(String, String)>>,
+    pub parse_param_lifetimes: Option<HashSet<String>>,
     // Error pretty-printers
     pub epp: HashMap<String, String>,
     pub programs: Option<String>,
@@ -118,6 +120,8 @@ impl GrammarAST {
             implicit_tokens: None,
             epp: HashMap::new(),
             programs: None,
+            parse_param_bindings: None,
+            parse_param_lifetimes: None,
         }
     }
 

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, collections::HashMap, error::Error, fmt};
+use std::{cell::RefCell, collections::HashMap, error::Error, fmt, iter::FromIterator};
 
 use num_traits::{self, AsPrimitive, PrimInt, Unsigned};
 #[cfg(feature = "serde")]
@@ -76,6 +76,10 @@ pub struct YaccGrammar<StorageT = u32> {
     implicit_rule: Option<RIdx<StorageT>>,
     /// User defined Rust programs which can be called within actions
     actions: Vec<Option<String>>,
+    /// Extra Parameters to the parse function, for user actions.
+    param_args: Vec<(String, String)>,
+    /// Lifetimes for `param_args`
+    param_lifetimes: Vec<String>,
     /// The programs section of a grammar, if specified; otherwise `None`.
     programs: Option<String>,
     /// The actiontypes of rules (one per rule).
@@ -335,6 +339,8 @@ where
             prod_precs: prod_precs.into_iter().map(Option::unwrap).collect(),
             implicit_rule: implicit_rule.map(|x| rule_map[&x]),
             actions,
+            param_args: Vec::from_iter(ast.parse_param_bindings.iter().flatten().cloned()),
+            param_lifetimes: Vec::from_iter(ast.parse_param_lifetimes.iter().flatten().cloned()),
             programs: ast.programs,
             avoid_insert,
             actiontypes,
@@ -473,6 +479,14 @@ where
 
     pub fn actiontype(&self, ridx: RIdx<StorageT>) -> &Option<String> {
         &self.actiontypes[usize::from(ridx)]
+    }
+
+    pub fn param_args(&self) -> &Vec<(String, String)> {
+        &self.param_args
+    }
+
+    pub fn param_lifetimes(&self) -> &Vec<String> {
+        &self.param_lifetimes
     }
 
     /// Get the programs part of the grammar

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -23,6 +23,7 @@ pub enum YaccParserErrorKind {
     IncompleteAction,
     MissingColon,
     MissingRightArrow,
+    MismatchedBrace,
     PrematureEnd,
     ProgramsNotSupported,
     UnknownDeclaration,
@@ -58,6 +59,7 @@ impl fmt::Display for YaccParserError {
             YaccParserErrorKind::IncompleteAction => "Incomplete action",
             YaccParserErrorKind::MissingColon => "Missing ':'",
             YaccParserErrorKind::MissingRightArrow => "Missing '->'",
+            YaccParserErrorKind::MismatchedBrace => "Mismatched brace",
             YaccParserErrorKind::PrematureEnd => "File ends prematurely",
             YaccParserErrorKind::ProgramsNotSupported => "Programs not currently supported",
             YaccParserErrorKind::UnknownDeclaration => "Unknown declaration",
@@ -194,6 +196,10 @@ impl YaccParser {
                     self.ast.avoid_insert.as_mut().unwrap().insert(n);
                     i = self.parse_ws(j, true)?;
                 }
+                continue;
+            }
+            if let Some(j) = self.lookahead_is("%parse_param", i) {
+                i = self.parse_param(j)?;
                 continue;
             }
             if let YaccKind::Eco = self.yacc_kind {
@@ -422,6 +428,95 @@ impl YaccParser {
         }
     }
 
+    // Handle parse_param declarations of the form:
+    // %parse_param <'a>(x: u32, y : (u32, u32))
+    fn parse_param(&mut self, mut i: usize) -> YaccResult<usize> {
+        i = self.parse_ws(i, false)?;
+        // First gobble up all of the '<' lifetime ',' ... '>
+        if let Some(mut j) = self.lookahead_is("<", i) {
+            let mut k = j;
+            let mut lifetimes = HashSet::new();
+            let mut add_lifetime = |j, k, c: char| {
+                let s = self.src[j..k].trim().to_string();
+                lifetimes.insert(s);
+                k + c.len_utf8()
+            };
+
+            while k < self.src.len() {
+                let c = self.src[k..].chars().next().unwrap();
+                match c {
+                    '\n' | '\r' => return Err(self.mk_error(YaccParserErrorKind::ReachedEOL, k)),
+                    ',' => {
+                        k = add_lifetime(j, k, ',');
+                        j = k;
+                    }
+                    '>' => {
+                        k = add_lifetime(j, k, '>');
+                        break;
+                    }
+                    _ => k += c.len_utf8(),
+                }
+            }
+            self.ast.parse_param_lifetimes = Some(lifetimes);
+            i = k;
+        }
+
+        // Next, the '(' pattern : type, ... ')'
+        i = self.parse_ws(i, false)?;
+        if self.lookahead_is("(", i).is_some() {
+            let mut j = i;
+            let mut bindings: Vec<(String, String)> = Vec::new();
+            while j < self.src.len() && self.lookahead_is(")", j).is_none() {
+                let c = self.src[j..].chars().next().unwrap();
+                j += c.len_utf8();
+
+                // Some binding name, or pattern.
+                j = self.parse_ws(j, false)?;
+                let (k, binding) = self.parse_to_single_colon(j)?;
+                let (k, typ) = self.parse_param_rust_type(k + ':'.len_utf8())?;
+                j = k;
+                bindings.push((binding.trim_end().to_string(), typ));
+            }
+            if !bindings.is_empty() {
+                self.ast.parse_param_bindings = Some(bindings);
+            }
+            i = j;
+        }
+        let (i, _) = self.parse_to_eol(i)?;
+        Ok(self.parse_ws(i, true)?)
+    }
+
+    // Parse a rust type, followed by either a ',' character or an unbalanced ')'
+    // Return the char indice of the trailing character,
+    fn parse_param_rust_type(&mut self, i: usize) -> YaccResult<(usize, String)> {
+        let i = self.parse_ws(i, false)?;
+        let mut j = i;
+        let mut brace_count = 0;
+
+        while j < self.src.len() {
+            let c = self.src[j..].chars().next().unwrap();
+            match c {
+                '\n' | '\r' => return Err(self.mk_error(YaccParserErrorKind::ReachedEOL, j)),
+                ')' | ',' if brace_count == 0 => {
+                    return Ok((j, self.src[i..j].trim_end().to_string()));
+                }
+                '(' | '{' | '[' | '<' => {
+                    brace_count += 1;
+                    j += c.len_utf8();
+                }
+                ')' | '}' | '>' | ']' => {
+                    if brace_count == 0 {
+                        return Err(self.mk_error(YaccParserErrorKind::MismatchedBrace, j));
+                    }
+                    brace_count -= 1;
+                    j += c.len_utf8();
+                }
+                c => j += c.len_utf8(),
+            }
+        }
+        Err(self.mk_error(YaccParserErrorKind::PrematureEnd, j))
+    }
+
     /// Parse up to (but do not include) the end of line (or, if it comes sooner, the end of file).
     fn parse_to_eol(&mut self, i: usize) -> YaccResult<(usize, String)> {
         let mut j = i;
@@ -619,6 +714,8 @@ impl YaccParser {
 
 #[cfg(test)]
 mod test {
+    use std::{collections::HashSet, iter::FromIterator};
+
     use super::{
         super::{
             ast::{GrammarAST, Production, Symbol},
@@ -1705,5 +1802,33 @@ x"
             }) => (),
             Err(e) => panic!("Incorrect error returned {}", e),
         }
+    }
+
+    #[test]
+    fn test_parse_param() {
+        let src = "
+          %parse_param <'a, 'b> (x: &'a (), (y, z) : (Result<((), ()), ((), ())>, ((u32, u32), &'b ())))
+          %%
+          A: 'a';
+         ";
+        let grm = parse(
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            &src,
+        )
+        .unwrap();
+
+        let expect_lifetimes = HashSet::from_iter([&"'a", &"'b"].iter().map(|s| s.to_string()));
+        let expect_bindings = [
+            ("x", "&'a ()"),
+            (
+                "(y, z)",
+                "(Result<((), ()), ((), ())>, ((u32, u32), &'b ()))",
+            ),
+        ]
+        .iter()
+        .map(|(v, t)| (v.to_string(), t.to_string()))
+        .collect::<Vec<(String, String)>>();
+        assert_eq!(grm.parse_param_lifetimes, Some(expect_lifetimes));
+        assert_eq!(grm.parse_param_bindings, Some(expect_bindings));
     }
 }


### PR DESCRIPTION
Here is the rebased branch from #214 which contains only the option parsing, and none of the implementation or tests which rely on the functitoning implementation.
As such it parses the `%parse_param` directive in the yacc grammar, but doesn't function to implement it.

The rebased versions of the implementation are [here](https://github.com/ratmice/grmtools/tree/parse_param), which builds off the commits in this PR, but still need work.
