### PR TITLE
Prepare a 0.10.0 release.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+# grmtools 0.10.0 (2021-03-29)
+
+## Breaking changes
+
+* A number of previously public items (functions, structs, struct attributes)
+  have been made private. Most of these were either not externally visible, or
+  only visible if accessed in undocumented ways, but some were incorrectly
+  public.
+
+
 # grmtools 0.9.3 (2021-01-28)
 
 * Optimise `NonStreamingLexer::line_col` from *O(n*) to *O(log n)* (where *n*

--- a/cfgrammar/Cargo.toml
+++ b/cfgrammar/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cfgrammar"
 description = "Grammar manipulation"
 repository = "https://github.com/softdevteam/grmtools"
-version = "0.9.3"
+version = "0.10.0"
 authors = ["Laurence Tratt <http://tratt.net/laurie/>"]
 edition = "2018"
 readme = "README.md"

--- a/doc/src/quickstart.md
+++ b/doc/src/quickstart.md
@@ -30,14 +30,14 @@ doc = false
 name = "calc"
 
 [build-dependencies]
-cfgrammar = "0.9"
-lrlex = "0.9"
-lrpar = "0.9"
+cfgrammar = "0.10"
+lrlex = "0.10"
+lrpar = "0.10"
 
 [dependencies]
-cfgrammar = "0.9"
-lrlex = "0.9"
-lrpar = "0.9"
+cfgrammar = "0.10"
+lrlex = "0.10"
+lrpar = "0.10"
 ```
 
 In this situation we want to statically compile the `.y` grammar and `.l` lexer

--- a/lrlex/Cargo.toml
+++ b/lrlex/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lrlex"
 description = "Simple lexer generator"
 repository = "https://github.com/softdevteam/grmtools"
-version = "0.9.3"
+version = "0.10.0"
 authors = ["Laurence Tratt <http://tratt.net/laurie/>"]
 edition = "2018"
 readme = "README.md"
@@ -20,7 +20,7 @@ path = "src/lib/mod.rs"
 [dependencies]
 getopts = "0.2" # only needed for src/main.rs
 lazy_static = "1.4"
-lrpar = { path = "../lrpar", version = "0.9" }
+lrpar = { path = "../lrpar", version = "0.10" }
 regex = "1.3"
 num-traits = "0.2"
 try_from = "0.3"

--- a/lrpar/Cargo.toml
+++ b/lrpar/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lrpar"
 description = "Yacc-compatible parser generator"
 repository = "https://github.com/softdevteam/grmtools"
-version = "0.9.3"
+version = "0.10.0"
 authors = ["Lukas Diekmann <http://lukasdiekmann.com/>", "Laurence Tratt <http://tratt.net/laurie/>"]
 edition = "2018"
 readme = "README.md"
@@ -21,11 +21,11 @@ vergen = "3"
 [dependencies]
 bincode = "1.2"
 cactus = "1.0"
-cfgrammar = { path="../cfgrammar", version = "0.9", features=["serde"] }
+cfgrammar = { path="../cfgrammar", version = "0.10", features=["serde"] }
 filetime = "0.2"
 indexmap = "1.3"
 lazy_static = "1.4"
-lrtable = { path="../lrtable", version = "0.9", features=["serde"] }
+lrtable = { path="../lrtable", version = "0.10", features=["serde"] }
 num-traits = "0.2"
 packedvec = "1.2"
 serde = { version="1.0", features=["derive"] }

--- a/lrtable/Cargo.toml
+++ b/lrtable/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lrtable"
 description = "LR grammar table generation"
 repository = "https://github.com/softdevteam/grmtools"
-version = "0.9.3"
+version = "0.10.0"
 authors = ["Lukas Diekmann <http://lukasdiekmann.com/>", "Laurence Tratt <http://tratt.net/laurie/>"]
 edition = "2018"
 readme = "README.md"
@@ -16,7 +16,7 @@ path = "src/lib/mod.rs"
 [dependencies]
 fnv = "1.0"
 num-traits = "0.2"
-cfgrammar = { path="../cfgrammar", version = "0.9", features=["serde"] }
+cfgrammar = { path="../cfgrammar", version = "0.10", features=["serde"] }
 serde = { version="1.0", features=["derive"], optional=true }
 vob = { version="2.0", features=["serde"] }
 sparsevec = { version="0.1", features=["serde"] }

--- a/nimbleparse/Cargo.toml
+++ b/nimbleparse/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nimbleparse"
 description = "Simple Yacc grammar debugging tool"
 repository = "https://github.com/softdevteam/grmtools"
-version = "0.9.3"
+version = "0.10.0"
 authors = ["Laurence Tratt <http://tratt.net/laurie/>"]
 edition = "2018"
 readme = "README.md"
@@ -14,9 +14,9 @@ doc = false
 name = "nimbleparse"
 
 [dependencies]
-cfgrammar = { path="../cfgrammar", version="0.9" }
+cfgrammar = { path="../cfgrammar", version="0.10" }
 getopts = "0.2"
-lrlex = { path="../lrlex", version="0.9" }
-lrpar = { path="../lrpar", version="0.9" }
-lrtable = { path="../lrtable", version="0.9" }
+lrlex = { path="../lrlex", version="0.10" }
+lrpar = { path="../lrpar", version="0.10" }
+lrtable = { path="../lrtable", version="0.10" }
 num-traits = "0.2"


### PR DESCRIPTION
The removal of several pub items means that this change requires an API bump.