### PR TITLE
Deprecate the `process_file_in_src` and `process_file` functions.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -18,6 +18,8 @@ rustup default stable
 cargo test
 cargo test --release
 
+RUSTDOCFLAGS="-Dwarnings" cargo doc --no-deps
+
 which cargo-deny | cargo install cargo-deny || true
 if [ "X`which cargo-deny`" != "X"]; then
     cargo-deny check license

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,23 @@
+# grmtools 0.10.3 (XXXX-YY-ZZ)
+
+* `CTParserBuilder::process_file_in_src` is deprecated in favour of
+  `CTParserBuilder::grammar_in_src_dir` and `CTParserBuilder::process`. In most
+  cases you can change your `build.rs` from:
+  ```rust
+    let lex_rule_ids_map = CTParserBuilder::new()
+        .process_file_in_src("grm.y")?;
+  ```
+  to:
+  ```rust
+    let lex_rule_ids_map = CTParserBuilder::new()
+        .grammar_in_src_dir("grm.y")?
+        .process()?;
+  ```
+
+  The less commonly used `process_file` function is similarly deprecated in
+  favour of the `grammar_path`, `output_path`, and `process` functions.
+
+
 # grmtools 0.10.2 (2021-08-09)
 
 * Optimise `NonStreamingLexer::span_lines_str` from *O(n)* to *O(log n)*.

--- a/doc/src/errorrecovery.md
+++ b/doc/src/errorrecovery.md
@@ -516,7 +516,8 @@ the first parsing error, with the `recoverer` method in `CTParserBuilder` or
     let lex_rule_ids_map = CTParserBuilder::new()
         .yacckind(YaccKind::Grmtools)
         .recoverer(lrpar::RecoveryKind::None)
-        .process_file_in_src("calc.y")?;
+        .grammar_path_in_src("calc.y")?
+        .process()?;
 ```
 
 and then no matter how many syntax errors we make, only one is reported:

--- a/doc/src/quickstart.md
+++ b/doc/src/quickstart.md
@@ -54,7 +54,8 @@ use lrpar::CTParserBuilder;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let lex_rule_ids_map = CTParserBuilder::new()
         .yacckind(YaccKind::Grmtools)
-        .process_file_in_src("calc.y")?;
+        .grammar_path_in_src("calc.y")?
+        .process()?;
     LexerBuilder::new()
         .rule_ids_map(lex_rule_ids_map)
         .process_file_in_src("calc.l")?;

--- a/lrpar/README.md
+++ b/lrpar/README.md
@@ -24,7 +24,8 @@ use lrpar::CTParserBuilder;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let lex_rule_ids_map = CTParserBuilder::new()
         .yacckind(YaccKind::Grmtools)
-        .process_file_in_src("calc.y")?;
+        .grammar_path_in_src("calc.y")?
+        .process();
     LexerBuilder::new()
         .rule_ids_map(lex_rule_ids_map)
         .process_file_in_src("calc.l")?;

--- a/lrpar/cttests/build.rs
+++ b/lrpar/cttests/build.rs
@@ -52,7 +52,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             outp.set_extension("rs");
             let lex_rule_ids_map = CTParserBuilder::new()
                 .yacckind(yacckind)
-                .process_file(pg.to_str().unwrap(), &outp)?;
+                .grammar_path(pg.to_str().unwrap())
+                .output_path(&outp)
+                .process()?;
 
             let mut outl = PathBuf::from(&out_dir);
             outl.push(format!("{}.l.rs", base));

--- a/lrpar/examples/calc_actions/build.rs
+++ b/lrpar/examples/calc_actions/build.rs
@@ -11,7 +11,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ".l" for lrlex).
     let lex_rule_ids_map = CTParserBuilder::new()
         .yacckind(YaccKind::Grmtools)
-        .process_file_in_src("calc.y")?;
+        .grammar_in_src_dir("calc.y")?
+        .process()?;
     LexerBuilder::new()
         .rule_ids_map(lex_rule_ids_map)
         .process_file_in_src("calc.l")?;

--- a/lrpar/examples/calc_ast/build.rs
+++ b/lrpar/examples/calc_ast/build.rs
@@ -11,7 +11,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ".l" for lrlex).
     let lex_rule_ids_map = CTParserBuilder::new()
         .yacckind(YaccKind::Grmtools)
-        .process_file_in_src("calc.y")?;
+        .grammar_in_src_dir("calc.y")?
+        .process()?;
     LexerBuilder::new()
         .rule_ids_map(lex_rule_ids_map)
         .process_file_in_src("calc.l")?;

--- a/lrpar/examples/calc_parsetree/build.rs
+++ b/lrpar/examples/calc_parsetree/build.rs
@@ -11,7 +11,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ".l" for lrlex).
     let lex_rule_ids_map = CTParserBuilder::<u8>::new_with_storaget()
         .yacckind(YaccKind::Original(YaccOriginalActionKind::GenericParseTree))
-        .process_file_in_src("calc.y")?;
+        .grammar_in_src_dir("calc.y")?
+        .process()?;
     LexerBuilder::new()
         .rule_ids_map(lex_rule_ids_map)
         .process_file_in_src("calc.l")?;

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -215,6 +215,14 @@ where
     where
         P: AsRef<Path>,
     {
+        if !srcp.as_ref().is_relative() {
+            return Err(format!(
+                "Grammar path '{}' must be a relative path.",
+                srcp.as_ref().to_str().unwrap_or("<invalid UTF-8>")
+            )
+            .into());
+        }
+
         let mut grmp = current_dir()?;
         grmp.push("src");
         grmp.push(srcp.as_ref());

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -32,7 +32,8 @@
 //! fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     let lex_rule_ids_map = CTParserBuilder::new()
 //!         .yacckind(YaccKind::Grmtools)
-//!         .process_file_in_src("calc.y")?;
+//!         .grammar_path_in_src("calc.y")?
+//!         .process()?;
 //!     LexerBuilder::new()
 //!         .rule_ids_map(lex_rule_ids_map)
 //!         .process_file_in_src("calc.l")?;


### PR DESCRIPTION
The `CTBuilder` API has always been a bit unsatisfactory, and some changes I'd like to make to it in the near future have made clear to me that we need some bigger changes.

https://github.com/softdevteam/grmtools/commit/4d6625c9b8210e9ac77aa6b905ec23e4bd12aa81 solves the problem that the `process_*` functions take arguments that really should have been options on the builder itself. In practise this means that `CTBuilder::process_file_in_src` is deprecated in favour of `CTBuilder::grammar_path_in_src` and `CTBuilder::process`. In most cases this means changing a `build.rs` from:

```rust
let lex_rule_ids_map = CTParserBuilder::new()
.process_file_in_src("grm.y")?;
```

to:

```rust
let lex_rule_ids_map = CTParserBuilder::new()
.grammar_path_in_src("grm.y")?
.process()?;
```

The less commonly used `process_file` function is similarly deprecated in favour of the `grammar_path`, `output_path`, and `process` functions. To my slight horror, some of the cttests used `process_file` in a way that only really worked by accident: by explicitly using `grammar_path` we lessen that chance. https://github.com/softdevteam/grmtools/commit/11981b6ee000eeb23a1d01b142b3ac397988254a ensures that.

While I'm here, I've tidied up some of the documentation that surrounds these functions: there's still more that could, and probably should, be done but that's best left to later commits.

This is a backwards compatible change in the sense that you can use the old functions but rustc will warn you about them. That should help people migrate their code more easily than a "hard" API change.