### PR TITLE
Rename lexeme_id_map to token_map for consistency with cfgrammar.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -96,7 +96,7 @@ In more detail:
 * `CTParserBuilder::process_file_in_src` is deprecated in favour of
   `CTParserBuilder::grammar_in_src_dir` and `CTParserBuilder::build`. The
   latter method consumes the `CTParserBuilder` returning a `CTParser` which
-  exposes a `lexeme_id_map` method whose result can be passed to lexers such as
+  exposes a `token_map` method whose result can be passed to lexers such as
   `lrlex`. 
 
   The less commonly used `process_file` function is similarly deprecated in

--- a/lrlex/src/lib/ctbuilder.rs
+++ b/lrlex/src/lib/ctbuilder.rs
@@ -275,7 +275,7 @@ where
             let mut ctp = CTParserBuilder::<LexemeT, StorageT>::new();
             ctp = lrcfg(ctp);
             let map = ctp.build()?;
-            self.rule_ids_map = Some(map.lexeme_id_map().to_owned());
+            self.rule_ids_map = Some(map.token_map().to_owned());
         }
 
         let lexerp = self

--- a/lrpar/cttests/build.rs
+++ b/lrpar/cttests/build.rs
@@ -60,7 +60,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             outl.push(format!("{}.l.rs", base));
             outl.set_extension("rs");
             CTLexerBuilder::new()
-                .rule_ids_map(cp.lexeme_id_map())
+                .rule_ids_map(cp.token_map())
                 .lexer_path(pl.to_str().unwrap())
                 .output_path(&outl)
                 .build()?;

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -434,7 +434,7 @@ where
     /// generated files.
     #[deprecated(
         since = "0.11.0",
-        note = "Please use grammar_in_src_dir(), build(), and lexeme_id_map() instead"
+        note = "Please use grammar_in_src_dir(), build(), and token_map() instead"
     )]
     #[allow(deprecated)]
     pub fn process_file_in_src(
@@ -1139,7 +1139,7 @@ where
 
     /// Returns a [HashMap] from lexeme string types to numeric types (e.g. `INT: 2`), suitable for
     /// handing to a lexer to coordinate the IDs of lexer and parser.
-    pub fn lexeme_id_map(&self) -> &HashMap<String, StorageT> {
+    pub fn token_map(&self) -> &HashMap<String, StorageT> {
         &self.rule_ids
     }
 


### PR DESCRIPTION
I'd forgotten that we used "lexeme" for the "run-time" aspect and "token" for the "compile-time" aspect of lexing, and that cfgrammar already exposes a `token_map` function that means the same as `lexeme_id_map`. Renaming it before a public release seems the right thing to do.