### PR TITLE
Collect spans for multiple duplicate rules during yacc parsing

### DIFF
--- a/cfgrammar/src/lib/span.rs
+++ b/cfgrammar/src/lib/span.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 /// A `Span` records what portion of the user's input something (e.g. a lexeme or production)
 /// references (i.e. the `Span` doesn't hold a reference / copy of the actual input).
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Span {
     start: usize,

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -13,6 +13,7 @@ use crate::Span;
 /// An AST representing a grammar. This is built up gradually: when it is finished, the
 /// `complete_and_validate` must be called exactly once in order to finish the set-up. At that
 /// point, any further mutations made to the struct lead to undefined behaviour.
+#[derive(Debug)]
 pub struct GrammarAST {
     pub start: Option<String>,
     // map from a rule name to indexes into prods


### PR DESCRIPTION
This series adds display in support of some tests,
then adds tests, then modifies `DuplicateRule` to collect spans into a vector.

It doesn't modify the return value, but does change behavior when you have a syntax error after a duplicate rule.
Now only triggers `DuplicateRule` error *after* successfully parsing all of the rules.

Not sure if we really want the macro, the reason it is a macro is because of the `$error_kind:path` which allows the match to work.
To turn it into a function I think we need to add `Eq`, and use the `if kind == error_kind` pattern guards.

The tests don't check the spans in anticipation of them changing.