### PR TITLE
Add a Vec<Span> to LexErrorKind::DuplicateName

### DIFF
--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -50,7 +50,7 @@ pub enum LexErrorKind {
     UnknownDeclaration,
     MissingSpace,
     InvalidName,
-    DuplicateName,
+    DuplicateName(Vec<Span>),
     RegexError,
 }
 
@@ -62,7 +62,7 @@ impl fmt::Display for LexBuildError {
             LexErrorKind::UnknownDeclaration => "Unknown declaration",
             LexErrorKind::MissingSpace => "Rule is missing a space",
             LexErrorKind::InvalidName => "Invalid rule name",
-            LexErrorKind::DuplicateName => "Rule name already exists",
+            LexErrorKind::DuplicateName(_) => "Rule name already exists",
             LexErrorKind::RegexError => "Invalid regular expression",
         };
         write!(f, "{s}")


### PR DESCRIPTION
Previously this error returned a span which was at the initial quotation
mark.  Now it points to the string inside the quotation mark.

In this case it would be a bit of work to keep this behavior since wouldn't directly correlate to any `name_span`.
I figured it would be easier to do it later, than do it and undo it later because we don't want that complexity.

let me know if you would like to keep that behavior the same.