### PR TITLE
Associate spans with production symbols

### DIFF
--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -38,17 +38,19 @@ pub struct Rule {
     pub actiont: Option<String>,
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct Production {
     pub symbols: Vec<Symbol>,
     pub precedence: Option<String>,
     pub action: Option<String>,
 }
 
-#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
 pub enum Symbol {
-    Rule(String),
-    Token(String),
+    Rule(String, Span),
+    Token(String, Span),
 }
 
 /// The various different possible grammar validation errors.
@@ -105,8 +107,8 @@ impl fmt::Display for GrammarValidationError {
 impl fmt::Display for Symbol {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Symbol::Rule(ref s) => write!(f, "{}", s),
-            Symbol::Token(ref s) => write!(f, "{}", s),
+            Symbol::Rule(ref s, _) => write!(f, "{}", s),
+            Symbol::Token(ref s, _) => write!(f, "{}", s),
         }
     }
 }
@@ -194,7 +196,7 @@ impl GrammarAST {
                 if !self.rules.contains_key(s) {
                     return Err(GrammarValidationError {
                         kind: GrammarValidationErrorKind::InvalidStartRule,
-                        sym: Some(Symbol::Rule(s.clone())),
+                        sym: Some(Symbol::Rule(s.clone(), Span::new(0, 0))),
                     });
                 }
             }
@@ -206,19 +208,19 @@ impl GrammarAST {
                     if !self.tokens.contains(n) {
                         return Err(GrammarValidationError {
                             kind: GrammarValidationErrorKind::UnknownToken,
-                            sym: Some(Symbol::Token(n.clone())),
+                            sym: Some(Symbol::Token(n.clone(), Span::new(0, 0))),
                         });
                     }
                     if !self.precs.contains_key(n) {
                         return Err(GrammarValidationError {
                             kind: GrammarValidationErrorKind::NoPrecForToken,
-                            sym: Some(Symbol::Token(n.clone())),
+                            sym: Some(Symbol::Token(n.clone(), Span::new(0, 0))),
                         });
                     }
                 }
                 for sym in &prod.symbols {
                     match *sym {
-                        Symbol::Rule(ref name) => {
+                        Symbol::Rule(ref name, _) => {
                             if !self.rules.contains_key(name) {
                                 return Err(GrammarValidationError {
                                     kind: GrammarValidationErrorKind::UnknownRuleRef,
@@ -226,7 +228,7 @@ impl GrammarAST {
                                 });
                             }
                         }
-                        Symbol::Token(ref name) => {
+                        Symbol::Token(ref name, _) => {
                             if !self.tokens.contains(name) {
                                 return Err(GrammarValidationError {
                                     kind: GrammarValidationErrorKind::UnknownToken,
@@ -249,7 +251,7 @@ impl GrammarAST {
             }
             return Err(GrammarValidationError {
                 kind: GrammarValidationErrorKind::UnknownEPP,
-                sym: Some(Symbol::Token(k.clone())),
+                sym: Some(Symbol::Token(k.clone(), Span::new(0, 0))),
             });
         }
         Ok(())
@@ -264,11 +266,11 @@ mod test {
     };
 
     fn rule(n: &str) -> Symbol {
-        Symbol::Rule(n.to_string())
+        Symbol::Rule(n.to_string(), Span::new(0, 0))
     }
 
     fn token(n: &str) -> Symbol {
-        Symbol::Token(n.to_string())
+        Symbol::Token(n.to_string(), Span::new(0, 0))
     }
 
     #[test]

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -279,10 +279,10 @@ where
                 let mut prod = Vec::with_capacity(astprod.symbols.len());
                 for astsym in &astprod.symbols {
                     match *astsym {
-                        ast::Symbol::Rule(ref n) => {
+                        ast::Symbol::Rule(ref n, _) => {
                             prod.push(Symbol::Rule(rule_map[n]));
                         }
-                        ast::Symbol::Token(ref n) => {
+                        ast::Symbol::Token(ref n, _) => {
                             prod.push(Symbol::Token(token_map[n]));
                             if implicit_rule.is_some() {
                                 prod.push(Symbol::Rule(rule_map[&implicit_rule.clone().unwrap()]));
@@ -295,7 +295,7 @@ where
                     prec = Some(ast.precs[n]);
                 } else {
                     for astsym in astprod.symbols.iter().rev() {
-                        if let ast::Symbol::Token(ref n) = *astsym {
+                        if let ast::Symbol::Token(ref n, _) = *astsym {
                             if let Some(p) = ast.precs.get(n) {
                                 prec = Some(*p);
                             }


### PR DESCRIPTION
Here is the attempt at using `(Span, Symbol)` instead of adding a `span` field to symbol.
The main reason I was trying to add it to field, is it seems to require us to change the type of the [`prod`](https://docs.rs/cfgrammar/latest/cfgrammar/yacc/grammar/struct.YaccGrammar.html#method.prod) function.

As such there is quite a bit more fallout in callers, and i'm generally not terribly fond of all these calls like `grm.prod(pindex)[i].1`
But for now I just went with it, though perhaps a `struct SpannedSymbol` with `symbol` and `span` fields would be preferred with all this indexing into slices.
