### PR TITLE
Format the generated code from lrlex slightly better.

### DIFF
--- a/lrlex/src/lib/builder.rs
+++ b/lrlex/src/lib/builder.rs
@@ -282,7 +282,7 @@ pub fn lexerdef() -> {lexerdef_type} {{
             };
             outs.push_str(&format!(
                 "
-Rule::new({}, {}, \"{}\".to_string()).unwrap(),",
+        Rule::new({}, {}, \"{}\".to_string()).unwrap(),",
                 tok_id,
                 n,
                 r.re_str.replace("\\", "\\\\").replace("\"", "\\\"")
@@ -292,9 +292,10 @@ Rule::new({}, {}, \"{}\".to_string()).unwrap(),",
         // Footer
         outs.push_str(&format!(
             "
-];
+    ];
     {lexerdef_name}::from_rules(rules)
 }}
+
 ",
             lexerdef_name = lexerdef_name
         ));


### PR DESCRIPTION
This changes code such as:

```
pub fn lexerdef() -> LRNonStreamingLexerDef<u8> {
    let rules = vec![
Rule::new(Some(0), Some("INT".to_string()), "[0-9]+".to_string()).unwrap(),
Rule::new(Some(1), Some("STRING".to_string()), "\"(?:\\\\\\\\|\\\\\"|[^\"])*\"".to_string()).unwrap(),
...
];
    LRNonStreamingLexerDef::from_rules(rules)
}
pub const T_SEQUENTIAL: u8 = 20;
```

to:

```
pub fn lexerdef() -> LRNonStreamingLexerDef<u8> {
    let rules = vec![
        Rule::new(Some(0), Some("INT".to_string()), "[0-9]+".to_string()).unwrap(),
        Rule::new(Some(1), Some("STRING".to_string()), "\"(?:\\\\\\\\|\\\\\"|[^\"])*\"".to_string()).unwrap(),
        ...
    ];
    LRNonStreamingLexerDef::from_rules(rules)
}

pub const T_SEQUENTIAL: u8 = 20;
```