### PR TITLE
Add a Vec<Span> to YaccErrorKind::Duplicate* variants

### DIFF
--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -20,8 +20,10 @@ pub struct GrammarAST {
     pub precs: HashMap<String, (Precedence, Span)>,
     pub avoid_insert: Option<HashMap<String, Span>>,
     pub implicit_tokens: Option<HashMap<String, Span>>,
-    // Error pretty-printers
-    pub epp: HashMap<String, String>,
+    // Error pretty-printers,
+    // The first span of the value is the span of the key,
+    // The second span in the value, is the span of the values string.
+    pub epp: HashMap<String, (Span, (String, Span))>,
     pub expect: Option<(usize, Span)>,
     pub expectrr: Option<(usize, Span)>,
     pub parse_param: Option<(String, String)>,
@@ -399,7 +401,8 @@ mod test {
         grm.start = Some(("A".to_string(), empty_span));
         grm.add_rule(("A".to_string(), empty_span), None);
         grm.add_prod("A".to_string(), vec![], None, None);
-        grm.epp.insert("k".to_owned(), "v".to_owned());
+        grm.epp
+            .insert("k".to_owned(), (empty_span, ("v".to_owned(), empty_span)));
         match grm.complete_and_validate() {
             Err(GrammarValidationError {
                 kind: GrammarValidationErrorKind::UnknownEPP,

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -194,7 +194,9 @@ where
         for (i, k) in ast.tokens.iter().enumerate() {
             token_names.push(Some((ast.spans[i], k.clone())));
             token_precs.push(ast.precs.get(k).map(|(prec, _)| prec).cloned());
-            token_epp.push(Some(ast.epp.get(k).unwrap_or(k).clone()));
+            token_epp.push(Some(
+                ast.epp.get(k).map(|(_, (s, _))| s).unwrap_or(k).clone(),
+            ));
         }
         let eof_token_idx = TIdx(token_names.len().as_());
         token_names.push(None);


### PR DESCRIPTION
It seems like it is best to add other YaccParserErrorKind variants for a nice clean history/merge.
(At least as long the variant isn't turning into a any kind of grand adventure).

* [X] `DuplicateRules` https://github.com/softdevteam/grmtools/commit/36534ca45807579adbc2907bf0aee6705dd3e1dc (In a previous PR #307),
* [X] `DuplicateAvoidInsert`
* [X] `DuplicatePrecedence`,
* [X] `DuplicateImplicitTokensDeclaration`,
* [X] `DuplicateExpectDeclaration`,
* [X] `DuplicateExpectRRDeclaration`,
* [X] `DuplicateStartDeclaration`,
* [X] `DuplicateActiontypeDeclaration`,
* [X] `DuplicateEPP`,