### PR TITLE
Use NewlineCache inside lrlex.

### DIFF
--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -57,6 +57,7 @@ pub mod newlinecache;
 pub mod span;
 pub mod yacc;
 
+pub use newlinecache::NewlineCache;
 pub use span::Span;
 
 /// A type specifically for rule indices.

--- a/lrlex/examples/calc_manual_lex/src/main.rs
+++ b/lrlex/examples/calc_manual_lex/src/main.rs
@@ -2,7 +2,7 @@
 
 use std::io::{self, BufRead, Write};
 
-use cfgrammar::Span;
+use cfgrammar::{NewlineCache, Span};
 use lrlex::{lrlex_mod, DefaultLexeme, LRNonStreamingLexer};
 use lrpar::{lrpar_mod, Lexeme, NonStreamingLexer};
 
@@ -98,7 +98,7 @@ fn lex(s: &str) -> LRNonStreamingLexer<DefaultLexeme<u8>, u8> {
             }
         }
     }
-    LRNonStreamingLexer::new(s, lexemes, Vec::new())
+    LRNonStreamingLexer::new(s, lexemes, NewlineCache::new())
 }
 
 fn eval(


### PR DESCRIPTION
This does require adding the `span_line_bytes` method, but is still a simplification overall.

@ratmice can you review this please? If/when you're happy with it, you can bors it.

bors delegate=ratmice