### PR TITLE
We are no longer tied to `'input`.

### DIFF
--- a/doc/src/actioncode.md
+++ b/doc/src/actioncode.md
@@ -52,10 +52,9 @@ make use of the following:
 
 A single extra parameter can be passed to action functions if the `%parse-param
 <var>: <type>` declaration is used. The variable `<var>` is then visible in all
-action code. Note that `<type>` must implement the [`Copy`
-trait](https://doc.rust-lang.org/std/marker/trait.Copy.html). If you wish to
-pass a reference it must currently be tied to the `'input` lifetime (i.e.
-`%parse-param x: &'lifetime ...`).
+action code. `<type>` must implement the [`Copy`
+trait](https://doc.rust-lang.org/std/marker/trait.Copy.html) (note that `&`
+references implement `Copy`).
 
 For example if a grammar has a declaration:
 

--- a/lrpar/cttests/src/parseparam.test
+++ b/lrpar/cttests/src/parseparam.test
@@ -2,7 +2,7 @@ name: Test %parse-param
 yacckind: Grmtools
 grammar: |
     %start S
-    %parse-param p: &'input u64
+    %parse-param p: &u64
     %%
     S -> u64:
         'INT' { *p + $lexer.span_str($1.unwrap().span()).parse::<u64>().unwrap() }


### PR DESCRIPTION
I'm not sure what I changed or when, but I no longer get compile-time errors if `%parse-param` references are not tied to `'input`. Whatever I did, I'm happy to loosen this restriction!