### PR TITLE
Faulty lexemes

### DIFF
--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -254,7 +254,7 @@ impl<'lexer, 'input: 'lexer, StorageT: Copy + Eq + Hash + PrimInt + TryFrom<usiz
                 if r.name.is_some() {
                     match r.tok_id {
                         Some(tok_id) => {
-                            lexemes.push(Ok(Lexeme::new(tok_id, old_i, Some(longest))));
+                            lexemes.push(Ok(Lexeme::new(tok_id, old_i, longest)));
                         }
                         None => {
                             lexemes.push(Err(LexError::new(Span::new(old_i, old_i))));

--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -269,6 +269,7 @@ where
             let new_lexeme = Lexeme::new_faulty(
                 StorageT::from(u32::from(tidx)).unwrap(),
                 next_lexeme.span().start(),
+                0,
             );
             let (new_laidx, n_pstack) = self.parser.lr_cactus(
                 Some(new_lexeme),
@@ -453,6 +454,7 @@ where
                 let new_lexeme = Lexeme::new_faulty(
                     StorageT::from(u32::from(tidx)).unwrap(),
                     next_lexeme.span().start(),
+                    0,
                 );
                 parser.lr_upto(
                     Some(new_lexeme),

--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -266,10 +266,9 @@ where
             }
 
             let next_lexeme = self.parser.next_lexeme(n.laidx);
-            let new_lexeme = Lexeme::new(
+            let new_lexeme = Lexeme::new_faulty(
                 StorageT::from(u32::from(tidx)).unwrap(),
                 next_lexeme.span().start(),
-                None,
             );
             let (new_laidx, n_pstack) = self.parser.lr_cactus(
                 Some(new_lexeme),
@@ -451,10 +450,9 @@ where
         match *r {
             ParseRepair::Insert(tidx) => {
                 let next_lexeme = parser.next_lexeme(laidx);
-                let new_lexeme = Lexeme::new(
+                let new_lexeme = Lexeme::new_faulty(
                     StorageT::from(u32::from(tidx)).unwrap(),
                     next_lexeme.span().start(),
-                    None,
                 );
                 parser.lr_upto(
                     Some(new_lexeme),
@@ -718,7 +716,7 @@ E : 'N'
         let err_tok_id = u32::from(grm.token_idx("N").unwrap()).to_u16().unwrap();
         match &errs[0] {
             LexParseError::ParseError(e) => {
-                assert_eq!(e.lexeme(), &Lexeme::new(err_tok_id, 2, Some(1)))
+                assert_eq!(e.lexeme(), &Lexeme::new(err_tok_id, 2, 1))
             }
             _ => unreachable!(),
         }

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -813,7 +813,7 @@ where
                             "
         let {prefix}arg_{} = match {prefix}args.next().unwrap() {{
             ::lrpar::parser::AStackType::Lexeme(l) => {{
-                if l.inserted() {{
+                if l.faulty() {{
                     Err(l)
                 }} else {{
                     Ok(l)

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -455,10 +455,9 @@ where
                 last_la.span().end()
             };
 
-            Lexeme::new(
+            Lexeme::new_faulty(
                 StorageT::from(u32::from(self.grm.eof_token_idx())).unwrap(),
                 last_la_end,
-                None,
             )
         }
     }
@@ -955,7 +954,7 @@ pub(crate) mod test {
                 }
             }
             assert!(longest > 0);
-            lexemes.push(Lexeme::new(longest_tok_id, i, Some(longest)));
+            lexemes.push(Lexeme::new(longest_tok_id, i, longest));
             i += longest;
         }
         lexemes
@@ -1089,8 +1088,8 @@ Call: 'ID' '(' ')';";
         let err_tok_id = usize::from(grm.eof_token_idx()).to_u16().unwrap();
         match &errs[0] {
             LexParseError::ParseError(e) => {
-                assert_eq!(e.lexeme(), &Lexeme::new(err_tok_id, 2, None));
-                assert!(e.lexeme().inserted());
+                assert_eq!(e.lexeme(), &Lexeme::new_faulty(err_tok_id, 2));
+                assert!(e.lexeme().faulty());
             }
             _ => unreachable!(),
         }
@@ -1101,8 +1100,8 @@ Call: 'ID' '(' ')';";
         let err_tok_id = usize::from(grm.token_idx("ID").unwrap()).to_u16().unwrap();
         match &errs[0] {
             LexParseError::ParseError(e) => {
-                assert_eq!(e.lexeme(), &Lexeme::new(err_tok_id, 2, Some(1)));
-                assert!(!e.lexeme().inserted());
+                assert_eq!(e.lexeme(), &Lexeme::new(err_tok_id, 2, 1));
+                assert!(!e.lexeme().faulty());
             }
             _ => unreachable!(),
         }

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -458,6 +458,7 @@ where
             Lexeme::new_faulty(
                 StorageT::from(u32::from(self.grm.eof_token_idx())).unwrap(),
                 last_la_end,
+                0,
             )
         }
     }
@@ -1088,7 +1089,7 @@ Call: 'ID' '(' ')';";
         let err_tok_id = usize::from(grm.eof_token_idx()).to_u16().unwrap();
         match &errs[0] {
             LexParseError::ParseError(e) => {
-                assert_eq!(e.lexeme(), &Lexeme::new_faulty(err_tok_id, 2));
+                assert_eq!(e.lexeme(), &Lexeme::new_faulty(err_tok_id, 2, 0));
                 assert!(e.lexeme().faulty());
             }
             _ => unreachable!(),


### PR DESCRIPTION
Previously we supported the idea of "inserted" lexemes -- that is, lexemes inserted by error recovery, which were expected to have a type, a starting position, but no length. This PR generalises this to the concept of "faulty" lexemes which might result from, for example, lexing errors. Faulty lexemes can have a non-zero length.

I *think* this is the right thing to do, but I welcome thoughts @ptersilie!