### PR TITLE
Add a name_span field to Rule.

### DIFF
--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -53,7 +53,10 @@
 use serde::{Deserialize, Serialize};
 
 mod idxnewtype;
+pub mod span;
 pub mod yacc;
+
+pub use span::Span;
 
 /// A type specifically for rule indices.
 pub use crate::idxnewtype::{PIdx, RIdx, SIdx, TIdx};

--- a/cfgrammar/src/lib/span.rs
+++ b/cfgrammar/src/lib/span.rs
@@ -1,0 +1,45 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// A `Span` records what portion of the user's input something (e.g. a lexeme or production)
+/// references (i.e. the `Span` doesn't hold a reference / copy of the actual input).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Span {
+    start: usize,
+    end: usize,
+}
+
+impl Span {
+    /// Create a new span starting at byte `start` and ending at byte `end`.
+    ///
+    /// # Panics
+    ///
+    /// If `end` is less than `start`.
+    pub fn new(start: usize, end: usize) -> Self {
+        if end < start {
+            panic!("Span starts ({}) after it ends ({})!", start, end);
+        }
+        Span { start, end }
+    }
+
+    /// Byte offset of the start of the span.
+    pub fn start(&self) -> usize {
+        self.start
+    }
+
+    /// Byte offset of the end of the span.
+    pub fn end(&self) -> usize {
+        self.end
+    }
+
+    /// Length in bytes of the span.
+    pub fn len(&self) -> usize {
+        self.end - self.start
+    }
+
+    /// Returns `true` if this `Span` covers 0 bytes, or `false` otherwise.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -8,6 +8,8 @@ use indexmap::{IndexMap, IndexSet};
 
 use super::Precedence;
 
+use crate::Span;
+
 /// An AST representing a grammar. This is built up gradually: when it is finished, the
 /// `complete_and_validate` must be called exactly once in order to finish the set-up. At that
 /// point, any further mutations made to the struct lead to undefined behaviour.
@@ -17,6 +19,7 @@ pub struct GrammarAST {
     pub rules: IndexMap<String, Rule>,
     pub prods: Vec<Production>,
     pub tokens: IndexSet<String>,
+    pub spans: Vec<Span>,
     pub precs: HashMap<String, Precedence>,
     pub avoid_insert: Option<HashSet<String>>,
     pub implicit_tokens: Option<HashSet<String>>,
@@ -115,6 +118,7 @@ impl GrammarAST {
             rules: IndexMap::new(), // Using an IndexMap means that we retain the order
             // of rules as they're found in the input file.
             prods: Vec::new(),
+            spans: Vec::new(),
             tokens: IndexSet::new(),
             precs: HashMap::new(),
             avoid_insert: None,

--- a/lrlex/src/lib/ctbuilder.rs
+++ b/lrlex/src/lib/ctbuilder.rs
@@ -400,11 +400,17 @@ pub fn lexerdef() -> {lexerdef_type} {{
                 Some(ref n) => format!("Some({:?}.to_string())", n),
                 None => "None".to_owned(),
             };
+            let n_span = format!(
+                "lrpar::Span::new({}, {})",
+                r.name_span.start(),
+                r.name_span.end()
+            );
             outs.push_str(&format!(
                 "
-        Rule::new({}, {}, \"{}\".to_string()).unwrap(),",
+        Rule::new({}, {}, {}, \"{}\".to_string()).unwrap(),",
                 tok_id,
                 n,
+                n_span,
                 r.re_str.replace('\\', "\\\\").replace('"', "\\\"")
             ));
         }

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -219,44 +219,6 @@ macro_rules! lrpar_mod {
     };
 }
 
-/// A `Span` records what portion of the user's input something (e.g. a lexeme or production)
-/// references (i.e. the `Span` doesn't hold a reference / copy of the actual input).
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct Span {
-    start: usize,
-    end: usize,
-}
-
-impl Span {
-    /// Create a new span starting at byte `start` and ending at byte `end`.
-    ///
-    /// # Panics
-    ///
-    /// If `end` is less than `start`.
-    pub fn new(start: usize, end: usize) -> Self {
-        if end < start {
-            panic!("Span starts ({}) after it ends ({})!", start, end);
-        }
-        Span { start, end }
-    }
-
-    /// Byte offset of the start of the span.
-    pub fn start(&self) -> usize {
-        self.start
-    }
-
-    /// Byte offset of the end of the span.
-    pub fn end(&self) -> usize {
-        self.end
-    }
-
-    /// Length in bytes of the span.
-    pub fn len(&self) -> usize {
-        self.end - self.start
-    }
-
-    /// Returns `true` if this `Span` covers 0 bytes, or `false` otherwise.
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-}
+// For backwards compatibility reexport Span which lived here,
+// before it was moved to cfgrammar.
+pub use cfgrammar::Span;


### PR DESCRIPTION
This adds a name_span field to lexerdef's rule, I assume it is okay to depend on span here from lrpar in lrlex since the depdency is already there.

Notes about the impl:
The span refers to inside the quotes, of the quoted name, and in the case of an anonymous rule with no name,
It points to the empty string at the semicolon.

This is why name is an option but span is not, this still needs to be documented and tested, 
But I wanted to post this up for comments before writing docs/tests in case of feedback on the impl causes different behavior.
So for now I merely checked it just with `iter_rules()` manually.

It *doesn't* add spans for re_str (`re_span`?), which is private and I'm not sure it would be alright to have a public span for that private field, and i'm not sure if I would actually need it -- I still need to play around with adding this info to diagnostics to get a feel for that.