### PR TITLE
Silence warnings about unused %parse-param variables.

### DIFF
--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -969,7 +969,7 @@ where
                 if actiont == "()" {
                     "".to_owned()
                 } else {
-                    format!("\n->                  {}", actiont)
+                    format!("\n                 -> {}", actiont)
                 }
             };
             outs.push_str(&format!(
@@ -979,7 +979,7 @@ where
                      {prefix}lexer: &'lexer dyn ::lrpar::NonStreamingLexer<'input, {lexemet}, {storaget}>,
                      {prefix}span: ::lrpar::Span,
                      {parse_paramdef},
-                     {args}) {returnt} {{
+                     {args}){returnt} {{
         let _ = {parse_paramname};\n",
                 usize::from(pidx),
                 rulename = grm.rule_name(grm.prod_to_rule(pidx)),


### PR DESCRIPTION
If a user defines a `%parse-param` variable but doesn't use it in a particular rule, then rustc complains about an unused variable. We partly silenced this before with the `let _ = <var>;` trick -- but it wasn't quite in the right place to silence all the warnings. This PR fixes that in https://github.com/softdevteam/grmtools/pull/259/commits/3418f4231606cc009931cb95cfb1dc2520962f1b (I also fixed some whitespace ugliness that I noticed at the same time in https://github.com/softdevteam/grmtools/pull/259/commits/73dc83c49bd60e834283c423affdc2fef911bad4).