### PR TITLE
Make line_col faster.

### DIFF
--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -348,24 +348,29 @@ impl<'lexer, 'input: 'lexer, StorageT: Copy + Eq + Hash + PrimInt + Unsigned>
             );
         }
 
+        /// Returns `(line byte offset, line index)`.
         fn lc_byte<StorageT>(lexer: &LRNonStreamingLexer<StorageT>, i: usize) -> (usize, usize) {
             match lexer.newlines.binary_search(&i) {
-                Ok(j) => (j + 2, 0),
-                Err(0) => (1, i),
-                Err(j) => (j + 1, i - lexer.newlines[j - 1]),
+                Ok(j) => (lexer.newlines[j], j + 2),
+                Err(0) => (0, 1),
+                Err(j) if j == lexer.newlines.len() + 1 => (lexer.newlines[j - 1], j + 1),
+                Err(j) => (lexer.newlines[j - 1], j + 1),
             }
         }
 
         fn lc_char<StorageT: Copy + Eq + Hash + PrimInt + Unsigned>(
             lexer: &LRNonStreamingLexer<StorageT>,
             i: usize,
+            s: &str,
         ) -> (usize, usize) {
-            let (line_idx, col_byte) = lc_byte(lexer, i);
-            let line = lexer.span_lines_str(Span::new(i, i));
-            (line_idx, line[..col_byte].chars().count() + 1)
+            let (line_byte, line_idx) = lc_byte(lexer, i);
+            (line_idx, s[line_byte..i].chars().count() + 1)
         }
 
-        (lc_char(self, span.start()), lc_char(self, span.end()))
+        (
+            lc_char(self, span.start(), self.s),
+            lc_char(self, span.end(), self.s),
+        )
     }
 }
 


### PR DESCRIPTION
`line_col` was previously a linear search that called another function that does a linear search. This PR changes the first linear search into a binary search (https://github.com/softdevteam/grmtools/commit/b62cab260a9b0f4a69a9b50d30eb57b9a43348b6) and removes the second linear search entirely (https://github.com/softdevteam/grmtools/commit/2d61edb7b4e882ef4007b431facacb031c0065b4).

This speeds up the easy bits of `line_col` significantly, moving us from `O(4n + x)` into `O(log_n + x)` where `n` is the number of lines in the file and `x` is whatever the cost to calculate the character offset from a line containing a string of bytes. Alas, this second thing is probably impossible to speed-up given that we're dealing with UTF-8. Still, this PR does at least address the most obviously egregious inefficiencies in `line_col` and it does so while decreasing the lines of code (allowing for the fact that I've added three lines of comments)!