### PR TITLE
Rename methods

### DIFF
--- a/cfgrammar/src/lib/newlinecache.rs
+++ b/cfgrammar/src/lib/newlinecache.rs
@@ -92,7 +92,7 @@ impl NewlineCache {
     ///
     /// May panic if `src` is different than the string(s) passed to `feed` (or might not panic and
     /// return non-deterministic results).
-    pub fn byte_to_line_and_col(&self, src: &str, byte: usize) -> Option<(usize, usize)> {
+    pub fn byte_to_line_num_and_col_num(&self, src: &str, byte: usize) -> Option<(usize, usize)> {
         if byte > self.feed_len() || src.len() != self.feed_len() {
             return None;
         }
@@ -183,7 +183,8 @@ mod tests {
         let mut result = Vec::new();
         for f in feed {
             for (offset, _) in f.char_indices() {
-                let line_col = cache.byte_to_line_and_col(full_string.as_str(), offset + src_pos);
+                let line_col =
+                    cache.byte_to_line_num_and_col_num(full_string.as_str(), offset + src_pos);
                 result.push(line_col.unwrap())
             }
             src_pos += f.len();
@@ -266,13 +267,13 @@ mod tests {
         // Byte exceeds input length
         cache.feed("1");
         assert_eq!(None, cache.byte_to_line_num(2));
-        assert_eq!(None, cache.byte_to_line_and_col("1", 2));
+        assert_eq!(None, cache.byte_to_line_num_and_col_num("1", 2));
         cache.feed("\n23");
         assert_eq!(None, cache.byte_to_line_num(5));
-        assert_eq!(None, cache.byte_to_line_and_col("1\n23", 5));
+        assert_eq!(None, cache.byte_to_line_num_and_col_num("1\n23", 5));
 
         // Byte valid, but src.len() exceeds input length.
-        assert_eq!(None, cache.byte_to_line_and_col("1\n234", 1));
+        assert_eq!(None, cache.byte_to_line_num_and_col_num("1\n234", 1));
     }
 
     #[test]

--- a/cfgrammar/src/lib/newlinecache.rs
+++ b/cfgrammar/src/lib/newlinecache.rs
@@ -1,8 +1,17 @@
 use crate::Span;
 use std::str::FromStr;
 
-/// Cache newlines from an input. These can be used to turn UTF-8 byte offsets into user-friendly
-/// line numbers without having to store the full input.
+/// Cache newlines from an input. These can be used to turn UTF-8 byte offsets into human-friendly
+/// line numbers (and vice versa) without having to store the full input. The cache stores only
+/// newline positions, and not the actual user input; the cache can only be filled incrementally
+/// using the [NewlineCache::feed] method.
+///
+/// It is easy to to intermix bytes and human-friendly line numbers so `NewlineCache` uses the
+/// following terminology:
+///   * `byte` and `byte`s: a UTF-8 byte offset.
+///   * `line_byte` and `line_byte`s: the UTF-8 byte offset of a line start or end.
+///   * `line_num`: a human-friendly line number.
+///   * `col_num`: a human-friendly column number.
 pub struct NewlineCache {
     newlines: Vec<usize>,
     trailing_bytes: usize,

--- a/cfgrammar/src/lib/newlinecache.rs
+++ b/cfgrammar/src/lib/newlinecache.rs
@@ -40,7 +40,7 @@ impl NewlineCache {
     /// Convert a byte offset in the input to a logical line number (i.e. a "human friendly" line
     /// number, starting from 1). Returns None if the byte offset exceeds the known input length.
     pub fn byte_to_line_num(&self, byte: usize) -> Option<usize> {
-        if byte > self.input_length() {
+        if byte > self.feed_len() {
             return None;
         }
 
@@ -62,7 +62,7 @@ impl NewlineCache {
     }
 
     /// Total known input length
-    fn input_length(&self) -> usize {
+    fn feed_len(&self) -> usize {
         self.newlines.last().unwrap() + self.trailing_bytes
     }
 
@@ -93,7 +93,7 @@ impl NewlineCache {
     /// May panic if `src` is different than the string(s) passed to `feed` (or might not panic and
     /// return non-deterministic results).
     pub fn byte_to_line_and_col(&self, src: &str, byte: usize) -> Option<(usize, usize)> {
-        if byte > self.input_length() || src.len() != self.input_length() {
+        if byte > self.feed_len() || src.len() != self.feed_len() {
             return None;
         }
 

--- a/cfgrammar/src/lib/newlinecache.rs
+++ b/cfgrammar/src/lib/newlinecache.rs
@@ -61,7 +61,7 @@ impl NewlineCache {
         }
     }
 
-    /// Total known input length
+    /// Number of bytes fed into the newline cache.
     fn feed_len(&self) -> usize {
         self.newlines.last().unwrap() + self.trailing_bytes
     }

--- a/cfgrammar/src/lib/newlinecache.rs
+++ b/cfgrammar/src/lib/newlinecache.rs
@@ -37,6 +37,11 @@ impl NewlineCache {
             }));
     }
 
+    /// Number of bytes fed into the newline cache.
+    fn feed_len(&self) -> usize {
+        self.newlines.last().unwrap() + self.trailing_bytes
+    }
+
     /// Convert a byte offset in the input to a logical line number (i.e. a "human friendly" line
     /// number, starting from 1). Returns None if the byte offset exceeds the known input length.
     pub fn byte_to_line_num(&self, byte: usize) -> Option<usize> {
@@ -59,11 +64,6 @@ impl NewlineCache {
                 .unwrap();
             Some(line_m1 + 1)
         }
-    }
-
-    /// Number of bytes fed into the newline cache.
-    fn feed_len(&self) -> usize {
-        self.newlines.last().unwrap() + self.trailing_bytes
     }
 
     /// Convert a logical line number into a byte offset.

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -860,7 +860,9 @@ mod test {
         ($src:ident, $e:ident) => {{
             let mut line_cache = crate::newlinecache::NewlineCache::new();
             line_cache.feed(&$src);
-            if let Some((line, column)) = line_cache.byte_to_line_and_col(&$src, $e.span.start()) {
+            if let Some((line, column)) =
+                line_cache.byte_to_line_num_and_col_num(&$src, $e.span.start())
+            {
                 panic!(
                     "Incorrect error returned {} at line {line} column {column}",
                     $e
@@ -876,7 +878,7 @@ mod test {
             let mut line_cache = crate::newlinecache::NewlineCache::new();
             line_cache.feed(&$src);
             line_cache
-                .byte_to_line_and_col(&$src, $span.start())
+                .byte_to_line_num_and_col_num(&$src, $span.start())
                 .unwrap()
         }};
     }

--- a/lrlex/src/lib/ctbuilder.rs
+++ b/lrlex/src/lib/ctbuilder.rs
@@ -310,7 +310,7 @@ where
                     let mut line_cache = NewlineCache::new();
                     line_cache.feed(&lex_src);
                     if let Some((line, column)) =
-                        line_cache.byte_to_line_and_col(&lex_src, e.span.start())
+                        line_cache.byte_to_line_num_and_col_num(&lex_src, e.span.start())
                     {
                         format!("{} at line {line} column {column}", e)
                     } else {

--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -348,10 +348,10 @@ impl<
 
         (
             self.newlines
-                .byte_to_line_and_col(self.s, span.start())
+                .byte_to_line_num_and_col_num(self.s, span.start())
                 .unwrap(),
             self.newlines
-                .byte_to_line_and_col(self.s, span.end())
+                .byte_to_line_num_and_col_num(self.s, span.end())
                 .unwrap(),
         )
     }

--- a/lrlex/src/lib/parser.rs
+++ b/lrlex/src/lib/parser.rs
@@ -165,7 +165,9 @@ mod test {
         ($src:ident, $e:ident) => {{
             let mut line_cache = ::cfgrammar::newlinecache::NewlineCache::new();
             line_cache.feed(&$src);
-            if let Some((line, column)) = line_cache.byte_to_line_and_col(&$src, $e.span.start()) {
+            if let Some((line, column)) =
+                line_cache.byte_to_line_num_and_col_num(&$src, $e.span.start())
+            {
                 panic!(
                     "Incorrect error returned {} at line {line} column {column}",
                     $e
@@ -181,7 +183,7 @@ mod test {
             let mut line_cache = ::cfgrammar::newlinecache::NewlineCache::new();
             line_cache.feed(&$src);
             line_cache
-                .byte_to_line_and_col(&$src, $span.start())
+                .byte_to_line_num_and_col_num(&$src, $span.start())
                 .unwrap()
         }};
     }

--- a/lrlex/src/main.rs
+++ b/lrlex/src/main.rs
@@ -58,7 +58,9 @@ fn main() {
     let lexerdef =
         LRNonStreamingLexerDef::<DefaultLexeme, _>::from_str(&lex_src).unwrap_or_else(|s| {
             let nlcache = NewlineCache::from_str(&lex_src).unwrap();
-            if let Some((line, column)) = nlcache.byte_to_line_and_col(&lex_src, s.span.start()) {
+            if let Some((line, column)) =
+                nlcache.byte_to_line_num_and_col_num(&lex_src, s.span.start())
+            {
                 writeln!(
                     stderr(),
                     "{}: {} at line {line} column {column}",

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -363,7 +363,8 @@ where
             YaccGrammarError::YaccParserError(e) => {
                 let mut line_cache = NewlineCache::new();
                 line_cache.feed(&inc);
-                if let Some((line, column)) = line_cache.byte_to_line_and_col(&inc, e.span.start())
+                if let Some((line, column)) =
+                    line_cache.byte_to_line_num_and_col_num(&inc, e.span.start())
                 {
                     format!("{} at line {line} column {column}", e)
                 } else {

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -107,7 +107,9 @@ fn main() {
         Ok(ast) => ast,
         Err(s) => {
             let nlcache = NewlineCache::from_str(&lex_src).unwrap();
-            if let Some((line, column)) = nlcache.byte_to_line_and_col(&lex_src, s.span.start()) {
+            if let Some((line, column)) =
+                nlcache.byte_to_line_num_and_col_num(&lex_src, s.span.start())
+            {
                 writeln!(
                     stderr(),
                     "{}: {} at line {line} column: {column}",
@@ -128,7 +130,9 @@ fn main() {
         Ok(x) => x,
         Err(YaccGrammarError::YaccParserError(s)) => {
             let nlcache = NewlineCache::from_str(&yacc_src).unwrap();
-            if let Some((line, column)) = nlcache.byte_to_line_and_col(&yacc_src, s.span.start()) {
+            if let Some((line, column)) =
+                nlcache.byte_to_line_num_and_col_num(&yacc_src, s.span.start())
+            {
                 writeln!(
                     stderr(),
                     "{}: {} at line {line} column {column}",


### PR DESCRIPTION
This PR renames some of `NewlineCache`s methods, (hopefully) making them more consistent, and documenting the pattern so that (again... hopefully!) people won't confuse bytes and line numbers too often.