### PR TITLE
Prepare a 0.12.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+# grmtools 0.12.0 (2022-04-14)
+
+* Move to Rust 2021 edition.
+
+* Various minor clean-ups.
+
+
 # grmtools 0.11.1 (2021-12-07)
 
 * Explicitly error if the users tries to generate two or more lexers or parsers

--- a/cfgrammar/Cargo.toml
+++ b/cfgrammar/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cfgrammar"
 description = "Grammar manipulation"
 repository = "https://github.com/softdevteam/grmtools"
-version = "0.11.1"
+version = "0.12.0"
 authors = ["Laurence Tratt <http://tratt.net/laurie/>"]
 edition = "2021"
 readme = "README.md"

--- a/doc/src/quickstart.md
+++ b/doc/src/quickstart.md
@@ -30,14 +30,14 @@ doc = false
 name = "calc"
 
 [build-dependencies]
-cfgrammar = "0.11"
-lrlex = "0.11"
-lrpar = "0.11"
+cfgrammar = "0.12"
+lrlex = "0.12"
+lrpar = "0.12"
 
 [dependencies]
-cfgrammar = "0.11"
-lrlex = "0.11"
-lrpar = "0.11"
+cfgrammar = "0.12"
+lrlex = "0.12"
+lrpar = "0.12"
 ```
 
 In this situation we want to statically compile the `.y` grammar and `.l` lexer

--- a/lrlex/Cargo.toml
+++ b/lrlex/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lrlex"
 description = "Simple lexer generator"
 repository = "https://github.com/softdevteam/grmtools"
-version = "0.11.1"
+version = "0.12.0"
 authors = ["Laurence Tratt <http://tratt.net/laurie/>"]
 edition = "2021"
 readme = "README.md"
@@ -23,7 +23,7 @@ vergen = { version = "7", default-features = false, features = ["build"] }
 [dependencies]
 getopts = "0.2" # only needed for src/main.rs
 lazy_static = "1.4"
-lrpar = { path = "../lrpar", version = "0.11" }
+lrpar = { path = "../lrpar", version = "0.12" }
 regex = "1"
 num-traits = "0.2"
 serde = "1.0"

--- a/lrlex/Cargo.toml
+++ b/lrlex/Cargo.toml
@@ -18,7 +18,7 @@ name = "lrlex"
 path = "src/lib/mod.rs"
 
 [build-dependencies]
-vergen = { version = "6", default-features = false, features = ["build"] }
+vergen = { version = "7", default-features = false, features = ["build"] }
 
 [dependencies]
 getopts = "0.2" # only needed for src/main.rs

--- a/lrpar/Cargo.toml
+++ b/lrpar/Cargo.toml
@@ -16,7 +16,7 @@ name = "lrpar"
 path = "src/lib/mod.rs"
 
 [build-dependencies]
-vergen = { version = "6", default-features = false, features = ["build"] }
+vergen = { version = "7", default-features = false, features = ["build"] }
 
 [dependencies]
 bincode = "1.2"

--- a/lrpar/Cargo.toml
+++ b/lrpar/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lrpar"
 description = "Yacc-compatible parser generator"
 repository = "https://github.com/softdevteam/grmtools"
-version = "0.11.1"
+version = "0.12.0"
 authors = ["Lukas Diekmann <http://lukasdiekmann.com/>", "Laurence Tratt <http://tratt.net/laurie/>"]
 edition = "2021"
 readme = "README.md"
@@ -21,11 +21,11 @@ vergen = { version = "7", default-features = false, features = ["build"] }
 [dependencies]
 bincode = "1.2"
 cactus = "1.0"
-cfgrammar = { path="../cfgrammar", version = "0.11", features=["serde"] }
+cfgrammar = { path="../cfgrammar", version = "0.12", features=["serde"] }
 filetime = "0.2"
 indexmap = "1.3"
 lazy_static = "1.4"
-lrtable = { path="../lrtable", version = "0.11", features=["serde"] }
+lrtable = { path="../lrtable", version = "0.12", features=["serde"] }
 num-traits = "0.2"
 packedvec = "1.2"
 serde = { version="1.0", features=["derive"] }

--- a/lrtable/Cargo.toml
+++ b/lrtable/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lrtable"
 description = "LR grammar table generation"
 repository = "https://github.com/softdevteam/grmtools"
-version = "0.11.1"
+version = "0.12.0"
 authors = ["Lukas Diekmann <http://lukasdiekmann.com/>", "Laurence Tratt <http://tratt.net/laurie/>"]
 edition = "2021"
 readme = "README.md"
@@ -16,7 +16,7 @@ path = "src/lib/mod.rs"
 [dependencies]
 fnv = "1.0"
 num-traits = "0.2"
-cfgrammar = { path="../cfgrammar", version = "0.11", features=["serde"] }
+cfgrammar = { path="../cfgrammar", version = "0.12", features=["serde"] }
 serde = { version="1.0", features=["derive"], optional=true }
 vob = { version="3.0", features=["serde"] }
 sparsevec = { version="0.1", features=["serde"] }

--- a/nimbleparse/Cargo.toml
+++ b/nimbleparse/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nimbleparse"
 description = "Simple Yacc grammar debugging tool"
 repository = "https://github.com/softdevteam/grmtools"
-version = "0.11.1"
+version = "0.12.0"
 authors = ["Laurence Tratt <http://tratt.net/laurie/>"]
 edition = "2021"
 readme = "README.md"
@@ -14,9 +14,9 @@ doc = false
 name = "nimbleparse"
 
 [dependencies]
-cfgrammar = { path="../cfgrammar", version="0.11" }
+cfgrammar = { path="../cfgrammar", version="0.12" }
 getopts = "0.2"
-lrlex = { path="../lrlex", version="0.11" }
-lrpar = { path="../lrpar", version="0.11" }
-lrtable = { path="../lrtable", version="0.11" }
+lrlex = { path="../lrlex", version="0.12" }
+lrpar = { path="../lrpar", version="0.12" }
+lrtable = { path="../lrtable", version="0.12" }
 num-traits = "0.2"


### PR DESCRIPTION
Because we've moved to the 2021 edition, I think it's best to force users to explicitly opt into 0.12, rather than have some people using older rustc versions suddenly find that `cargo update` means they can't use grmtools anymore.