### PR TITLE
Add support for the %expect declaration.

### DIFF
--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -25,6 +25,7 @@ pub struct GrammarAST {
     // Error pretty-printers
     pub epp: HashMap<String, String>,
     pub expect: Option<usize>,
+    pub expectrr: Option<usize>,
     pub programs: Option<String>,
 }
 
@@ -121,6 +122,7 @@ impl GrammarAST {
             implicit_tokens: None,
             epp: HashMap::new(),
             expect: None,
+            expectrr: None,
             programs: None,
             parse_param_bindings: None,
             parse_param_lifetimes: None,

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -24,6 +24,7 @@ pub struct GrammarAST {
     pub parse_param_lifetimes: Option<HashSet<String>>,
     // Error pretty-printers
     pub epp: HashMap<String, String>,
+    pub expect: Option<usize>,
     pub programs: Option<String>,
 }
 
@@ -119,6 +120,7 @@ impl GrammarAST {
             avoid_insert: None,
             implicit_tokens: None,
             epp: HashMap::new(),
+            expect: None,
             programs: None,
             parse_param_bindings: None,
             parse_param_lifetimes: None,

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -86,6 +86,8 @@ pub struct YaccGrammar<StorageT = u32> {
     actiontypes: Vec<Option<String>>,
     /// Tokens marked as %avoid_insert (if any).
     avoid_insert: Option<Vob>,
+    /// How many shift/reduce conflicts the grammar author expected (if any).
+    expect: Option<usize>,
 }
 
 // Internally, we assume that a grammar's start rule has a single production. Since we manually
@@ -349,6 +351,7 @@ where
             programs: ast.programs,
             avoid_insert,
             actiontypes,
+            expect: ast.expect,
         })
     }
 
@@ -528,6 +531,11 @@ where
         } else {
             false
         }
+    }
+
+    // How many shift/reduce conflicts were expected?
+    pub fn expect(&self) -> Option<usize> {
+        self.expect
     }
 
     /// Is there a path from the `from` rule to the `to` rule? Note that recursive rules

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -88,6 +88,8 @@ pub struct YaccGrammar<StorageT = u32> {
     avoid_insert: Option<Vob>,
     /// How many shift/reduce conflicts the grammar author expected (if any).
     expect: Option<usize>,
+    /// How many reduce/reduce conflicts the grammar author expected (if any).
+    expectrr: Option<usize>,
 }
 
 // Internally, we assume that a grammar's start rule has a single production. Since we manually
@@ -352,6 +354,7 @@ where
             avoid_insert,
             actiontypes,
             expect: ast.expect,
+            expectrr: ast.expectrr,
         })
     }
 
@@ -536,6 +539,11 @@ where
     // How many shift/reduce conflicts were expected?
     pub fn expect(&self) -> Option<usize> {
         self.expect
+    }
+
+    // How many reduce/reduce conflicts were expected?
+    pub fn expectrr(&self) -> Option<usize> {
+        self.expectrr
     }
 
     /// Is there a path from the `from` rule to the `to` rule? Note that recursive rules

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -34,6 +34,7 @@ pub enum YaccParserErrorKind {
     DuplicateAvoidInsertDeclaration,
     DuplicateImplicitTokensDeclaration,
     DuplicateExpectDeclaration,
+    DuplicateExpectRRDeclaration,
     DuplicateStartDeclaration,
     DuplicateActiontypeDeclaration,
     DuplicateEPP,
@@ -73,6 +74,7 @@ impl fmt::Display for YaccParserError {
                 "Duplicate %avoid_insert declaration"
             }
             YaccParserErrorKind::DuplicateExpectDeclaration => "Duplicate %expect declaration",
+            YaccParserErrorKind::DuplicateExpectRRDeclaration => "Duplicate %expect-rr declaration",
             YaccParserErrorKind::DuplicateImplicitTokensDeclaration => {
                 "Duplicate %implicit_tokens declaration"
             }
@@ -181,6 +183,16 @@ impl YaccParser {
                 i = self.parse_ws(j, false)?;
                 let (j, v) = self.parse_string(i)?;
                 self.ast.epp.insert(n, v);
+                i = self.parse_ws(j, true)?;
+                continue;
+            }
+            if let Some(j) = self.lookahead_is("%expect-rr", i) {
+                if self.ast.expectrr.is_some() {
+                    return Err(self.mk_error(YaccParserErrorKind::DuplicateExpectRRDeclaration, i));
+                }
+                i = self.parse_ws(j, false)?;
+                let (j, n) = self.parse_int(i)?;
+                self.ast.expectrr = Some(n);
                 i = self.parse_ws(j, true)?;
                 continue;
             }

--- a/lrpar/cttests/src/expect.test
+++ b/lrpar/cttests/src/expect.test
@@ -1,0 +1,12 @@
+name: Test %expect
+yacckind: Original(YaccOriginalActionKind::NoAction)
+grammar: |
+    %start A
+    %expect 1
+    %%
+    A: 'a' 'b' | B 'b';
+    B: 'a';
+lexer: |
+    %%
+    a 'a'
+    b 'b'

--- a/lrpar/cttests/src/expectrr.test
+++ b/lrpar/cttests/src/expectrr.test
@@ -1,0 +1,14 @@
+name: Test %expect
+yacckind: Original(YaccOriginalActionKind::NoAction)
+grammar: |
+    %start A
+    %expect 1
+    %expect-rr 1
+    %%
+    A : 'a' 'b' | B 'b';
+    B : 'a' | C;
+    C : 'a';
+lexer: |
+    %%
+    a 'a'
+    b 'b'

--- a/lrpar/cttests/src/lib.rs
+++ b/lrpar/cttests/src/lib.rs
@@ -14,6 +14,9 @@ lrpar_mod!("calc_actiontype.y");
 lrlex_mod!("calc_noactions.l");
 lrpar_mod!("calc_noactions.y");
 
+lrlex_mod!("expect.l");
+lrpar_mod!("expect.y");
+
 lrlex_mod!("lexer_lifetime.l");
 lrpar_mod!("lexer_lifetime.y");
 
@@ -235,4 +238,9 @@ fn test_passthrough() {
         (Some(Ok(ref s)), _) if s == "$101" => (),
         _ => unreachable!(),
     }
+}
+
+#[test]
+fn test_expect() {
+    // This test merely needs to compile in order to be successful.
 }

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -360,8 +360,13 @@ where
         fs::remove_file(&outp).ok();
 
         let (sgraph, stable) = from_yacc(&grm, Minimiser::Pager)?;
