### PR TITLE
Spans for Symbols

### DIFF
--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -131,13 +131,14 @@ impl GrammarAST {
         }
     }
 
-    pub fn add_rule(&mut self, name: String, actiont: Option<String>) {
+    pub fn add_rule(&mut self, name: String, actiont: Option<String>, span: Option<Span>) {
         self.rules.insert(
             name.clone(),
             Rule {
                 name,
                 pidxs: Vec::new(),
                 actiont,
+                span,
             },
         );
     }
@@ -287,7 +288,7 @@ mod test {
     fn test_invalid_start_rule() {
         let mut grm = GrammarAST::new();
         grm.start = Some("A".to_string());
-        grm.add_rule("B".to_string(), None);
+        grm.add_rule("B".to_string(), None, None);
         grm.add_prod("B".to_string(), vec![], None, None);
         match grm.complete_and_validate() {
             Err(GrammarValidationError {
@@ -302,7 +303,7 @@ mod test {
     fn test_valid_start_rule() {
         let mut grm = GrammarAST::new();
         grm.start = Some("A".to_string());
-        grm.add_rule("A".to_string(), None);
+        grm.add_rule("A".to_string(), None, None);
         grm.add_prod("A".to_string(), vec![], None, None);
         assert!(grm.complete_and_validate().is_ok());
     }
@@ -311,8 +312,8 @@ mod test {
     fn test_valid_rule_ref() {
         let mut grm = GrammarAST::new();
         grm.start = Some("A".to_string());
-        grm.add_rule("A".to_string(), None);
-        grm.add_rule("B".to_string(), None);
+        grm.add_rule("A".to_string(), None, None);
+        grm.add_rule("B".to_string(), None, None);
         grm.add_prod("A".to_string(), vec![rule("B")], None, None);
         grm.add_prod("B".to_string(), vec![], None, None);
         assert!(grm.complete_and_validate().is_ok());
@@ -322,7 +323,7 @@ mod test {
     fn test_invalid_rule_ref() {
         let mut grm = GrammarAST::new();
         grm.start = Some("A".to_string());
-        grm.add_rule("A".to_string(), None);
+        grm.add_rule("A".to_string(), None, None);
         grm.add_prod("A".to_string(), vec![rule("B")], None, None);
         match grm.complete_and_validate() {
             Err(GrammarValidationError {
@@ -338,7 +339,7 @@ mod test {
         let mut grm = GrammarAST::new();
         grm.tokens.insert("b".to_string());
         grm.start = Some("A".to_string());
-        grm.add_rule("A".to_string(), None);
+        grm.add_rule("A".to_string(), None, None);
         grm.add_prod("A".to_string(), vec![token("b")], None, None);
         assert!(grm.complete_and_validate().is_ok());
     }
@@ -350,7 +351,7 @@ mod test {
         let mut grm = GrammarAST::new();
         grm.tokens.insert("b".to_string());
         grm.start = Some("A".to_string());
-        grm.add_rule("A".to_string(), None);
+        grm.add_rule("A".to_string(), None, None);
         grm.add_prod("A".to_string(), vec![rule("b")], None, None);
         assert!(grm.complete_and_validate().is_err());
     }
@@ -359,7 +360,7 @@ mod test {
     fn test_invalid_token_ref() {
         let mut grm = GrammarAST::new();
         grm.start = Some("A".to_string());
-        grm.add_rule("A".to_string(), None);
+        grm.add_rule("A".to_string(), None, None);
         grm.add_prod("A".to_string(), vec![token("b")], None, None);
         match grm.complete_and_validate() {
             Err(GrammarValidationError {
@@ -374,7 +375,7 @@ mod test {
     fn test_invalid_rule_forgotten_token() {
         let mut grm = GrammarAST::new();
         grm.start = Some("A".to_string());
-        grm.add_rule("A".to_string(), None);
+        grm.add_rule("A".to_string(), None, None);
         grm.add_prod("A".to_string(), vec![rule("b"), token("b")], None, None);
         match grm.complete_and_validate() {
             Err(GrammarValidationError {
@@ -389,7 +390,7 @@ mod test {
     fn test_invalid_epp() {
         let mut grm = GrammarAST::new();
         grm.start = Some("A".to_string());
-        grm.add_rule("A".to_string(), None);
+        grm.add_rule("A".to_string(), None, None);
         grm.add_prod("A".to_string(), vec![], None, None);
         grm.epp.insert("k".to_owned(), "v".to_owned());
         match grm.complete_and_validate() {
@@ -413,7 +414,7 @@ mod test {
         );
         grm.start = Some("A".to_string());
         grm.tokens.insert("b".to_string());
-        grm.add_rule("A".to_string(), None);
+        grm.add_rule("A".to_string(), None, None);
         grm.add_prod(
             "A".to_string(),
             vec![token("b")],
@@ -427,7 +428,7 @@ mod test {
     fn test_invalid_precedence_override() {
         let mut grm = GrammarAST::new();
         grm.start = Some("A".to_string());
-        grm.add_rule("A".to_string(), None);
+        grm.add_rule("A".to_string(), None, None);
         grm.add_prod(
             "A".to_string(),
             vec![token("b")],

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -40,8 +40,8 @@ pub enum AssocKind {
 pub struct YaccGrammar<StorageT = u32> {
     /// How many rules does this grammar have?
     rules_len: RIdx<StorageT>,
-    /// A mapping from `RIdx` -> `String`.
-    rule_names: Vec<String>,
+    /// A mapping from `RIdx` -> `(Span, String)`.
+    rule_names: Vec<(Option<Span>, String)>,
     /// A mapping from `TIdx` -> `Option<(Span, String)>`. Every user-specified token will have a name,
     /// but tokens inserted by cfgrammar (e.g. the EOF token) won't.
     token_names: Vec<Option<(Span, String)>>,
@@ -138,7 +138,7 @@ where
             }
         }
 
-        let mut rule_names: Vec<String> = Vec::with_capacity(ast.rules.len() + 1);
+        let mut rule_names: Vec<(Option<Span>, String)> = Vec::with_capacity(ast.rules.len() + 1);
 
         // Generate a guaranteed unique start rule name. We simply keep making the string longer
         // until we've hit something unique (at the very worst, this will require looping for as
@@ -148,7 +148,7 @@ where
         while ast.rules.get(&start_rule).is_some() {
             start_rule += START_RULE;
         }
-        rule_names.push(start_rule.clone());
+        rule_names.push((None, start_rule.clone()));
 
         let implicit_rule;
         let implicit_start_rule;
@@ -163,13 +163,13 @@ where
                     while ast.rules.get(&n1).is_some() {
                         n1 += IMPLICIT_RULE;
                     }
-                    rule_names.push(n1.clone());
+                    rule_names.push((None, n1.clone()));
                     implicit_rule = Some(n1);
                     let mut n2 = IMPLICIT_START_RULE.to_string();
                     while ast.rules.get(&n2).is_some() {
                         n2 += IMPLICIT_START_RULE;
                     }
-                    rule_names.push(n2.clone());
+                    rule_names.push((None, n2.clone()));
                     implicit_start_rule = Some(n2);
                 } else {
                     implicit_rule = None;
@@ -178,12 +178,12 @@ where
             }
         };
 
-        for k in ast.rules.keys() {
-            rule_names.push(k.clone());
+        for (k, rule) in &ast.rules {
+            rule_names.push((rule.span, k.clone()));
         }
         let mut rules_prods: Vec<Vec<PIdx<StorageT>>> = Vec::with_capacity(rule_names.len());
         let mut rule_map = HashMap::<String, RIdx<StorageT>>::new();
-        for (i, v) in rule_names.iter().enumerate() {
+        for (i, (_, v)) in rule_names.iter().enumerate() {
             rules_prods.push(Vec::new());
             rule_map.insert(v.clone(), RIdx(i.as_()));
         }
@@ -215,7 +215,7 @@ where
         let mut prods_rules = vec![None; ast.prods.len()];
         let mut actions = vec![None; ast.prods.len()];
         let mut actiontypes = vec![None; rule_names.len()];
-        for astrulename in &rule_names {
+        for (_, astrulename) in &rule_names {
             let ridx = rule_map[astrulename];
             if astrulename == &start_rule {
                 // Add the special start rule which has a single production which references a
@@ -414,7 +414,12 @@ where
 
     /// Return the name of rule `ridx`. Panics if `ridx` doesn't exist.
     pub fn rule_name(&self, ridx: RIdx<StorageT>) -> &str {
-        &self.rule_names[usize::from(ridx)]
+        self.rule_names[usize::from(ridx)].1.as_str()
+    }
+
+    /// Return the span of rule `ridx`. Panics if `ridx` doesn't exist.
+    pub fn rule_span(&self, ridx: RIdx<StorageT>) -> Option<&Span> {
+        self.rule_names[usize::from(ridx)].0.as_ref()
     }
 
     /// Return the `RIdx` of the implict rule if it exists, or `None` otherwise.
@@ -426,7 +431,7 @@ where
     pub fn rule_idx(&self, n: &str) -> Option<RIdx<StorageT>> {
         self.rule_names
             .iter()
-            .position(|x| x == n)
+            .position(|(_, x)| x == n)
             // The call to as_() is safe because rule_names is guaranteed to be
             // small enough to fit into StorageT
             .map(|x| RIdx(x.as_()))
@@ -1480,5 +1485,9 @@ mod test {
         let foo_span = grm.token_span(*foo_tidx.unwrap());
         assert_eq!(a_span, Some(&Span::new(8, 9)));
         assert_eq!(foo_span, Some(&Span::new(14, 17)));
+        assert_eq!(
+            grm.rule_span(grm.rule_idx("AB").unwrap()),
+            Some(&Span::new(3, 5))
+        );
     }
 }

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -279,10 +279,10 @@ where
                 let mut prod = Vec::with_capacity(astprod.symbols.len());
                 for astsym in &astprod.symbols {
                     match *astsym {
-                        ast::Symbol::Rule(ref n) => {
+                        ast::Symbol::Rule(ref n, _span) => {
                             prod.push(Symbol::Rule(rule_map[n]));
                         }
-                        ast::Symbol::Token(ref n) => {
+                        ast::Symbol::Token(ref n, _span) => {
                             prod.push(Symbol::Token(token_map[n]));
                             if implicit_rule.is_some() {
                                 prod.push(Symbol::Rule(rule_map[&implicit_rule.clone().unwrap()]));
@@ -295,7 +295,7 @@ where
                     prec = Some(ast.precs[n]);
                 } else {
                     for astsym in astprod.symbols.iter().rev() {
-                        if let ast::Symbol::Token(ref n) = *astsym {
+                        if let ast::Symbol::Token(ref n, _span) = *astsym {
                             if let Some(p) = ast.precs.get(n) {
                                 prec = Some(*p);
                             }

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -321,11 +321,12 @@ impl YaccParser {
         if self.ast.start.is_none() {
             self.ast.start = Some(rn.clone());
         }
+        let span = Span::new(i, j);
         match self.yacc_kind {
             YaccKind::Original(_) | YaccKind::Eco => {
                 if self.ast.get_rule(&rn).is_none() {
                     self.ast
-                        .add_rule(rn.clone(), self.global_actiontype.clone());
+                        .add_rule(rn.clone(), self.global_actiontype.clone(), Some(span));
                 }
                 i = j;
             }
@@ -341,7 +342,7 @@ impl YaccParser {
                 }
                 i = self.parse_ws(i, true)?;
                 let (j, actiont) = self.parse_to_single_colon(i)?;
-                self.ast.add_rule(rn.clone(), Some(actiont));
+                self.ast.add_rule(rn.clone(), Some(actiont), Some(span));
                 i = j;
             }
         }

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -375,7 +375,7 @@ impl YaccParser {
                 i = self.parse_ws(j, true)?;
                 self.ast.tokens.insert(sym.clone());
                 self.ast.spans.push(span);
-                syms.push(Symbol::Token(sym));
+                syms.push(Symbol::Token(sym, Some(span)));
             } else if let Some(j) = self.lookahead_is("%prec", i) {
                 i = self.parse_ws(j, true)?;
                 let (k, sym, _) = self.parse_token(i)?;
@@ -390,11 +390,11 @@ impl YaccParser {
                 i = j;
                 action = Some(a);
             } else {
-                let (j, sym, _) = self.parse_token(i)?;
+                let (j, sym, span) = self.parse_token(i)?;
                 if self.ast.tokens.contains(&sym) {
-                    syms.push(Symbol::Token(sym));
+                    syms.push(Symbol::Token(sym, Some(span)));
                 } else {
-                    syms.push(Symbol::Rule(sym));
+                    syms.push(Symbol::Rule(sym, Some(span)));
                 }
                 i = j;
             }
@@ -704,16 +704,16 @@ mod test {
     }
 
     fn rule(n: &str) -> Symbol {
-        Symbol::Rule(n.to_string())
+        Symbol::Rule(n.to_string(), None)
     }
 
     fn token(n: &str) -> Symbol {
-        Symbol::Token(n.to_string())
+        Symbol::Token(n.to_string(), None)
     }
 
     #[test]
     fn test_macro() {
-        assert_eq!(Symbol::Token("A".to_string()), token("A"));
+        assert_eq!(Symbol::Token("A".to_string(), None), token("A"));
     }
 
     #[test]


### PR DESCRIPTION
Marking as a draft, I would like to 
1. test this more, so I would like to just work of this branch for a bit in my project, exercising it.
2. think about the second patch a bit more.

Regarding the second patch -- what I was after was spans for `productions`, adding them directly to productions seemed fraught (can't seem remember why though, I will have to check). adding them to symbols *seemed* to be the way, then get the Symbol for the production and you have it's span.

But it is kind of roundabout, and also caused the custom `hash` and `eq` impls.