### PR TITLE
Implement FromIterator<&str> for NewlineCache.

### DIFF
--- a/cfgrammar/src/lib/newlinecache.rs
+++ b/cfgrammar/src/lib/newlinecache.rs
@@ -135,17 +135,26 @@ impl FromStr for NewlineCache {
     }
 }
 
+impl<'a> FromIterator<&'a str> for NewlineCache {
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = &'a str>,
+    {
+        let mut nlcache = NewlineCache::new();
+        for s in iter.into_iter() {
+            nlcache.feed(s)
+        }
+        nlcache
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::NewlineCache;
 
     fn newline_test_helper(feed: &[&str], tests: &[(usize, usize)]) {
-        let mut cache = NewlineCache::new();
-        let mut full_string = String::new();
-        for f in feed {
-            cache.feed(f);
-            full_string.push_str(f);
-        }
+        let cache: NewlineCache = feed.iter().copied().collect();
+        let full_string = feed.concat();
 
         let mut src_pos = 0;
         let mut result = Vec::new();


### PR DESCRIPTION
Adding a `FromStr` impl made me wonder if we couldn't clean up `newline_test_helper` a little with an `FromIterator` implementation.  It ends up adding more code than it removes, but does reduce code at the call site...
I think it makes the call site clearer.

I haven't really looked at the code generation and whether `feed` + `push_str` in a single loop yields any better code though.
But I guess the presence of `FromIterator` stops anyone from writing loops manually.

Curious if you think it is worthwhile?