### PR TITLE
Move all references to lrpar::Span to cfgrammar::Span.

### DIFF
--- a/doc/src/actioncode.md
+++ b/doc/src/actioncode.md
@@ -23,7 +23,7 @@ Action code is normal Rust code with the addition of the following special varia
    stored by the grammar without copying memory.
 
  * `$span` is a
-   [`lrpar::Span`](https://softdevteam.github.io/grmtools/master/api/lrpar/struct.Span.html)
+   [`cfgrammar::Span`](https://softdevteam.github.io/grmtools/master/api/cfgrammar/struct.Span.html)
    tuple (with both elements of type `usize`) which captures how much of the
    user's input the current production matched.
 

--- a/doc/src/ast_example.md
+++ b/doc/src/ast_example.md
@@ -30,7 +30,7 @@ Factor -> Result<Expr, ()>:
     ;
 %%
 
-use lrpar::Span;
+use cfgrammar::Span;
 
 #[derive(Debug)]
 pub enum Expr {

--- a/lrlex/Cargo.toml
+++ b/lrlex/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/lib/mod.rs"
 vergen = { version = "7", default-features = false, features = ["build"] }
 
 [dependencies]
+cfgrammar = { path = "../cfgrammar", version = "0.12" }
 getopts = "0.2" # only needed for src/main.rs
 lazy_static = "1.4"
 lrpar = { path = "../lrpar", version = "0.12" }

--- a/lrlex/examples/calc_manual_lex/src/calc.y
+++ b/lrlex/examples/calc_manual_lex/src/calc.y
@@ -25,7 +25,7 @@ Unmatched -> ():
     ;
 %%
 
-use lrpar::Span;
+use cfgrammar::Span;
 
 #[derive(Debug)]
 pub enum Expr {

--- a/lrlex/examples/calc_manual_lex/src/main.rs
+++ b/lrlex/examples/calc_manual_lex/src/main.rs
@@ -2,8 +2,9 @@
 
 use std::io::{self, BufRead, Write};
 
+use cfgrammar::Span;
 use lrlex::{lrlex_mod, DefaultLexeme, LRNonStreamingLexer};
-use lrpar::{lrpar_mod, Lexeme, NonStreamingLexer, Span};
+use lrpar::{lrpar_mod, Lexeme, NonStreamingLexer};
 
 lrlex_mod!("token_map");
 // Using `lrpar_mod!` brings the parser for `calc.y` into scope. By default the module name will be

--- a/lrlex/examples/calclex/Cargo.toml
+++ b/lrlex/examples/calclex/Cargo.toml
@@ -13,5 +13,6 @@ name = "calclex"
 lrlex = { path = "../.." }
 
 [dependencies]
+cfgrammar = { path = "../../../cfgrammar" }
 lrlex = { path = "../.." }
 lrpar = { path = "../../../lrpar" }

--- a/lrlex/src/lib/ctbuilder.rs
+++ b/lrlex/src/lib/ctbuilder.rs
@@ -401,7 +401,7 @@ pub fn lexerdef() -> {lexerdef_type} {{
                 None => "None".to_owned(),
             };
             let n_span = format!(
-                "lrpar::Span::new({}, {})",
+                "::cfgrammar::Span::new({}, {})",
                 r.name_span.start(),
                 r.name_span.end()
             );

--- a/lrlex/src/lib/lexemes.rs
+++ b/lrlex/src/lib/lexemes.rs
@@ -1,6 +1,7 @@
 use std::{cmp, error::Error, fmt, hash::Hash, marker};
 
-use lrpar::{Lexeme, Span};
+use cfgrammar::Span;
+use lrpar::Lexeme;
 
 /// lrlex's standard lexeme struct: all lexemes are instances of this struct.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]

--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -6,11 +6,12 @@ use std::{
     slice::Iter,
 };
 
+use cfgrammar::Span;
 use num_traits::{PrimInt, Unsigned};
 use regex::{self, Regex, RegexBuilder};
 use try_from::TryFrom;
 
-use lrpar::{LexError, Lexeme, Lexer, NonStreamingLexer, Span};
+use lrpar::{LexError, Lexeme, Lexer, NonStreamingLexer};
 
 use crate::{parser::LexParser, LexBuildResult};
 
@@ -675,16 +676,16 @@ b 'B'
         let lexerdef = LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).unwrap();
         assert_eq!(
             lexerdef.get_rule_by_name("A").unwrap().name_span,
-            lrpar::Span::new(6, 7)
+            Span::new(6, 7)
         );
         assert_eq!(
             lexerdef.get_rule_by_name("B").unwrap().name_span,
-            lrpar::Span::new(12, 13)
+            Span::new(12, 13)
         );
         let anonymous_rules = lexerdef
             .iter_rules()
             .filter(|rule| rule.name.is_none())
             .collect::<Vec<_>>();
-        assert_eq!(anonymous_rules[0].name_span, lrpar::Span::new(21, 21));
+        assert_eq!(anonymous_rules[0].name_span, Span::new(21, 21));
     }
 }

--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -3,7 +3,7 @@
 //! compiles it to Rust code. The resulting [LRNonStreamingLexerDef] can then be given an input
 //! string, from which it instantiates an [LRNonStreamingLexer]. This provides an iterator which
 //! can produce the sequence of [lrpar::Lexeme]s for that input, as well as answer basic queries
-//! about [lrpar::Span]s (e.g. extracting substrings, calculating line and column numbers).
+//! about [cfgrammar::Span]s (e.g. extracting substrings, calculating line and column numbers).
 
 #![allow(clippy::new_without_default)]
 #![allow(clippy::type_complexity)]

--- a/lrlex/src/lib/parser.rs
+++ b/lrlex/src/lib/parser.rs
@@ -1,3 +1,4 @@
+use cfgrammar::Span;
 use try_from::TryFrom;
 
 use crate::{lexer::Rule, LexBuildError, LexBuildResult, LexErrorKind};
@@ -107,7 +108,7 @@ impl<StorageT: TryFrom<usize>> LexParser<StorageT> {
         if orig_name == ";" {
             name = None;
             let pos = i + rspace + 1;
-            name_span = lrpar::Span::new(pos, pos);
+            name_span = Span::new(pos, pos);
         } else {
             debug_assert!(!orig_name.is_empty());
             if !((orig_name.starts_with('\'') && orig_name.ends_with('\''))
@@ -116,7 +117,7 @@ impl<StorageT: TryFrom<usize>> LexParser<StorageT> {
                 return Err(self.mk_error(LexErrorKind::InvalidName, i + rspace + 1));
             }
             name = Some(orig_name[1..orig_name.len() - 1].to_string());
-            name_span = lrpar::Span::new(i + rspace + 2, i + rspace + orig_name.len());
+            name_span = Span::new(i + rspace + 2, i + rspace + orig_name.len());
             let dup_name = self.rules.iter().any(|r| {
                 r.name
                     .as_ref()

--- a/lrpar/cttests/src/lib.rs
+++ b/lrpar/cttests/src/lib.rs
@@ -1,7 +1,7 @@
+#[cfg(test)]
+use cfgrammar::Span;
 use lrlex::lrlex_mod;
 use lrpar::lrpar_mod;
-#[cfg(test)]
-use lrpar::Span;
 #[cfg(test)]
 use lrpar::{Lexeme, Lexer, NonStreamingLexer};
 

--- a/lrpar/cttests/src/span.test
+++ b/lrpar/cttests/src/span.test
@@ -4,7 +4,7 @@ grammar: |
     %start Expr
     %avoid_insert "INT"
     %%
-    Expr -> Vec<::lrpar::Span>:
+    Expr -> Vec<::cfgrammar::Span>:
           Expr '+' Term {
               let mut spans = $1;
               spans.extend($3);
@@ -18,7 +18,7 @@ grammar: |
           }
         ;
 
-    Term -> Vec<::lrpar::Span>:
+    Term -> Vec<::cfgrammar::Span>:
           Term '*' Factor {
               let mut spans = $1;
               spans.extend($3);
@@ -32,7 +32,7 @@ grammar: |
           }
         ;
 
-    Factor -> Vec<::lrpar::Span>:
+    Factor -> Vec<::cfgrammar::Span>:
           '(' Expr ')' {
               let mut spans = $2;
               spans.push($span);

--- a/lrpar/examples/calc_ast/src/calc.y
+++ b/lrpar/examples/calc_ast/src/calc.y
@@ -25,7 +25,7 @@ Unmatched -> ():
     ;
 %%
 
-use lrpar::Span;
+use cfgrammar::Span;
 
 #[derive(Debug)]
 pub enum Expr {

--- a/lrpar/examples/calc_ast/src/main.rs
+++ b/lrpar/examples/calc_ast/src/main.rs
@@ -2,8 +2,9 @@
 
 use std::io::{self, BufRead, Write};
 
+use cfgrammar::Span;
 use lrlex::{lrlex_mod, DefaultLexeme};
-use lrpar::{lrpar_mod, NonStreamingLexer, Span};
+use lrpar::{lrpar_mod, NonStreamingLexer};
 
 // Using `lrlex_mod!` brings the lexer for `calc.l` into scope. By default the module name will be
 // `calc_l` (i.e. the file name, minus any extensions, with a suffix of `_l`).

--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -7,14 +7,14 @@ use std::{
 };
 
 use cactus::Cactus;
-use cfgrammar::TIdx;
+use cfgrammar::{Span, TIdx};
 use lrtable::{Action, StIdx};
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 
 use super::{
     dijkstra::dijkstra,
     parser::{AStackType, ParseRepair, Parser, Recoverer},
-    Lexeme, Span,
+    Lexeme,
 };
 
 const PARSE_AT_LEAST: usize = 3; // N in Corchuelo et al.

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -715,7 +715,7 @@ where
                     "\n        #[allow(clippy::type_complexity)]
         let actions: ::std::vec::Vec<&dyn Fn(::cfgrammar::RIdx<{storaget}>,
                        &'lexer dyn ::lrpar::NonStreamingLexer<'input, {lexemet}, {storaget}>,
-                       ::lrpar::Span,
+                       ::cfgrammar::Span,
                        ::std::vec::Drain<::lrpar::parser::AStackType<{lexemet}, {actionskind}<'input>>>,
                        {parse_paramty})
                     -> {actionskind}<'input>> = ::std::vec![{wrappers}];\n",
@@ -823,7 +823,7 @@ where
             outs.push_str(&format!(
                 "    fn {prefix}wrapper_{}<'lexer, 'input: 'lexer>({prefix}ridx: ::cfgrammar::RIdx<{storaget}>,
                       {prefix}lexer: &'lexer dyn ::lrpar::NonStreamingLexer<'input, {lexemet}, {storaget}>,
-                      {prefix}span: ::lrpar::Span,
+                      {prefix}span: ::cfgrammar::Span,
                       mut {prefix}args: ::std::vec::Drain<::lrpar::parser::AStackType<{lexemet}, {actionskind}<'input>>>,
                       {parse_paramdef})
                    -> {actionskind}<'input> {{",
@@ -994,7 +994,7 @@ where
     #[allow(clippy::too_many_arguments)]
     fn {prefix}action_{}<'lexer, 'input: 'lexer>({prefix}ridx: ::cfgrammar::RIdx<{storaget}>,
                      {prefix}lexer: &'lexer dyn ::lrpar::NonStreamingLexer<'input, {lexemet}, {storaget}>,
-                     {prefix}span: ::lrpar::Span,
+                     {prefix}span: ::cfgrammar::Span,
                      {parse_paramdef},
                      {args}){returnt} {{
         let _ = {parse_paramname};\n",

--- a/lrpar/src/lib/lex_api.rs
+++ b/lrpar/src/lib/lex_api.rs
@@ -2,9 +2,8 @@
 
 use std::{cmp, error::Error, fmt, hash::Hash, marker};
 
+use cfgrammar::Span;
 use num_traits::{PrimInt, Unsigned};
-
-use crate::Span;
 
 /// A Lexing error.
 #[derive(Copy, Clone, Debug)]

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -219,6 +219,8 @@ macro_rules! lrpar_mod {
     };
 }
 
-// For backwards compatibility reexport Span which lived here,
-// before it was moved to cfgrammar.
+#[deprecated(
+    since = "0.13.0",
+    note = "Please import this as `cfgrammar::Span` instead"
+)]
 pub use cfgrammar::Span;

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -8,12 +8,12 @@ use std::{
 };
 
 use cactus::Cactus;
-use cfgrammar::{yacc::YaccGrammar, RIdx, TIdx};
+use cfgrammar::{yacc::YaccGrammar, RIdx, Span, TIdx};
 use lrtable::{Action, StIdx, StateTable};
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 use serde::{Deserialize, Serialize};
 
-use crate::{cpctplus, LexError, Lexeme, NonStreamingLexer, Span};
+use crate::{cpctplus, LexError, Lexeme, NonStreamingLexer};
 
 #[cfg(test)]
 const RECOVERY_TIME_BUDGET: u64 = 60_000; // milliseconds
@@ -873,13 +873,16 @@ impl<LexemeT: Lexeme<StorageT>, StorageT: Hash + PrimInt + Unsigned> ParseError<
 pub(crate) mod test {
     use std::collections::HashMap;
 
-    use cfgrammar::yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind};
+    use cfgrammar::{
+        yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
+        Span,
+    };
     use lrtable::{from_yacc, Minimiser};
     use num_traits::ToPrimitive;
     use regex::Regex;
 
     use super::*;
-    use crate::{test_utils::TestLexeme, Lexeme, Lexer, Span};
+    use crate::{test_utils::TestLexeme, Lexeme, Lexer};
 
     pub(crate) fn do_parse(
         rcvry_kind: RecoveryKind,

--- a/lrpar/src/lib/test_utils.rs
+++ b/lrpar/src/lib/test_utils.rs
@@ -1,8 +1,9 @@
 #![allow(clippy::len_without_is_empty)]
 
+use cfgrammar::Span;
 use std::{error::Error, fmt, hash::Hash};
 
-use crate::{Lexeme, Span};
+use crate::Lexeme;
 
 type StorageT = u16;
 


### PR DESCRIPTION
This also allows us to mark lrpar::Span as deprecated, so people get a (hopefully) gentle upgrade path.

@ratmice Could you review this please? You'll have rights with bors to merge it if/when you think it's ready.

bors delegate=ratmice