### PR TITLE
Tweak minor aspects of the Yacc parser

### DIFF
--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -155,7 +155,12 @@ impl GrammarAST {
         });
     }
 
+    #[deprecated(since = "0.10.2", note = "Please use set_programs instead")]
     pub fn add_programs(&mut self, s: String) {
+        self.set_programs(s);
+    }
+
+    pub fn set_programs(&mut self, s: String) {
         self.programs = Some(s)
     }
 

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -442,17 +442,11 @@ impl YaccParser {
     fn parse_programs(&mut self, mut i: usize) -> YaccResult<usize> {
         if let Some(j) = self.lookahead_is("%%", i) {
             i = self.parse_ws(j, true)?;
-            if i == self.src.len() {
-                Ok(i)
-            } else {
-                let prog = self.src[i..].to_string();
-                i += prog.len();
-                self.ast.add_programs(prog);
-                Ok(i)
-            }
-        } else {
-            Ok(i)
+            let prog = self.src[i..].to_string();
+            i += prog.len();
+            self.ast.add_programs(prog);
         }
+        Ok(i)
     }
 
     // Handle parse_param declarations of the form:

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -444,7 +444,7 @@ impl YaccParser {
             i = self.parse_ws(j, true)?;
             let prog = self.src[i..].to_string();
             i += prog.len();
-            self.ast.add_programs(prog);
+            self.ast.set_programs(prog);
         }
         Ok(i)
     }


### PR DESCRIPTION
This PR first simplifies part of the parser (https://github.com/softdevteam/grmtools/commit/6c050f1ca02d3663cdb02f2f19cbf37d57c23e20) before renaming a misleading function (https://github.com/softdevteam/grmtools/commit/9ad0c624e301f5c980c1d2c0a19569c67225b24d).