### PR TITLE
Turn StateTableError to an enum, handle self-loop for #290

### DIFF
--- a/lrtable/src/lib/mod.rs
+++ b/lrtable/src/lib/mod.rs
@@ -16,7 +16,7 @@ pub mod statetable;
 
 pub use crate::{
     stategraph::StateGraph,
-    statetable::{Action, StateTable, StateTableError, StateTableErrorKind},
+    statetable::{Action, StateTable, StateTableError},
 };
 use cfgrammar::yacc::YaccGrammar;
 


### PR DESCRIPTION
Here is at least an attempt to fix #290,
It appeared to me that bison ignores this case entirely (no additional errors or self recursion, besides the conflicts, and if you run the parser it won't loop forever), and I believe I see in the bison code where it ignores it.

It's worth pointing out the Accept/Reduce errors here with it's "Infinitely recursive rule let through",
I haven't yet gone and tried to fully understand what makes this case different from an Accept/Reduce.

I had to switch the error around here, because unless I am mistaken, at that point we don't appear to have any way to get a `PIdx`.
