### PR TITLE
Type wrangling

### DIFF
--- a/cfgrammar/src/lib/idxnewtype.rs
+++ b/cfgrammar/src/lib/idxnewtype.rs
@@ -40,8 +40,7 @@ IdxNewtype!(
     /// A type specifically for rule indices.
     ///
     /// It is guaranteed that `RIdx` can be converted, without loss of precision, to `usize` with
-    /// the idiom `RIdx::from(x_usize)`. `usize` values can be converted to `RIdx`, causing a
-    /// panic if this would lead to a loss of precision with `usize::from(y_ridx)`.
+    /// the idiom `usize::from(...)`.
     RIdx
 );
 IdxNewtype!(
@@ -49,23 +48,20 @@ IdxNewtype!(
     /// have two productions for the single rule `E`).
     ///
     /// It is guaranteed that `PIdx` can be converted, without loss of precision, to `usize` with
-    /// the idiom `PIdx::from(x_usize)`. `usize` values can be converted to `PTIdx`, causing a
-    /// panic if this would lead to a loss of precision with `usize::from(y_pidx)`.
+    /// the idiom `usize::from(...)`.
     PIdx
 );
 IdxNewtype!(
     /// A type specifically for symbol indices (within a production).
     ///
     /// It is guaranteed that `SIdx` can be converted, without loss of precision, to `usize` with
-    /// the idiom `SIdx::from(x_usize)`. `usize` values can be converted to `RIdx`, causing a
-    /// panic if this would lead to a loss of precision with `usize::from(y_sidx)`.
+    /// the idiom `usize::from(...)`.
     SIdx
 );
 IdxNewtype!(
     /// A type specifically for token indices.
     ///
     /// It is guaranteed that `TIdx` can be converted, without loss of precision, to `usize` with
-    /// the idiom `TIdx::from(x_usize)`. `usize` values can be converted to `TIdx`, causing a
-    /// panic if this would lead to a loss of precision with `usize::from(y_tidx)`.
+    /// the idiom `usize::from(...)`.
     TIdx
 );

--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -109,7 +109,6 @@ pub(super) fn recoverer<'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigne
 ) -> Box<dyn Recoverer<StorageT, ActionT> + 'a>
 where
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>,
 {
     Box::new(CPCTPlus { parser })
 }
