### PR TITLE
Prototype multiple errors for YaccParserError

### DIFF
--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -52,11 +52,13 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+pub mod errors;
 mod idxnewtype;
 pub mod newlinecache;
 pub mod span;
 pub mod yacc;
 
+pub use errors::Errors;
 pub use newlinecache::NewlineCache;
 pub use span::Span;
 

--- a/cfgrammar/src/lib/span.rs
+++ b/cfgrammar/src/lib/span.rs
@@ -43,3 +43,8 @@ impl Span {
         self.len() == 0
     }
 }
+
+pub trait Spanned {
+    fn span(&self) -> Span;
+    fn spans_of_duplicates(&self) -> Option<&[Span]>;
+}

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -12,7 +12,7 @@ use super::{
     parser::{YaccParser, YaccParserError},
     YaccKind,
 };
-use crate::{PIdx, RIdx, SIdx, Span, Symbol, TIdx};
+use crate::{Errors, PIdx, RIdx, SIdx, Span, Symbol, TIdx};
 
 const START_RULE: &str = "^";
 const IMPLICIT_RULE: &str = "~";
@@ -1025,14 +1025,14 @@ where
 
 #[derive(Debug)]
 pub enum YaccGrammarError {
-    YaccParserError(YaccParserError),
+    YaccParserError(Errors<YaccParserError>),
     GrammarValidationError(GrammarValidationError),
 }
 
 impl Error for YaccGrammarError {}
 
-impl From<YaccParserError> for YaccGrammarError {
-    fn from(err: YaccParserError) -> YaccGrammarError {
+impl From<Errors<YaccParserError>> for YaccGrammarError {
+    fn from(err: Errors<YaccParserError>) -> YaccGrammarError {
         YaccGrammarError::YaccParserError(err)
     }
 }

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -127,18 +127,7 @@ fn main() {
     let grm = match YaccGrammar::new(yacckind, &yacc_src) {
         Ok(x) => x,
         Err(YaccGrammarError::YaccParserError(s)) => {
-            let nlcache = NewlineCache::from_str(&yacc_src).unwrap();
-            if let Some((line, column)) = nlcache.byte_to_line_and_col(&yacc_src, s.span.start()) {
-                writeln!(
-                    stderr(),
-                    "{}: {} at line {line} column {column}",
-                    &yacc_y_path,
-                    &s
-                )
-                .ok();
-            } else {
-                writeln!(stderr(), "{}: {}", &yacc_y_path, &s).ok();
-            }
+            s.display_with_src_path(&yacc_src, yacc_y_path).unwrap();
             process::exit(1);
         }
         Err(YaccGrammarError::GrammarValidationError(s)) => {


### PR DESCRIPTION
I may be absent for a few days, Here is at least an experiment towards returning multiple errors.
It also tries to do some methods for integrating the newline cache/custom display methods,
I ended up with an unsafe line, and don't have time to see if there is a nice way to remove it.

It basically is just a newtype around Vec (with a pub vec even), that implements `Display + Debug`.
I'd added a trait for primary & duplicate spans...

Perhaps I got carried away, and it could be split up, below is as far as I got on the output.


```
foo.y: 3 Errors were encountered
  Duplicated %avoid_insert declaration at line 4 column 16
    1 duplicate at:
      line 5 column 16
  Duplicated %start declaration at line 1 column 8
    2 duplicates at:
      line 2 column 8
      line 3 column 8
```