### PR TITLE
Suppress Clippy's "unnecessary wrap" warning.

### DIFF
--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::cognitive_complexity)]
 #![allow(clippy::many_single_char_names)]
 #![allow(clippy::new_without_default)]
+#![allow(clippy::unnecessary_wraps)]
 
 //! A library for manipulating Context Free Grammars (CFG). It is impractical to fully homogenise
 //! all the types of grammars out there, so the aim is for different grammar types

--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -7,6 +7,7 @@
 
 #![allow(clippy::new_without_default)]
 #![allow(clippy::type_complexity)]
+#![allow(clippy::unnecessary_wraps)]
 
 use std::{error::Error, fmt, hash::Hash};
 

--- a/lrpar/examples/calc_ast/src/main.rs
+++ b/lrpar/examples/calc_ast/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unnecessary_wraps)]
+
 use std::io::{self, BufRead, Write};
 
 use lrlex::lrlex_mod;

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -411,6 +411,7 @@ where
         ));
         outs.push_str(
             "    #![allow(clippy::type_complexity)]
+    #![allow(clippy::unnecessary_wraps)]
 ",
         );
 

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -5,6 +5,7 @@
 #![allow(clippy::range_plus_one)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::type_complexity)]
+#![allow(clippy::unnecessary_wraps)]
 
 //! `lrpar` provides a Yacc-compatible parser (where grammars can be generated at
 //! compile-time or run-time). It can take in traditional `.y` files and convert


### PR DESCRIPTION
This warning tells us to a) change code that is best off left as is b) warns about code that cannot be changed (i.e. the warning has false positives). See https://github.com/rust-lang/rust-clippy/issues/6613 for some more details.