### PR TITLE
Point lrpar readers at different versions of the guide / book / API.

### DIFF
--- a/lrpar/README.md
+++ b/lrpar/README.md
@@ -2,10 +2,19 @@
 
 `lrpar` provides a Yacc-compatible parser (where grammars can be generated at
 compile-time or run-time). It can take in traditional `.y` files and convert
-them into an idiomatic Rust parser. More details can be found in the [grmtools
-book](https://softdevteam.github.io/grmtools/master/book); the
-[quickstart guide](https://softdevteam.github.io/grmtools/master/book/quickstart.html)
-is a good place to start.
+them into an idiomatic Rust parser.
+
+If you're new to `lrpar`, please read the "quick start guide". The "grmtools
+book" and API reference have more detailed information.  You can find the
+appropriate documentation for the version of lrpar you are using here:
+
+| Latest release                          | master |
+|-----------------------------------------|--------|
+| [Quickstart guide](https://softdevteam.github.io/grmtools/latest_release/book/quickstart.html) | [Quickstart guide](https://softdevteam.github.io/grmtools/master/book/quickstart.html) |
+| [grmtools book](https://softdevteam.github.io/grmtools/latest_release/book/) | [grmtools book](https://softdevteam.github.io/grmtools/master/book) |
+| [lrpar API](https://docs.rs/lrpar/)         | [lrpar API](https://softdevteam.github.io/grmtools/master/api/lrpar/)         |
+
+[Documentation for all past and present releases](https://softdevteam.github.io/grmtools/)
 
 
 ## Example


### PR DESCRIPTION
You can see the preview rendering of this change at https://github.com/ltratt/grmtools/tree/more_doc_links/lrpar.