-        if stable.conflicts().is_some() && self.error_on_conflicts {
-            return Err(Box::new(CTConflictsError { stable }));
+        if self.error_on_conflicts {
+            if let Some(c) = stable.conflicts() {
+                match grm.expect() {
+                    Some(i) if i == c.sr_len() => (),
+                    _ => return Err(Box::new(CTConflictsError { stable })),
+                }
+            }
         }
 
         let mod_name = match self.mod_name {

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -58,9 +58,9 @@ where
         let conflicts = self.stable.conflicts().unwrap();
         write!(
             f,
-            "CTConflictsError{{{} Shift/Reduce, {} Reduce/Reduce}}",
-            conflicts.sr_len(),
-            conflicts.rr_len()
+            "CTConflictsError{{{} Reduce/Reduce, {} Shift/Reduce}}",
+            conflicts.rr_len(),
+            conflicts.sr_len()
         )
     }
 }
@@ -75,9 +75,9 @@ where
         let conflicts = self.stable.conflicts().unwrap();
         write!(
             f,
-            "CTConflictsError{{{} Shift/Reduce, {} Reduce/Reduce}}",
-            conflicts.sr_len(),
-            conflicts.rr_len()
+            "CTConflictsError{{{} Reduce/Reduce, {} Shift/Reduce}}",
+            conflicts.rr_len(),
+            conflicts.sr_len()
         )
     }
 }

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -31,24 +31,24 @@ where
     usize: AsPrimitive<StorageT>,
     u32: AsPrimitive<StorageT>,
 {
-    /// Return an iterator over all shift/reduce conflicts.
-    pub fn sr_conflicts(&self) -> impl Iterator<Item = &(TIdx<StorageT>, PIdx<StorageT>, StIdx)> {
-        self.shift_reduce.iter()
-    }
-
     /// Return an iterator over all reduce/reduce conflicts.
     pub fn rr_conflicts(&self) -> impl Iterator<Item = &(PIdx<StorageT>, PIdx<StorageT>, StIdx)> {
         self.reduce_reduce.iter()
     }
 
-    /// How many shift/reduce conflicts are there?
-    pub fn sr_len(&self) -> usize {
-        self.shift_reduce.len()
+    /// Return an iterator over all shift/reduce conflicts.
+    pub fn sr_conflicts(&self) -> impl Iterator<Item = &(TIdx<StorageT>, PIdx<StorageT>, StIdx)> {
+        self.shift_reduce.iter()
     }
 
     /// How many reduce/reduce conflicts are there?
     pub fn rr_len(&self) -> usize {
         self.reduce_reduce.len()
+    }
+
+    /// How many shift/reduce conflicts are there?
+    pub fn sr_len(&self) -> usize {
+        self.shift_reduce.len()
     }
 
     /// Returns a pretty-printed version of the conflicts.
@@ -57,23 +57,6 @@ where
         let mut s = String::new();
         s.push_str(&self.pp_sr(grm));
         s.push_str(&self.pp_rr(grm));
-        s
-    }
-
-    /// Returns a pretty-printed version of the shift/reduce conflicts.
-    pub fn pp_sr(&self, grm: &YaccGrammar<StorageT>) -> String {
-        let mut s = String::new();
-        if self.sr_len() > 0 {
-            s.push_str("Shift/Reduce conflicts:\n");
-            for (tidx, pidx, stidx) in self.sr_conflicts() {
-                s.push_str(&format!(
-                    "   State {:?}: Shift(\"{}\") / Reduce({})\n",
-                    usize::from(*stidx),
-                    grm.token_name(*tidx).unwrap(),
-                    grm.pp_prod(*pidx)
-                ));
-            }
-        }
         s
     }
 
@@ -88,6 +71,23 @@ where
                     usize::from(*stidx),
                     grm.pp_prod(*pidx),
                     grm.pp_prod(*r_pidx)
+                ));
+            }
+        }
+        s
+    }
+
+    /// Returns a pretty-printed version of the shift/reduce conflicts.
+    pub fn pp_sr(&self, grm: &YaccGrammar<StorageT>) -> String {
+        let mut s = String::new();
+        if self.sr_len() > 0 {
+            s.push_str("Shift/Reduce conflicts:\n");
+            for (tidx, pidx, stidx) in self.sr_conflicts() {
+                s.push_str(&format!(
+                    "   State {:?}: Shift(\"{}\") / Reduce({})\n",
+                    usize::from(*stidx),
+                    grm.token_name(*tidx).unwrap(),
+                    grm.pp_prod(*pidx)
                 ));
             }
         }

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -52,7 +52,16 @@ where
     }
 
     /// Returns a pretty-printed version of the conflicts.
