### PR TITLE
It's hard to use the 'visibility' function with 'Visibility' being exported.

### DIFF
--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -18,7 +18,7 @@ mod lexer;
 mod parser;
 
 pub use crate::{
-    builder::{LexerBuilder, LexerKind},
+    builder::{LexerBuilder, LexerKind, Visibility},
     lexer::{LRNonStreamingLexer, LRNonStreamingLexerDef, LexerDef, Rule},
 };
 


### PR DESCRIPTION
Fixes https://github.com/softdevteam/grmtools/issues/222.