### PR TITLE
Add serde derives for RecoveryKind.

### DIFF
--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -11,6 +11,7 @@ use cactus::Cactus;
 use cfgrammar::{yacc::YaccGrammar, RIdx, TIdx};
 use lrtable::{Action, StIdx, StateTable};
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
+use serde::{Deserialize, Serialize};
 
 use crate::{cpctplus, LexError, Lexeme, NonStreamingLexer, Span};
 
@@ -591,7 +592,7 @@ pub(super) trait Recoverer<
 }
 
 /// What recovery algorithm should be used when a syntax error is encountered?
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub enum RecoveryKind {
     /// The CPCT+ algorithm from Diekmann/Tratt "Don't Panic! Better, Fewer, Syntax Errors for LR
     /// Parsers".


### PR DESCRIPTION
Sorry, should have probably been part of my last serde patch, because it lacked the serde feature.
I thought I would have to add serde as a new optional dependency with a feature to `lrpar/`,
but failed notice that it lacks the feature because it is a required dependency.

Thus it would seem less controversial than I imagined.