+    #[deprecated(since = "0.10.0", note = "Please use pp_rr() and pp_sr() instead")]
     pub fn pp(&self, grm: &YaccGrammar<StorageT>) -> String {
+        let mut s = String::new();
+        s.push_str(&self.pp_sr(grm));
+        s.push_str(&self.pp_rr(grm));
+        s
+    }
+
+    /// Returns a pretty-printed version of the shift/reduce conflicts.
+    pub fn pp_sr(&self, grm: &YaccGrammar<StorageT>) -> String {
         let mut s = String::new();
         if self.sr_len() > 0 {
             s.push_str("Shift/Reduce conflicts:\n");
@@ -65,7 +74,12 @@ where
                 ));
             }
         }
+        s
+    }
 
+    /// Returns a pretty-printed version of the reduce/reduce conflicts.
+    pub fn pp_rr(&self, grm: &YaccGrammar<StorageT>) -> String {
+        let mut s = String::new();
         if self.rr_len() > 0 {
             s.push_str("Reduce/Reduce conflicts:\n");
             for (pidx, r_pidx, stidx) in self.rr_conflicts() {

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -124,7 +124,11 @@ fn main() {
 
     if !quiet {
         if let Some(c) = stable.conflicts() {
-            println!("{}", c.pp(&grm));
+            match grm.expect() {
+                Some(i) if i == c.sr_len() => (),
+                _ => println!("{}", c.pp_sr(&grm)),
+            }
+            println!("{}", c.pp_rr(&grm));
             println!("Stategraph:\n{}\n", sgraph.pp_core_states(&grm));
         }
     }

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -124,12 +124,25 @@ fn main() {
 
     if !quiet {
         if let Some(c) = stable.conflicts() {
-            match grm.expect() {
-                Some(i) if i == c.sr_len() => (),
-                _ => println!("{}", c.pp_sr(&grm)),
+            let pp_rr = if let Some(i) = grm.expectrr() {
+                i != c.rr_len()
+            } else {
+                0 != c.rr_len()
+            };
+            let pp_sr = if let Some(i) = grm.expect() {
+                i != c.sr_len()
+            } else {
+                0 != c.sr_len()
+            };
+            if pp_rr {
+                println!("{}", c.pp_rr(&grm));
             }
-            println!("{}", c.pp_rr(&grm));
-            println!("Stategraph:\n{}\n", sgraph.pp_core_states(&grm));
+            if pp_sr {
+                println!("{}", c.pp_sr(&grm));
+            }
+            if pp_rr || pp_sr {
+                println!("Stategraph:\n{}\n", sgraph.pp_core_states(&grm));
+            }
         }
     }
 


### PR DESCRIPTION
This allows a grammar author to tell Yacc how many shift/reduce conflicts it expects. In our context, this means that compile-time grammar generation and nimbleparse don't need to report errors iff the number of shift/reduce conflicts
exactly matches that specified.

Fixes https://github.com/softdevteam/grmtools/issues/234.