### PR TITLE
appease clippy --all-targets

### DIFF
--- a/cfgrammar/src/lib/yacc/firsts.rs
+++ b/cfgrammar/src/lib/yacc/firsts.rs
@@ -158,10 +158,7 @@ mod test {
     {
         let ridx = grm.rule_idx(rn).unwrap();
         for tidx in grm.iter_tidxs() {
-            let n = match grm.token_name(tidx) {
-                Some(n) => n,
-                None => &"<no name>",
-            };
+            let n = grm.token_name(tidx).unwrap_or("<no name>");
             match should_be.iter().position(|&x| x == n) {
                 Some(_) => {
                     if !firsts.is_set(ridx, tidx) {
@@ -184,7 +181,7 @@ mod test {
     fn test_first() {
         let grm = YaccGrammar::new(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &"
+            "
           %start C
           %token c d
           %%
@@ -206,7 +203,7 @@ mod test {
     fn test_first_no_subsequent_rules() {
         let grm = YaccGrammar::new(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &"
+            "
           %start C
           %token c d
           %%
@@ -224,7 +221,7 @@ mod test {
     fn test_first_epsilon() {
         let grm = YaccGrammar::new(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &"
+            "
           %start A
           %token a b c
           %%
@@ -245,7 +242,7 @@ mod test {
     fn test_last_epsilon() {
         let grm = YaccGrammar::new(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &"
+            "
           %start A
           %token b c
           %%
@@ -265,7 +262,7 @@ mod test {
     fn test_first_no_multiples() {
         let grm = YaccGrammar::new(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &"
+            "
           %start A
           %token b c
           %%
@@ -281,7 +278,7 @@ mod test {
     fn eco_grammar() -> YaccGrammar {
         YaccGrammar::new(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &"
+            "
           %start S
           %token a b c d f
           %%
@@ -312,7 +309,7 @@ mod test {
     fn test_first_from_eco_bug() {
         let grm = YaccGrammar::new(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &"
+            "
           %start E
           %token a b c d e f
           %%

--- a/cfgrammar/src/lib/yacc/follows.rs
+++ b/cfgrammar/src/lib/yacc/follows.rs
@@ -135,7 +135,7 @@ mod test {
             } else {
                 grm.token_name(tidx).unwrap_or("<no name>")
             };
-            if should_be.iter().find(|&x| x == &n).is_none() {
+            if !should_be.iter().any(|x| x == &n) {
                 if follows.is_set(ridx, tidx) {
                     panic!("{} is incorrectly set in {}", n, rn);
                 }
@@ -150,7 +150,7 @@ mod test {
         // Adapted from p2 of https://www.cs.uaf.edu/~cs331/notes/FirstFollow.pdf
         let grm = YaccGrammar::new(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &"
+            "
                 %start E
                 %%
                 E: T E2 ;
@@ -174,7 +174,7 @@ mod test {
         // Adapted from https://www.l2f.inesc-id.pt/~david/w/pt/Top-Down_Parsing/Exercise_5:_Test_2010/07/01
         let grm = YaccGrammar::new(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &"
+            "
                 %start A
                 %%
                 A : 't' B2 D | 'v' D2 ;
@@ -197,7 +197,7 @@ mod test {
     fn test_follow3() {
         let grm = YaccGrammar::new(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &"
+            "
                 %start S
                 %%
                 S: A 'b';
@@ -214,7 +214,7 @@ mod test {
     fn test_follow_corchuelo() {
         let grm = YaccGrammar::new(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &"
+            "
                 %start E
                 %%
                 E : 'N'

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -1238,9 +1238,9 @@ mod test {
         let itfs_prod1 = &grm.prods[usize::from(grm.rules_prods[usize::from(itfs_rule_idx)][0])];
         assert_eq!(itfs_prod1.len(), 2);
         assert_eq!(itfs_prod1[0], Symbol::Rule(grm.rule_idx(IMPLICIT_RULE).unwrap()));
-        assert_eq!(itfs_prod1[1], Symbol::Rule(grm.rule_idx(&"S").unwrap()));
+        assert_eq!(itfs_prod1[1], Symbol::Rule(grm.rule_idx("S").unwrap()));
 
-        let s_rule_idx = grm.rule_idx(&"S").unwrap();
+        let s_rule_idx = grm.rule_idx("S").unwrap();
         assert_eq!(grm.rules_prods[usize::from(s_rule_idx)].len(), 2);
 
         let s_prod1 = &grm.prods[usize::from(grm.rules_prods[usize::from(s_rule_idx)][0])];
@@ -1252,7 +1252,7 @@ mod test {
         assert_eq!(s_prod2.len(), 1);
         assert_eq!(s_prod2[0], Symbol::Rule(grm.rule_idx("T").unwrap()));
 
-        let t_rule_idx = grm.rule_idx(&"T").unwrap();
+        let t_rule_idx = grm.rule_idx("T").unwrap();
         assert_eq!(grm.rules_prods[usize::from(s_rule_idx)].len(), 2);
 
         let t_prod1 = &grm.prods[usize::from(grm.rules_prods[usize::from(t_rule_idx)][0])];
@@ -1299,9 +1299,9 @@ mod test {
           "
         ).unwrap();
 
-        let a_ridx = grm.rule_idx(&"A").unwrap();
-        let b_ridx = grm.rule_idx(&"B").unwrap();
-        let c_ridx = grm.rule_idx(&"C").unwrap();
+        let a_ridx = grm.rule_idx("A").unwrap();
+        let b_ridx = grm.rule_idx("B").unwrap();
+        let c_ridx = grm.rule_idx("C").unwrap();
         assert!(grm.has_path(a_ridx, b_ridx));
         assert!(grm.has_path(a_ridx, c_ridx));
         assert!(grm.has_path(b_ridx, b_ridx));
@@ -1329,11 +1329,11 @@ mod test {
         ).unwrap();
 
         let scores = rule_min_costs(&grm, &[1, 1, 1]);
-        assert_eq!(scores[usize::from(grm.rule_idx(&"A").unwrap())], 0);
-        assert_eq!(scores[usize::from(grm.rule_idx(&"B").unwrap())], 1);
-        assert_eq!(scores[usize::from(grm.rule_idx(&"C").unwrap())], 1);
-        assert_eq!(scores[usize::from(grm.rule_idx(&"D").unwrap())], 2);
-        assert_eq!(scores[usize::from(grm.rule_idx(&"E").unwrap())], 1);
+        assert_eq!(scores[usize::from(grm.rule_idx("A").unwrap())], 0);
+        assert_eq!(scores[usize::from(grm.rule_idx("B").unwrap())], 1);
+        assert_eq!(scores[usize::from(grm.rule_idx("C").unwrap())], 1);
+        assert_eq!(scores[usize::from(grm.rule_idx("D").unwrap())], 2);
+        assert_eq!(scores[usize::from(grm.rule_idx("E").unwrap())], 1);
     }
 
     #[test]

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -1229,7 +1229,7 @@ x"
         for src in srcs.iter() {
             match parse(
                 YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-                &src.to_string(),
+                src,
             ) {
                 Ok(_) => panic!("Duplicate precedence parsed"),
                 Err(YaccParserError {
@@ -1257,7 +1257,7 @@ x"
                  | '-'  expr %prec '*'
                  | NAME ;
         ";
-        let grm = parse(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), &src).unwrap();
+        let grm = parse(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), src).unwrap();
         assert_eq!(grm.precs.len(), 4);
         assert_eq!(grm.prods[grm.rules["expr"].pidxs[0]].precedence, None);
         assert_eq!(grm.prods[grm.rules["expr"].pidxs[3]].symbols.len(), 3);
@@ -1269,7 +1269,7 @@ x"
     fn test_bad_prec_overrides() {
         match parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &"
+            "
           %%
           S: 'A' %prec ;
           ",
@@ -1285,7 +1285,7 @@ x"
 
         match parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &"
+            "
           %%
           S: 'A' %prec B;
           B: ;
@@ -1305,7 +1305,7 @@ x"
     fn test_parse_avoid_insert() {
         let ast = parse(
             YaccKind::Eco,
-            &"
+            "
           %avoid_insert ws1 ws2
           %start R
           %%
@@ -1330,7 +1330,7 @@ x"
     fn test_multiple_avoid_insert() {
         let ast = parse(
             YaccKind::Eco,
-            &"
+            "
           %avoid_insert X
           %avoid_insert Y
           %%
@@ -1347,7 +1347,7 @@ x"
     fn test_duplicate_avoid_insert() {
         match parse(
             YaccKind::Eco,
-            &"
+            "
           %avoid_insert X Y
           %avoid_insert Y
           %%
@@ -1367,7 +1367,7 @@ x"
     fn test_duplicate_avoid_insert2() {
         match parse(
             YaccKind::Eco,
-            &"
+            "
           %avoid_insert X
           %avoid_insert Y Y
           %%
@@ -1387,7 +1387,7 @@ x"
     fn test_no_implicit_tokens_in_original_yacc() {
         match parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &"
+            "
           %implicit_tokens X
           %%
           ",
@@ -1406,7 +1406,7 @@ x"
     fn test_parse_implicit_tokens() {
         let ast = parse(
             YaccKind::Eco,
-            &"
+            "
           %implicit_tokens ws1 ws2
           %start R
           %%
@@ -1431,7 +1431,7 @@ x"
     fn test_multiple_implicit_tokens() {
         let ast = parse(
             YaccKind::Eco,
-            &"
+            "
           %implicit_tokens X
           %implicit_tokens Y
           %%
@@ -1448,7 +1448,7 @@ x"
     fn test_duplicate_implicit_tokens() {
         match parse(
             YaccKind::Eco,
-            &"
+            "
           %implicit_tokens X
           %implicit_tokens X Y
           %%
@@ -1468,7 +1468,7 @@ x"
     fn test_duplicate_implicit_tokens2() {
         match parse(
             YaccKind::Eco,
-            &"
+            "
           %implicit_tokens X X
           %implicit_tokens Y
           %%
@@ -1488,7 +1488,7 @@ x"
     fn test_parse_epp() {
         let ast = parse(
             YaccKind::Eco,
-            &"
+            "
           %epp A \"a\"
           %epp B 'a'
           %epp C '\"'
@@ -1515,7 +1515,7 @@ x"
     fn test_duplicate_epp() {
         match parse(
             YaccKind::Eco,
-            &"
+            "
           %epp A \"a\"
           %epp A \"a\"
           %%
@@ -1535,7 +1535,7 @@ x"
     fn test_broken_string() {
         match parse(
             YaccKind::Eco,
-            &"
+            "
           %epp A \"a
           %%
           ",
@@ -1551,7 +1551,7 @@ x"
 
         match parse(
             YaccKind::Eco,
-            &"
+            "
           %epp A \"a",
         ) {
             Ok(_) => panic!(),
@@ -1568,7 +1568,7 @@ x"
     fn test_duplicate_start() {
         match parse(
             YaccKind::Eco,
-            &"
+            "
           %start X
           %start X
           %%
@@ -1588,7 +1588,7 @@ x"
     fn test_implicit_start() {
         let ast = parse(
             YaccKind::Eco,
-            &"
+            "
           %%
           R: ;
           R2: ;
@@ -1603,7 +1603,7 @@ x"
     fn test_action() {
         let grm = parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &"
+            "
           %%
           A: 'a' B { println!(\"test\"); }
            ;
@@ -1628,7 +1628,7 @@ x"
     fn test_programs() {
         let grm = parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &"
+            "
          %%
          A: 'a';
          %%
@@ -1642,7 +1642,7 @@ x"
     fn test_actions_with_newlines() {
         match parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &"
+            "
          %%
          A: 'a' { foo();
                   bar(); }
@@ -1672,7 +1672,7 @@ x"
 
         match parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &"
+            "
             /* An invalid comment * /
             %token   a
             %%\n
@@ -1689,7 +1689,7 @@ x"
 
         match parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &"
+            "
             %token   a
             %%
             /* A valid
@@ -1709,7 +1709,7 @@ x"
 
         match parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &"
+            "
             %token   a
             %%
             // Valid comment
@@ -1729,7 +1729,7 @@ x"
     fn test_action_type() {
         let grm = parse(
             YaccKind::Original(YaccOriginalActionKind::UserAction),
-            &"
+            "
          %actiontype T
          %%
          A: 'a';
@@ -1744,7 +1744,7 @@ x"
     fn test_only_one_type() {
         match parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &"
+            "
          %actiontype T1
          %actiontype T2
          %%
@@ -1767,7 +1767,7 @@ x"
           %%
           A: 'a';
          ";
-        let grm = parse(YaccKind::Original(YaccOriginalActionKind::UserAction), &src).unwrap();
+        let grm = parse(YaccKind::Original(YaccOriginalActionKind::UserAction), src).unwrap();
 
         assert_eq!(
             grm.parse_param,

--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -412,7 +412,7 @@ mod test {
         assert_eq!(lexerdef.set_rule_ids(&map), (None, None));
 
         let lexemes = lexerdef
-            .lexer(&"abc 123")
+            .lexer("abc 123")
             .iter()
             .map(|x| x.unwrap())
             .collect::<Vec<_>>();
@@ -435,7 +435,7 @@ mod test {
         "
         .to_string();
         let lexerdef = LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).unwrap();
-        match lexerdef.lexer(&"abc").iter().next().unwrap() {
+        match lexerdef.lexer("abc").iter().next().unwrap() {
             Ok(_) => panic!("Invalid input lexed"),
             Err(e) => {
                 if e.span().start() != 0 || e.span().end() != 0 {
@@ -459,7 +459,7 @@ if 'IF'
         assert_eq!(lexerdef.set_rule_ids(&map), (None, None));
 
         let lexemes = lexerdef
-            .lexer(&"iff if")
+            .lexer("iff if")
             .iter()
             .map(|x| x.unwrap())
             .collect::<Vec<DefaultLexeme<u8>>>();
@@ -631,7 +631,7 @@ if 'IF'
             (Some(missing_from_lexer), Some(missing_from_parser))
         );
 
-        match lexerdef.lexer(&" a ").iter().next().unwrap() {
+        match lexerdef.lexer(" a ").iter().next().unwrap() {
             Ok(_) => panic!("Invalid input lexed"),
             Err(e) => {
                 if e.span().start() != 1 || e.span().end() != 1 {

--- a/lrpar/cttests/src/lib.rs
+++ b/lrpar/cttests/src/lib.rs
@@ -115,7 +115,7 @@ fn test_input_lifetime() {
     let lexerdef = lexer_lifetime_l::lexerdef();
     let input = "a";
     let _ = {
-        let lexer = lexerdef.lexer(&input);
+        let lexer = lexerdef.lexer(input);
         let lx = lexer.iter().next().unwrap().unwrap();
         lexer.span_str(lx.span())
     };
@@ -126,6 +126,7 @@ fn test_lexer_lifetime() {
     // This test only exists to make sure that this code compiles: there's no need for us to
     // actually run anything.
 
+    #[allow(clippy::needless_lifetimes)]
     pub(crate) fn parse_data<'a>(input: &'a str) -> Option<&'a str> {
         let lexer_def = crate::lexer_lifetime_l::lexerdef();
         let l = lexer_def.lexer(input);
@@ -151,10 +152,7 @@ fn test_span() {
                     Span::new(2, 3),
                     Span::new(2, 3),
                     Span::new(0, 3),
-                ] =>
-        {
-            ()
-        }
+                ] => {}
         _ => unreachable!(),
     }
 
@@ -169,10 +167,7 @@ fn test_span() {
                     Span::new(4, 5),
                     Span::new(4, 5),
                     Span::new(0, 5),
-                ] =>
-        {
-            ()
-        }
+                ] => {}
         _ => unreachable!(),
     }
 
@@ -189,10 +184,7 @@ fn test_span() {
                     Span::new(4, 5),
                     Span::new(2, 5),
                     Span::new(0, 5),
-                ] =>
-        {
-            ()
-        }
+                ] => {}
         _ => unreachable!(),
     }
 
@@ -207,10 +199,7 @@ fn test_span() {
                     Span::new(3, 4),
                     Span::new(3, 4),
                     Span::new(0, 4),
-                ] =>
-        {
-            ()
-        }
+                ] => {}
         _ => unreachable!(),
     }
 
@@ -225,10 +214,7 @@ fn test_span() {
                     Span::new(0, 3),
                     Span::new(0, 3),
                     Span::new(0, 3),
-                ] =>
-        {
-            ()
-        }
+                ] => {}
         _ => unreachable!(),
     }
 }

--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -670,14 +670,13 @@ mod test {
                     expected
                 );
                 for i in 0..e.repairs().len() {
-                    if expected
+                    if !expected
                         .iter()
-                        .find(|x| **x == pp_repairs(&grm, &e.repairs()[i]))
-                        .is_none()
+                        .any(|x| *x == pp_repairs(grm, &e.repairs()[i]))
                     {
                         panic!(
                             "No match found for:\n  {}",
-                            pp_repairs(&grm, &e.repairs()[i])
+                            pp_repairs(grm, &e.repairs()[i])
                         );
                     }
                 }
@@ -702,7 +701,7 @@ E : 'N'
 ";
 
         let us = "(nn";
-        let (grm, pr) = do_parse(RecoveryKind::CPCTPlus, &lexs, &grms, us);
+        let (grm, pr) = do_parse(RecoveryKind::CPCTPlus, lexs, grms, us);
         let (pt, errs) = pr.unwrap_err();
         let pp = pt.unwrap().pp(&grm, us);
         // Note that:
@@ -757,13 +756,13 @@ E : 'N'
             ],
         );
 
-        let (grm, pr) = do_parse(RecoveryKind::CPCTPlus, &lexs, &grms, "n)+n+n+n)");
+        let (grm, pr) = do_parse(RecoveryKind::CPCTPlus, lexs, grms, "n)+n+n+n)");
         let (_, errs) = pr.unwrap_err();
         assert_eq!(errs.len(), 2);
         check_all_repairs(&grm, &errs[0], &["Delete"]);
         check_all_repairs(&grm, &errs[1], &["Delete"]);
 
-        let (grm, pr) = do_parse(RecoveryKind::CPCTPlus, &lexs, &grms, "(((+n)+n+n+n)");
+        let (grm, pr) = do_parse(RecoveryKind::CPCTPlus, lexs, grms, "(((+n)+n+n+n)");
         let (_, errs) = pr.unwrap_err();
         assert_eq!(errs.len(), 2);
         check_all_repairs(&grm, &errs[0], &["Insert \"N\"", "Delete"]);
@@ -787,7 +786,7 @@ U: 'd';
 ";
 
         let us = "";
-        let (grm, pr) = do_parse(RecoveryKind::CPCTPlus, &lexs, &grms, &us);
+        let (grm, pr) = do_parse(RecoveryKind::CPCTPlus, lexs, grms, us);
         let (_, errs) = pr.unwrap_err();
         check_all_repairs(
             &grm,

--- a/lrtable/src/lib/itemset.rs
+++ b/lrtable/src/lib/itemset.rs
@@ -170,9 +170,9 @@ mod test {
     #[rustfmt::skip]
     fn test_dragon_grammar() {
         // From http://binarysculpting.com/2012/02/04/computing-lr1-closure/
-        let grm = &YaccGrammar::new(
+        let grm = YaccGrammar::new(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &"
+            "
           %start S
           %%
           S: L '=' R | R;
@@ -200,7 +200,7 @@ mod test {
     fn eco_grammar() -> YaccGrammar {
         YaccGrammar::new(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &"
+            "
           %start S
           %token a b c d f
           %%
@@ -251,7 +251,7 @@ mod test {
     fn grammar3() -> YaccGrammar {
         YaccGrammar::new(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &"
+            "
           %start S
           %token a b c d
           %%

--- a/lrtable/src/lib/pager.rs
+++ b/lrtable/src/lib/pager.rs
@@ -426,7 +426,7 @@ mod test {
     fn grammar3() -> YaccGrammar {
         YaccGrammar::new(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &"
+            "
           %start S
           %token a b c d
           %%
@@ -447,65 +447,65 @@ mod test {
         assert_eq!(sg.all_edges_len(), 10);
 
         assert_eq!(sg.closed_state(sg.start_state()).items.len(), 3);
-        state_exists(&grm, &sg.closed_state(sg.start_state()), "^", 0, SIdx(0), vec!["$"]);
-        state_exists(&grm, &sg.closed_state(sg.start_state()), "S", 0, SIdx(0), vec!["$", "b"]);
-        state_exists(&grm, &sg.closed_state(sg.start_state()), "S", 1, SIdx(0), vec!["$", "b"]);
+        state_exists(&grm, sg.closed_state(sg.start_state()), "^", 0, SIdx(0), vec!["$"]);
+        state_exists(&grm, sg.closed_state(sg.start_state()), "S", 0, SIdx(0), vec!["$", "b"]);
+        state_exists(&grm, sg.closed_state(sg.start_state()), "S", 1, SIdx(0), vec!["$", "b"]);
 
         let s1 = sg.edge(sg.start_state(), Symbol::Rule(grm.rule_idx("S").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s1).items.len(), 2);
-        state_exists(&grm, &sg.closed_state(s1), "^", 0, SIdx(1), vec!["$"]);
-        state_exists(&grm, &sg.closed_state(s1), "S", 0, SIdx(1), vec!["$", "b"]);
+        state_exists(&grm, sg.closed_state(s1), "^", 0, SIdx(1), vec!["$"]);
+        state_exists(&grm, sg.closed_state(s1), "S", 0, SIdx(1), vec!["$", "b"]);
 
         let s2 = sg.edge(s1, Symbol::Token(grm.token_idx("b").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s2).items.len(), 1);
-        state_exists(&grm, &sg.closed_state(s2), "S", 0, SIdx(2), vec!["$", "b"]);
+        state_exists(&grm, sg.closed_state(s2), "S", 0, SIdx(2), vec!["$", "b"]);
 
         let s3 = sg.edge(sg.start_state(), Symbol::Token(grm.token_idx("b").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s3).items.len(), 4);
-        state_exists(&grm, &sg.closed_state(s3), "S", 1, SIdx(1), vec!["$", "b", "c"]);
-        state_exists(&grm, &sg.closed_state(s3), "A", 0, SIdx(0), vec!["a"]);
-        state_exists(&grm, &sg.closed_state(s3), "A", 1, SIdx(0), vec!["a"]);
-        state_exists(&grm, &sg.closed_state(s3), "A", 2, SIdx(0), vec!["a"]);
+        state_exists(&grm, sg.closed_state(s3), "S", 1, SIdx(1), vec!["$", "b", "c"]);
+        state_exists(&grm, sg.closed_state(s3), "A", 0, SIdx(0), vec!["a"]);
+        state_exists(&grm, sg.closed_state(s3), "A", 1, SIdx(0), vec!["a"]);
+        state_exists(&grm, sg.closed_state(s3), "A", 2, SIdx(0), vec!["a"]);
 
         let s4 = sg.edge(s3, Symbol::Rule(grm.rule_idx("A").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s4).items.len(), 1);
-        state_exists(&grm, &sg.closed_state(s4), "S", 1, SIdx(2), vec!["$", "b", "c"]);
+        state_exists(&grm, sg.closed_state(s4), "S", 1, SIdx(2), vec!["$", "b", "c"]);
 
         let s5 = sg.edge(s4, Symbol::Token(grm.token_idx("a").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s5).items.len(), 1);
-        state_exists(&grm, &sg.closed_state(s5), "S", 1, SIdx(3), vec!["$", "b", "c"]);
+        state_exists(&grm, sg.closed_state(s5), "S", 1, SIdx(3), vec!["$", "b", "c"]);
 
         let s6 = sg.edge(s3, Symbol::Token(grm.token_idx("a").unwrap())).unwrap();
         // result from merging 10 into 3
         assert_eq!(s3, sg.edge(s6, Symbol::Token(grm.token_idx("b").unwrap())).unwrap());
         assert_eq!(sg.closed_state(s6).items.len(), 5);
-        state_exists(&grm, &sg.closed_state(s6), "A", 0, SIdx(1), vec!["a"]);
-        state_exists(&grm, &sg.closed_state(s6), "A", 1, SIdx(1), vec!["a"]);
-        state_exists(&grm, &sg.closed_state(s6), "A", 2, SIdx(1), vec!["a"]);
-        state_exists(&grm, &sg.closed_state(s6), "S", 0, SIdx(0), vec!["b", "c"]);
-        state_exists(&grm, &sg.closed_state(s6), "S", 1, SIdx(0), vec!["b", "c"]);
+        state_exists(&grm, sg.closed_state(s6), "A", 0, SIdx(1), vec!["a"]);
+        state_exists(&grm, sg.closed_state(s6), "A", 1, SIdx(1), vec!["a"]);
+        state_exists(&grm, sg.closed_state(s6), "A", 2, SIdx(1), vec!["a"]);
+        state_exists(&grm, sg.closed_state(s6), "S", 0, SIdx(0), vec!["b", "c"]);
+        state_exists(&grm, sg.closed_state(s6), "S", 1, SIdx(0), vec!["b", "c"]);
 
         let s7 = sg.edge(s6, Symbol::Rule(grm.rule_idx("S").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s7).items.len(), 3);
-        state_exists(&grm, &sg.closed_state(s7), "A", 0, SIdx(2), vec!["a"]);
-        state_exists(&grm, &sg.closed_state(s7), "A", 2, SIdx(2), vec!["a"]);
-        state_exists(&grm, &sg.closed_state(s7), "S", 0, SIdx(1), vec!["b", "c"]);
+        state_exists(&grm, sg.closed_state(s7), "A", 0, SIdx(2), vec!["a"]);
+        state_exists(&grm, sg.closed_state(s7), "A", 2, SIdx(2), vec!["a"]);
+        state_exists(&grm, sg.closed_state(s7), "S", 0, SIdx(1), vec!["b", "c"]);
 
         let s8 = sg.edge(s7, Symbol::Token(grm.token_idx("c").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s8).items.len(), 1);
-        state_exists(&grm, &sg.closed_state(s8), "A", 0, SIdx(3), vec!["a"]);
+        state_exists(&grm, sg.closed_state(s8), "A", 0, SIdx(3), vec!["a"]);
 
         let s9 = sg.edge(s7, Symbol::Token(grm.token_idx("b").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s9).items.len(), 2);
-        state_exists(&grm, &sg.closed_state(s9), "A", 2, SIdx(3), vec!["a"]);
-        state_exists(&grm, &sg.closed_state(s9), "S", 0, SIdx(2), vec!["b", "c"]);
+        state_exists(&grm, sg.closed_state(s9), "A", 2, SIdx(3), vec!["a"]);
+        state_exists(&grm, sg.closed_state(s9), "S", 0, SIdx(2), vec!["b", "c"]);
     }
 
     // Pager grammar
     fn grammar_pager() -> YaccGrammar {
         YaccGrammar::new(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &"
+            "
             %start X
             %%
              X : 'a' Y 'd' | 'a' Z 'c' | 'a' T | 'b' Y 'e' | 'b' Z 'd' | 'b' T;
@@ -521,136 +521,136 @@ mod test {
 
     #[rustfmt::skip]
     fn test_pager_graph(grm: &YaccGrammar) {
-        let sg = pager_stategraph(&grm);
+        let sg = pager_stategraph(grm);
 
         assert_eq!(sg.all_states_len(), StIdx(23));
         assert_eq!(sg.all_edges_len(), 27);
 
         // State 0
         assert_eq!(sg.closed_state(sg.start_state()).items.len(), 7);
-        state_exists(&grm, &sg.closed_state(sg.start_state()), "^", 0, SIdx(0), vec!["$"]);
-        state_exists(&grm, &sg.closed_state(sg.start_state()), "X", 0, SIdx(0), vec!["$"]);
-        state_exists(&grm, &sg.closed_state(sg.start_state()), "X", 1, SIdx(0), vec!["$"]);
-        state_exists(&grm, &sg.closed_state(sg.start_state()), "X", 2, SIdx(0), vec!["$"]);
-        state_exists(&grm, &sg.closed_state(sg.start_state()), "X", 3, SIdx(0), vec!["$"]);
-        state_exists(&grm, &sg.closed_state(sg.start_state()), "X", 4, SIdx(0), vec!["$"]);
-        state_exists(&grm, &sg.closed_state(sg.start_state()), "X", 5, SIdx(0), vec!["$"]);
+        state_exists(grm, sg.closed_state(sg.start_state()), "^", 0, SIdx(0), vec!["$"]);
+        state_exists(grm, sg.closed_state(sg.start_state()), "X", 0, SIdx(0), vec!["$"]);
+        state_exists(grm, sg.closed_state(sg.start_state()), "X", 1, SIdx(0), vec!["$"]);
+        state_exists(grm, sg.closed_state(sg.start_state()), "X", 2, SIdx(0), vec!["$"]);
+        state_exists(grm, sg.closed_state(sg.start_state()), "X", 3, SIdx(0), vec!["$"]);
+        state_exists(grm, sg.closed_state(sg.start_state()), "X", 4, SIdx(0), vec!["$"]);
+        state_exists(grm, sg.closed_state(sg.start_state()), "X", 5, SIdx(0), vec!["$"]);
 
         let s1 = sg.edge(sg.start_state(), Symbol::Token(grm.token_idx("a").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s1).items.len(), 7);
-        state_exists(&grm, &sg.closed_state(s1), "X", 0, SIdx(1), vec!["a", "d", "e", "$"]);
-        state_exists(&grm, &sg.closed_state(s1), "X", 1, SIdx(1), vec!["a", "d", "e", "$"]);
-        state_exists(&grm, &sg.closed_state(s1), "X", 2, SIdx(1), vec!["a", "d", "e", "$"]);
-        state_exists(&grm, &sg.closed_state(s1), "Y", 0, SIdx(0), vec!["d"]);
-        state_exists(&grm, &sg.closed_state(s1), "Y", 1, SIdx(0), vec!["d"]);
-        state_exists(&grm, &sg.closed_state(s1), "Z", 0, SIdx(0), vec!["c"]);
-        state_exists(&grm, &sg.closed_state(s1), "T", 0, SIdx(0), vec!["a", "d", "e", "$"]);
+        state_exists(grm, sg.closed_state(s1), "X", 0, SIdx(1), vec!["a", "d", "e", "$"]);
+        state_exists(grm, sg.closed_state(s1), "X", 1, SIdx(1), vec!["a", "d", "e", "$"]);
+        state_exists(grm, sg.closed_state(s1), "X", 2, SIdx(1), vec!["a", "d", "e", "$"]);
+        state_exists(grm, sg.closed_state(s1), "Y", 0, SIdx(0), vec!["d"]);
+        state_exists(grm, sg.closed_state(s1), "Y", 1, SIdx(0), vec!["d"]);
+        state_exists(grm, sg.closed_state(s1), "Z", 0, SIdx(0), vec!["c"]);
+        state_exists(grm, sg.closed_state(s1), "T", 0, SIdx(0), vec!["a", "d", "e", "$"]);
 
         let s7 = sg.edge(sg.start_state(), Symbol::Token(grm.token_idx("b").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s7).items.len(), 7);
-        state_exists(&grm, &sg.closed_state(s7), "X", 3, SIdx(1), vec!["a", "d", "e", "$"]);
-        state_exists(&grm, &sg.closed_state(s7), "X", 4, SIdx(1), vec!["a", "d", "e", "$"]);
-        state_exists(&grm, &sg.closed_state(s7), "X", 5, SIdx(1), vec!["a", "d", "e", "$"]);
-        state_exists(&grm, &sg.closed_state(s1), "Y", 0, SIdx(0), vec!["d"]);
-        state_exists(&grm, &sg.closed_state(s1), "Y", 1, SIdx(0), vec!["d"]);
-        state_exists(&grm, &sg.closed_state(s1), "Z", 0, SIdx(0), vec!["c"]);
-        state_exists(&grm, &sg.closed_state(s1), "T", 0, SIdx(0), vec!["a", "d", "e", "$"]);
+        state_exists(grm, sg.closed_state(s7), "X", 3, SIdx(1), vec!["a", "d", "e", "$"]);
+        state_exists(grm, sg.closed_state(s7), "X", 4, SIdx(1), vec!["a", "d", "e", "$"]);
+        state_exists(grm, sg.closed_state(s7), "X", 5, SIdx(1), vec!["a", "d", "e", "$"]);
+        state_exists(grm, sg.closed_state(s1), "Y", 0, SIdx(0), vec!["d"]);
+        state_exists(grm, sg.closed_state(s1), "Y", 1, SIdx(0), vec!["d"]);
+        state_exists(grm, sg.closed_state(s1), "Z", 0, SIdx(0), vec!["c"]);
+        state_exists(grm, sg.closed_state(s1), "T", 0, SIdx(0), vec!["a", "d", "e", "$"]);
 
         let s4 = sg.edge(s1, Symbol::Token(grm.token_idx("u").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s4).items.len(), 8);
         assert_eq!(s4, sg.edge(s7, Symbol::Token(grm.token_idx("u").unwrap())).unwrap());
-        state_exists(&grm, &sg.closed_state(s4), "Y", 1, SIdx(1), vec!["d", "e"]);
-        state_exists(&grm, &sg.closed_state(s4), "T", 0, SIdx(1), vec!["a", "d", "e", "$"]);
-        state_exists(&grm, &sg.closed_state(s4), "X", 0, SIdx(0), vec!["a", "d", "e"]);
-        state_exists(&grm, &sg.closed_state(s4), "X", 1, SIdx(0), vec!["a", "d", "e"]);
-        state_exists(&grm, &sg.closed_state(s4), "X", 2, SIdx(0), vec!["a", "d", "e"]);
-        state_exists(&grm, &sg.closed_state(s4), "X", 3, SIdx(0), vec!["a", "d", "e"]);
-        state_exists(&grm, &sg.closed_state(s4), "X", 4, SIdx(0), vec!["a", "d", "e"]);
-        state_exists(&grm, &sg.closed_state(s4), "X", 5, SIdx(0), vec!["a", "d", "e"]);
+        state_exists(grm, sg.closed_state(s4), "Y", 1, SIdx(1), vec!["d", "e"]);
+        state_exists(grm, sg.closed_state(s4), "T", 0, SIdx(1), vec!["a", "d", "e", "$"]);
+        state_exists(grm, sg.closed_state(s4), "X", 0, SIdx(0), vec!["a", "d", "e"]);
+        state_exists(grm, sg.closed_state(s4), "X", 1, SIdx(0), vec!["a", "d", "e"]);
+        state_exists(grm, sg.closed_state(s4), "X", 2, SIdx(0), vec!["a", "d", "e"]);
+        state_exists(grm, sg.closed_state(s4), "X", 3, SIdx(0), vec!["a", "d", "e"]);
+        state_exists(grm, sg.closed_state(s4), "X", 4, SIdx(0), vec!["a", "d", "e"]);
+        state_exists(grm, sg.closed_state(s4), "X", 5, SIdx(0), vec!["a", "d", "e"]);
 
         assert_eq!(s1, sg.edge(s4, Symbol::Token(grm.token_idx("a").unwrap())).unwrap());
         assert_eq!(s7, sg.edge(s4, Symbol::Token(grm.token_idx("b").unwrap())).unwrap());
 
         let s2 = sg.edge(s1, Symbol::Token(grm.token_idx("t").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s2).items.len(), 3);
-        state_exists(&grm, &sg.closed_state(s2), "Y", 0, SIdx(1), vec!["d"]);
-        state_exists(&grm, &sg.closed_state(s2), "Z", 0, SIdx(1), vec!["c"]);
-        state_exists(&grm, &sg.closed_state(s2), "W", 0, SIdx(0), vec!["d"]);
+        state_exists(grm, sg.closed_state(s2), "Y", 0, SIdx(1), vec!["d"]);
+        state_exists(grm, sg.closed_state(s2), "Z", 0, SIdx(1), vec!["c"]);
+        state_exists(grm, sg.closed_state(s2), "W", 0, SIdx(0), vec!["d"]);
 
         let s3 = sg.edge(s2, Symbol::Token(grm.token_idx("u").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s3).items.len(), 3);
-        state_exists(&grm, &sg.closed_state(s3), "Z", 0, SIdx(2), vec!["c"]);
-        state_exists(&grm, &sg.closed_state(s3), "W", 0, SIdx(1), vec!["d"]);
-        state_exists(&grm, &sg.closed_state(s3), "V", 0, SIdx(0), vec!["d"]);
+        state_exists(grm, sg.closed_state(s3), "Z", 0, SIdx(2), vec!["c"]);
+        state_exists(grm, sg.closed_state(s3), "W", 0, SIdx(1), vec!["d"]);
+        state_exists(grm, sg.closed_state(s3), "V", 0, SIdx(0), vec!["d"]);
 
         let s5 = sg.edge(s4, Symbol::Rule(grm.rule_idx("X").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s5).items.len(), 2);
-        state_exists(&grm, &sg.closed_state(s5), "Y", 1, SIdx(2), vec!["d", "e"]);
-        state_exists(&grm, &sg.closed_state(s5), "T", 0, SIdx(2), vec!["a", "d", "e", "$"]);
+        state_exists(grm, sg.closed_state(s5), "Y", 1, SIdx(2), vec!["d", "e"]);
+        state_exists(grm, sg.closed_state(s5), "T", 0, SIdx(2), vec!["a", "d", "e", "$"]);
 
         let s6 = sg.edge(s5, Symbol::Token(grm.token_idx("a").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s6).items.len(), 1);
-        state_exists(&grm, &sg.closed_state(s6), "T", 0, SIdx(3), vec!["a", "d", "e", "$"]);
+        state_exists(grm, sg.closed_state(s6), "T", 0, SIdx(3), vec!["a", "d", "e", "$"]);
 
         let s8 = sg.edge(s7, Symbol::Token(grm.token_idx("t").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s8).items.len(), 3);
-        state_exists(&grm, &sg.closed_state(s8), "Y", 0, SIdx(1), vec!["e"]);
-        state_exists(&grm, &sg.closed_state(s8), "Z", 0, SIdx(1), vec!["d"]);
-        state_exists(&grm, &sg.closed_state(s8), "W", 0, SIdx(0), vec!["e"]);
+        state_exists(grm, sg.closed_state(s8), "Y", 0, SIdx(1), vec!["e"]);
+        state_exists(grm, sg.closed_state(s8), "Z", 0, SIdx(1), vec!["d"]);
+        state_exists(grm, sg.closed_state(s8), "W", 0, SIdx(0), vec!["e"]);
 
         let s9 = sg.edge(s8, Symbol::Token(grm.token_idx("u").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s9).items.len(), 3);
-        state_exists(&grm, &sg.closed_state(s9), "Z", 0, SIdx(2), vec!["d"]);
-        state_exists(&grm, &sg.closed_state(s9), "W", 0, SIdx(1), vec!["e"]);
-        state_exists(&grm, &sg.closed_state(s3), "V", 0, SIdx(0), vec!["d"]);
+        state_exists(grm, sg.closed_state(s9), "Z", 0, SIdx(2), vec!["d"]);
+        state_exists(grm, sg.closed_state(s9), "W", 0, SIdx(1), vec!["e"]);
+        state_exists(grm, sg.closed_state(s3), "V", 0, SIdx(0), vec!["d"]);
 
         // Ommitted successors from the graph in Fig.3
 
         // X-successor of S0
         let s0x = sg.edge(sg.start_state(), Symbol::Rule(grm.rule_idx("X").unwrap())).unwrap();
-        state_exists(&grm, &sg.closed_state(s0x), "^", 0, SIdx(1), vec!["$"]);
+        state_exists(grm, sg.closed_state(s0x), "^", 0, SIdx(1), vec!["$"]);
 
         // Y-successor of S1 (and it's d-successor)
         let s1y = sg.edge(s1, Symbol::Rule(grm.rule_idx("Y").unwrap())).unwrap();
-        state_exists(&grm, &sg.closed_state(s1y), "X", 0, SIdx(2), vec!["a", "d", "e", "$"]);
+        state_exists(grm, sg.closed_state(s1y), "X", 0, SIdx(2), vec!["a", "d", "e", "$"]);
         let s1yd = sg.edge(s1y, Symbol::Token(grm.token_idx("d").unwrap())).unwrap();
-        state_exists(&grm, &sg.closed_state(s1yd), "X", 0, SIdx(3), vec!["a", "d", "e", "$"]);
+        state_exists(grm, sg.closed_state(s1yd), "X", 0, SIdx(3), vec!["a", "d", "e", "$"]);
 
         // Z-successor of S1 (and it's successor)
         let s1z = sg.edge(s1, Symbol::Rule(grm.rule_idx("Z").unwrap())).unwrap();
-        state_exists(&grm, &sg.closed_state(s1z), "X", 1, SIdx(2), vec!["a", "d", "e", "$"]);
+        state_exists(grm, sg.closed_state(s1z), "X", 1, SIdx(2), vec!["a", "d", "e", "$"]);
         let s1zc = sg.edge(s1z, Symbol::Token(grm.token_idx("c").unwrap())).unwrap();
-        state_exists(&grm, &sg.closed_state(s1zc), "X", 1, SIdx(3), vec!["a", "d", "e", "$"]);
+        state_exists(grm, sg.closed_state(s1zc), "X", 1, SIdx(3), vec!["a", "d", "e", "$"]);
 
         // T-successor of S1
         let s1t = sg.edge(s1, Symbol::Rule(grm.rule_idx("T").unwrap())).unwrap();
-        state_exists(&grm, &sg.closed_state(s1t), "X", 2, SIdx(2), vec!["a", "d", "e", "$"]);
+        state_exists(grm, sg.closed_state(s1t), "X", 2, SIdx(2), vec!["a", "d", "e", "$"]);
 
         // Y-successor of S7 (and it's d-successor)
         let s7y = sg.edge(s7, Symbol::Rule(grm.rule_idx("Y").unwrap())).unwrap();
-        state_exists(&grm, &sg.closed_state(s7y), "X", 3, SIdx(2), vec!["a", "d", "e", "$"]);
+        state_exists(grm, sg.closed_state(s7y), "X", 3, SIdx(2), vec!["a", "d", "e", "$"]);
         let s7ye = sg.edge(s7y, Symbol::Token(grm.token_idx("e").unwrap())).unwrap();
-        state_exists(&grm, &sg.closed_state(s7ye), "X", 3, SIdx(3), vec!["a", "d", "e", "$"]);
+        state_exists(grm, sg.closed_state(s7ye), "X", 3, SIdx(3), vec!["a", "d", "e", "$"]);
 
         // Z-successor of S7 (and it's successor)
         let s7z = sg.edge(s7, Symbol::Rule(grm.rule_idx("Z").unwrap())).unwrap();
-        state_exists(&grm, &sg.closed_state(s7z), "X", 4, SIdx(2), vec!["a", "d", "e", "$"]);
+        state_exists(grm, sg.closed_state(s7z), "X", 4, SIdx(2), vec!["a", "d", "e", "$"]);
         let s7zd = sg.edge(s7z, Symbol::Token(grm.token_idx("d").unwrap())).unwrap();
-        state_exists(&grm, &sg.closed_state(s7zd), "X", 4, SIdx(3), vec!["a", "d", "e", "$"]);
+        state_exists(grm, sg.closed_state(s7zd), "X", 4, SIdx(3), vec!["a", "d", "e", "$"]);
 
         // T-successor of S7
         let s7t = sg.edge(s7, Symbol::Rule(grm.rule_idx("T").unwrap())).unwrap();
-        state_exists(&grm, &sg.closed_state(s7t), "X", 5, SIdx(2), vec!["a", "d", "e", "$"]);
+        state_exists(grm, sg.closed_state(s7t), "X", 5, SIdx(2), vec!["a", "d", "e", "$"]);
 
         // W-successor of S2 and S8 (merged)
         let s8w = sg.edge(s8, Symbol::Rule(grm.rule_idx("W").unwrap())).unwrap();
         assert_eq!(s8w, sg.edge(s2, Symbol::Rule(grm.rule_idx("W").unwrap())).unwrap());
-        state_exists(&grm, &sg.closed_state(s8w), "Y", 0, SIdx(2), vec!["d", "e"]);
+        state_exists(grm, sg.closed_state(s8w), "Y", 0, SIdx(2), vec!["d", "e"]);
 
         // V-successor of S3 and S9 (merged)
         let s9v = sg.edge(s9, Symbol::Rule(grm.rule_idx("V").unwrap())).unwrap();
         assert_eq!(s9v, sg.edge(s3, Symbol::Rule(grm.rule_idx("V").unwrap())).unwrap());
-        state_exists(&grm, &sg.closed_state(s9v), "W", 0, SIdx(2), vec!["d", "e"]);
+        state_exists(grm, sg.closed_state(s9v), "W", 0, SIdx(2), vec!["d", "e"]);
     }
 
     #[test]
@@ -677,6 +677,6 @@ mod test {
 
         // State 0
         assert_eq!(sg.core_state(sg.start_state()).items.len(), 1);
-        state_exists(&grm, &sg.core_state(sg.start_state()), "^", 0, SIdx(0), vec!["$"]);
+        state_exists(&grm, sg.core_state(sg.start_state()), "^", 0, SIdx(0), vec!["$"]);
     }
 }

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -255,7 +255,7 @@ mod test {
         // Taken from p13 of https://link.springer.com/article/10.1007/s00236-010-0115-6
         let grm = YaccGrammar::new(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &"
+            "
             %start A
             %%
             A: 'OPEN_BRACKET' A 'CLOSE_BRACKET'

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -526,7 +526,7 @@ where
 
 fn resolve_shift_reduce<StorageT: 'static + Hash + PrimInt + Unsigned>(
     grm: &YaccGrammar<StorageT>,
-    actions: &mut Vec<usize>,
+    actions: &mut [usize],
     off: usize,
     tidx: TIdx<StorageT>,
     pidx: PIdx<StorageT>,

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -599,7 +599,7 @@ mod test {
         // Taken from p19 of www.cs.umd.edu/~mvz/cmsc430-s07/M10lr.pdf
         let grm = YaccGrammar::new(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &"
+            "
             %start Expr
             %%
             Expr : Term '-' Expr | Term;
@@ -679,7 +679,7 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_default_reduce_reduce() {
-        let grm = YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), &"
+        let grm = YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), "
             %start A
             %%
             A : B 'x' | C 'x' 'x';
@@ -703,7 +703,7 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_default_shift_reduce() {
-        let grm = YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), &"
+        let grm = YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), "
             %start Expr
             %%
             Expr : Expr '+' Expr
@@ -733,7 +733,7 @@ mod test {
     #[rustfmt::skip]
     fn test_conflict_resolution() {
         // Example taken from p54 of Locally least-cost error repair in LR parsers, Carl Cerecke
-        let grm = YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), &"
+        let grm = YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), "
             %start S
             %%
             S: A 'c' 'd'
@@ -758,7 +758,7 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_left_associativity() {
-        let grm = YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), &"
+        let grm = YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), "
             %start Expr
             %left '+'
             %left '*'
@@ -797,7 +797,7 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_left_right_associativity() {
-        let grm = &YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), &"
+        let grm = &YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), "
             %start Expr
             %right '='
             %left '+'
@@ -808,8 +808,8 @@ mod test {
                  | Expr '=' Expr
                  | 'id' ;
           ").unwrap();
-        let sg = pager_stategraph(&grm);
-        let st = StateTable::new(&grm, &sg).unwrap();
+        let sg = &pager_stategraph(grm);
+        let st = StateTable::new(grm, sg).unwrap();
         let len = usize::from(grm.tokens_len()) * usize::from(sg.all_states_len());
         assert_eq!(st.actions.len(), len);
 
@@ -853,7 +853,7 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_left_right_nonassoc_associativity() {
-        let grm = YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), &"
+        let grm = YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), "
             %start Expr
             %right '='
             %left '+'
@@ -929,7 +929,7 @@ mod test {
     fn conflicts() {
         let grm = YaccGrammar::new(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &"
+            "
 %start A
 %%
 A : 'a' 'b' | B 'b';
@@ -965,7 +965,7 @@ C : 'a';
     fn accept_reduce_conflict() {
         let grm = YaccGrammar::new(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
-            &"
+            "
 %start D
 %%
 D : D;


### PR DESCRIPTION
Now that i've figured out how to reproduce all those clippy lints, I was getting in my initial 2021 edition bump.
Here is 2 patches one with one from `cargo clippy --all-targets`, and a follow up with `cargo +nightly clippy --all-targets`.

There is some subsequent cleanup I think that could be done, in particular calls to `state_exists`, pass the parameters as a reference sometimes, other times the reference is in the type of the variable passed as a parameter.

This could be made more uniform by declaring the reference in the let binding rather than call site perhaps.
I didn't do it here because it isn't required to appease clippy, and its already pretty big patch.