@@ -123,7 +122,6 @@ impl<
     > Recoverer<StorageT, ActionT> for CPCTPlus<'a, 'b, 'input, StorageT, ActionT>
 where
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>,
 {
     fn recover(
         &self,
@@ -256,7 +254,6 @@ impl<
     > CPCTPlus<'a, 'b, 'input, StorageT, ActionT>
 where
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>,
 {
     fn insert(&self, n: &PathFNode<StorageT>, nbrs: &mut Vec<(u16, PathFNode<StorageT>)>) {
         let laidx = n.laidx;
@@ -445,7 +442,6 @@ fn apply_repairs<'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, Acti
 ) -> usize
 where
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>,
 {
     for r in repairs.iter() {
         match *r {
@@ -541,7 +537,6 @@ fn rank_cnds<'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned, ActionT:
 ) -> Vec<Vec<ParseRepair<StorageT>>>
 where
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>,
 {
     let mut cnds = Vec::new();
     let mut furthest = 0;

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -52,7 +52,6 @@ impl<StorageT> fmt::Display for CTConflictsError<StorageT>
 where
     StorageT: 'static + Debug + Hash + PrimInt + Serialize + Unsigned,
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let conflicts = self.stable.conflicts().unwrap();
@@ -69,7 +68,6 @@ impl<StorageT> fmt::Debug for CTConflictsError<StorageT>
 where
     StorageT: 'static + Debug + Hash + PrimInt + Serialize + Unsigned,
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let conflicts = self.stable.conflicts().unwrap();
@@ -86,7 +84,6 @@ impl<StorageT> Error for CTConflictsError<StorageT>
 where
     StorageT: 'static + Debug + Hash + PrimInt + Serialize + Unsigned,
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>,
 {
 }
 
@@ -158,7 +155,6 @@ impl<'a, StorageT> CTParserBuilder<'a, StorageT>
 where
     StorageT: 'static + Debug + Hash + PrimInt + Serialize + Unsigned,
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>,
 {
     /// Create a new `CTParserBuilder`.
     ///
@@ -1092,7 +1088,6 @@ impl<StorageT> CTParser<StorageT>
 where
     StorageT: 'static + Debug + Hash + PrimInt + Serialize + Unsigned,
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>,
 {
     /// Returns `true` if this compile-time parser was regenerated or `false` if it was not.
     pub fn regenerated(&self) -> bool {

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -98,7 +98,6 @@ impl<'a, 'b: 'a, 'input: 'b, StorageT: 'static + Debug + Hash + PrimInt + Unsign
     Parser<'a, 'b, 'input, StorageT, Node<StorageT>>
 where
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>,
 {
     fn parse_generictree(
         rcvry_kind: RecoveryKind,
@@ -151,7 +150,6 @@ impl<'a, 'b: 'a, 'input: 'b, StorageT: 'static + Debug + Hash + PrimInt + Unsign
     Parser<'a, 'b, 'input, StorageT, ()>
 where
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>,
 {
     fn parse_noaction(
         rcvry_kind: RecoveryKind,
@@ -201,7 +199,6 @@ impl<
     > Parser<'a, 'b, 'input, StorageT, ActionT>
 where
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>,
 {
     fn parse_actions(
         rcvry_kind: RecoveryKind,
@@ -675,7 +672,6 @@ pub struct RTParserBuilder<'a, StorageT: Eq + Hash> {
 impl<'a, StorageT: 'static + Debug + Hash + PrimInt + Unsigned> RTParserBuilder<'a, StorageT>
 where
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>,
 {
     /// Create a new run-time parser from a `YaccGrammar`, a `StateGraph`, and a `StateTable`.
     pub fn new(grm: &'a YaccGrammar<StorageT>, stable: &'a StateTable<StorageT>) -> Self {

--- a/lrtable/src/lib/mod.rs
+++ b/lrtable/src/lib/mod.rs
@@ -66,7 +66,6 @@ pub fn from_yacc<StorageT: 'static + Hash + PrimInt + Unsigned>(
 ) -> Result<(StateGraph<StorageT>, StateTable<StorageT>), StateTableError<StorageT>>
 where
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>,
 {
     match m {
         Minimiser::Pager => {

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -29,7 +29,6 @@ pub struct Conflicts<StorageT> {
 impl<StorageT: 'static + Hash + PrimInt + Unsigned> Conflicts<StorageT>
 where
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>,
 {
     /// Return an iterator over all reduce/reduce conflicts.
     pub fn rr_conflicts(&self) -> impl Iterator<Item = &(PIdx<StorageT>, PIdx<StorageT>, StIdx)> {
@@ -158,7 +157,6 @@ const ERROR: usize = 0;
 impl<StorageT: 'static + Hash + PrimInt + Unsigned> StateTable<StorageT>
 where
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>,
 {
     pub fn new(
         grm: &YaccGrammar<StorageT>,
@@ -538,7 +536,6 @@ fn resolve_shift_reduce<StorageT: 'static + Hash + PrimInt + Unsigned>(
     conflict_stidx: StIdx, // State in which the conflict occured
 ) where
     usize: AsPrimitive<StorageT>,
-    u32: AsPrimitive<StorageT>,
 {
     let tidx_prec = grm.token_precedence(tidx);
     let pidx_prec = grm.prod_precedence(pidx);


### PR DESCRIPTION
After correcting some incorrect documentation (https://github.com/softdevteam/grmtools/commit/d3e28160861080b863ca8001b81caf65d41917db), this PR mostly removes a number of unnecessary `where` clauses (https://github.com/softdevteam/grmtools/commit/896c6c324d77ba97bf1f578c922f02c18a7529ee).