### PR TITLE
merge YaccParserError and GrammarValidationError

### DIFF
--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -1,9 +1,9 @@
-use std::{collections::HashMap, error::Error, fmt};
+use std::{collections::HashMap, fmt};
 
 use indexmap::{IndexMap, IndexSet};
 
 use super::Precedence;
-
+use super::{YaccParserError, YaccParserErrorKind};
 use crate::Span;
 
 /// An AST representing a grammar. This is built up gradually: when it is finished, the
@@ -50,57 +50,6 @@ pub struct Production {
 pub enum Symbol {
     Rule(String, Span),
     Token(String, Span),
-}
-
-/// The various different possible grammar validation errors.
-#[derive(Debug)]
-pub enum GrammarValidationErrorKind {
-    NoStartRule,
-    InvalidStartRule,
-    UnknownRuleRef,
-    UnknownToken,
-    NoPrecForToken,
-    UnknownEPP,
-}
-
-/// `GrammarAST` validation errors return an instance of this struct.
-#[derive(Debug)]
-pub struct GrammarValidationError {
-    pub kind: GrammarValidationErrorKind,
-    pub sym: Option<Symbol>,
-}
-
-impl Error for GrammarValidationError {}
-
-impl fmt::Display for GrammarValidationError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.kind {
-            GrammarValidationErrorKind::NoStartRule => write!(f, "No start rule specified"),
-            GrammarValidationErrorKind::InvalidStartRule => write!(
-                f,
-                "Start rule '{}' does not appear in grammar",
-                self.sym.as_ref().unwrap()
-            ),
-            GrammarValidationErrorKind::UnknownRuleRef => write!(
-                f,
-                "Unknown reference to rule '{}'",
-                self.sym.as_ref().unwrap()
-            ),
-            GrammarValidationErrorKind::UnknownToken => {
-                write!(f, "Unknown token '{}'", self.sym.as_ref().unwrap())
-            }
-            GrammarValidationErrorKind::NoPrecForToken => write!(
-                f,
-                "Token '{}' used in %prec has no precedence attached",
-                self.sym.as_ref().unwrap()
-            ),
-            GrammarValidationErrorKind::UnknownEPP => write!(
-                f,
-                "Unknown token '{}' in %epp declaration",
-                self.sym.as_ref().unwrap()
-            ),
-        }
-    }
 }
 
 impl fmt::Display for Symbol {
@@ -183,19 +132,21 @@ impl GrammarAST {
     ///   4) If a production has a precedence token, then it references a declared token
     ///   5) Every token declared with %epp matches a known token
     /// If the validation succeeds, None is returned.
-    pub(crate) fn complete_and_validate(&mut self) -> Result<(), GrammarValidationError> {
+    pub(crate) fn complete_and_validate(&mut self) -> Result<(), YaccParserError> {
         match self.start {
             None => {
-                return Err(GrammarValidationError {
-                    kind: GrammarValidationErrorKind::NoStartRule,
+                return Err(YaccParserError {
+                    span: Span::new(0, 0),
+                    kind: YaccParserErrorKind::ValidationNoStartRule,
                     sym: None,
                 });
             }
             Some((ref s, span)) => {
                 if !self.rules.contains_key(s) {
-                    return Err(GrammarValidationError {
-                        kind: GrammarValidationErrorKind::InvalidStartRule,
+                    return Err(YaccParserError {
+                        kind: YaccParserErrorKind::ValidationInvalidStartRule,
                         sym: Some(Symbol::Rule(s.clone(), span)),
+                        span,
                     });
                 }
             }
@@ -205,33 +156,37 @@ impl GrammarAST {
                 let prod = &self.prods[pidx];
                 if let Some(ref n) = prod.precedence {
                     if !self.tokens.contains(n) {
-                        return Err(GrammarValidationError {
-                            kind: GrammarValidationErrorKind::UnknownToken,
+                        return Err(YaccParserError {
+                            kind: YaccParserErrorKind::ValidationUnknownToken,
                             sym: Some(Symbol::Token(n.clone(), Span::new(0, 0))),
+                            span: Span::new(0, 0),
                         });
                     }
                     if !self.precs.contains_key(n) {
-                        return Err(GrammarValidationError {
-                            kind: GrammarValidationErrorKind::NoPrecForToken,
+                        return Err(YaccParserError {
+                            kind: YaccParserErrorKind::ValidationNoPrecForToken,
                             sym: Some(Symbol::Token(n.clone(), Span::new(0, 0))),
+                            span: Span::new(0, 0),
                         });
                     }
                 }
                 for sym in &prod.symbols {
                     match *sym {
-                        Symbol::Rule(ref name, _) => {
+                        Symbol::Rule(ref name, span) => {
                             if !self.rules.contains_key(name) {
-                                return Err(GrammarValidationError {
-                                    kind: GrammarValidationErrorKind::UnknownRuleRef,
+                                return Err(YaccParserError {
+                                    kind: YaccParserErrorKind::ValidationUnknownRuleRef,
                                     sym: Some(sym.clone()),
+                                    span,
                                 });
                             }
                         }
-                        Symbol::Token(ref name, _) => {
+                        Symbol::Token(ref name, span) => {
                             if !self.tokens.contains(name) {
-                                return Err(GrammarValidationError {
-                                    kind: GrammarValidationErrorKind::UnknownToken,
+                                return Err(YaccParserError {
+                                    kind: YaccParserErrorKind::ValidationUnknownToken,
                                     sym: Some(sym.clone()),
+                                    span,
                                 });
                             }
                         }
@@ -248,9 +203,10 @@ impl GrammarAST {
                     continue;
                 }
             }
-            return Err(GrammarValidationError {
-                kind: GrammarValidationErrorKind::UnknownEPP,
+            return Err(YaccParserError {
+                kind: YaccParserErrorKind::ValidationUnknownEPP,
                 sym: Some(Symbol::Token(k.clone(), Span::new(0, 0))),
+                span: Span::new(0, 0),
             });
         }
         Ok(())
@@ -261,7 +217,7 @@ impl GrammarAST {
 mod test {
     use super::{
         super::{AssocKind, Precedence},
-        GrammarAST, GrammarValidationError, GrammarValidationErrorKind, Span, Symbol,
+        GrammarAST, Span, Symbol, YaccParserError, YaccParserErrorKind,
     };
 
     fn rule(n: &str) -> Symbol {
@@ -276,8 +232,8 @@ mod test {
     fn test_empty_grammar() {
         let mut grm = GrammarAST::new();
         match grm.complete_and_validate() {
-            Err(GrammarValidationError {
-                kind: GrammarValidationErrorKind::NoStartRule,
+            Err(YaccParserError {
+                kind: YaccParserErrorKind::ValidationNoStartRule,
                 ..
             }) => (),
             _ => panic!("Validation error"),
@@ -292,8 +248,8 @@ mod test {
         grm.add_rule(("B".to_string(), empty_span), None);
         grm.add_prod("B".to_string(), vec![], None, None);
         match grm.complete_and_validate() {
-            Err(GrammarValidationError {
-                kind: GrammarValidationErrorKind::InvalidStartRule,
+            Err(YaccParserError {
+                kind: YaccParserErrorKind::ValidationInvalidStartRule,
                 ..
             }) => (),
             _ => panic!("Validation error"),
@@ -330,8 +286,8 @@ mod test {
         grm.add_rule(("A".to_string(), empty_span), None);
         grm.add_prod("A".to_string(), vec![rule("B")], None, None);
         match grm.complete_and_validate() {
-            Err(GrammarValidationError {
-                kind: GrammarValidationErrorKind::UnknownRuleRef,
+            Err(YaccParserError {
+                kind: YaccParserErrorKind::ValidationUnknownRuleRef,
                 ..
             }) => (),
             _ => panic!("Validation error"),
@@ -370,8 +326,8 @@ mod test {
         grm.add_rule(("A".to_string(), empty_span), None);
         grm.add_prod("A".to_string(), vec![token("b")], None, None);
         match grm.complete_and_validate() {
-            Err(GrammarValidationError {
-                kind: GrammarValidationErrorKind::UnknownToken,
+            Err(YaccParserError {
+                kind: YaccParserErrorKind::ValidationUnknownToken,
                 ..
             }) => (),
             _ => panic!("Validation error"),
@@ -386,8 +342,8 @@ mod test {
         grm.add_rule(("A".to_string(), empty_span), None);
         grm.add_prod("A".to_string(), vec![rule("b"), token("b")], None, None);
         match grm.complete_and_validate() {
-            Err(GrammarValidationError {
-                kind: GrammarValidationErrorKind::UnknownRuleRef,
+            Err(YaccParserError {
+                kind: YaccParserErrorKind::ValidationUnknownRuleRef,
                 ..
             }) => (),
             _ => panic!("Validation error"),
@@ -404,8 +360,8 @@ mod test {
         grm.epp
             .insert("k".to_owned(), (empty_span, ("v".to_owned(), empty_span)));
         match grm.complete_and_validate() {
-            Err(GrammarValidationError {
-                kind: GrammarValidationErrorKind::UnknownEPP,
+            Err(YaccParserError {
+                kind: YaccParserErrorKind::ValidationUnknownEPP,
                 ..
             }) => (),
             _ => panic!("Validation error"),
@@ -451,16 +407,16 @@ mod test {
             None,
         );
         match grm.complete_and_validate() {
-            Err(GrammarValidationError {
-                kind: GrammarValidationErrorKind::UnknownToken,
+            Err(YaccParserError {
+                kind: YaccParserErrorKind::ValidationUnknownToken,
                 ..
             }) => (),
             _ => panic!("Validation error"),
         }
         grm.tokens.insert("b".to_string());
         match grm.complete_and_validate() {
-            Err(GrammarValidationError {
-                kind: GrammarValidationErrorKind::NoPrecForToken,
+            Err(YaccParserError {
+                kind: YaccParserErrorKind::ValidationNoPrecForToken,
                 ..
             }) => (),
             _ => panic!("Validation error"),

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, collections::HashMap, error::Error, fmt};
+use std::{cell::RefCell, collections::HashMap};
 
 use num_traits::{self, AsPrimitive, PrimInt, Unsigned};
 #[cfg(feature = "serde")]
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use vob::Vob;
 
 use super::{
-    ast::{self, GrammarValidationError},
+    ast,
     firsts::YaccFirsts,
     follows::YaccFollows,
     parser::{YaccParser, YaccParserError},
@@ -94,7 +94,7 @@ pub struct YaccGrammar<StorageT = u32> {
 // create the start rule ourselves (without relying on user input), this is a safe assumption.
 
 impl YaccGrammar<u32> {
-    pub fn new(yacc_kind: YaccKind, s: &str) -> Result<Self, YaccGrammarError> {
+    pub fn new(yacc_kind: YaccKind, s: &str) -> Result<Self, YaccParserError> {
         YaccGrammar::new_with_storaget(yacc_kind, s)
     }
 }
@@ -110,7 +110,7 @@ where
     /// As we're compiling the `YaccGrammar`, we add a new start rule (which we'll refer to as `^`,
     /// though the actual name is a fresh name that is guaranteed to be unique) that references the
     /// user defined start rule.
-    pub fn new_with_storaget(yacc_kind: YaccKind, s: &str) -> Result<Self, YaccGrammarError> {
+    pub fn new_with_storaget(yacc_kind: YaccKind, s: &str) -> Result<Self, YaccParserError> {
         let ast = match yacc_kind {
             YaccKind::Original(_) | YaccKind::Grmtools | YaccKind::Eco => {
                 let mut yp = YaccParser::new(yacc_kind, s.to_string());
@@ -1021,35 +1021,6 @@ where
         }
     }
     costs
-}
-
-#[derive(Debug)]
-pub enum YaccGrammarError {
-    YaccParserError(YaccParserError),
-    GrammarValidationError(GrammarValidationError),
-}
-
-impl Error for YaccGrammarError {}
-
-impl From<YaccParserError> for YaccGrammarError {
-    fn from(err: YaccParserError) -> YaccGrammarError {
-        YaccGrammarError::YaccParserError(err)
-    }
-}
-
-impl From<GrammarValidationError> for YaccGrammarError {
-    fn from(err: GrammarValidationError) -> YaccGrammarError {
-        YaccGrammarError::GrammarValidationError(err)
-    }
-}
-
-impl fmt::Display for YaccGrammarError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            YaccGrammarError::YaccParserError(ref e) => e.fmt(f),
-            YaccGrammarError::GrammarValidationError(ref e) => e.fmt(f),
-        }
-    }
 }
 
 #[cfg(test)]

--- a/cfgrammar/src/lib/yacc/mod.rs
+++ b/cfgrammar/src/lib/yacc/mod.rs
@@ -5,8 +5,7 @@ pub mod grammar;
 pub mod parser;
 
 pub use self::{
-    ast::{GrammarValidationError, GrammarValidationErrorKind},
-    grammar::{AssocKind, Precedence, SentenceGenerator, YaccGrammar, YaccGrammarError},
+    grammar::{AssocKind, Precedence, SentenceGenerator, YaccGrammar},
     parser::{YaccParserError, YaccParserErrorKind},
 };
 

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -19,7 +19,7 @@ use std::{
 use bincode::{deserialize, serialize_into};
 use cfgrammar::{
     newlinecache::NewlineCache,
-    yacc::{YaccGrammar, YaccGrammarError, YaccKind, YaccOriginalActionKind},
+    yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
     RIdx, Symbol,
 };
 use filetime::FileTime;
@@ -359,18 +359,14 @@ where
 
         let inc = read_to_string(grmp).unwrap();
 
-        let grm = YaccGrammar::<StorageT>::new_with_storaget(yk, &inc).map_err(|e| match e {
-            YaccGrammarError::YaccParserError(e) => {
-                let mut line_cache = NewlineCache::new();
-                line_cache.feed(&inc);
-                if let Some((line, column)) = line_cache.byte_to_line_and_col(&inc, e.span.start())
-                {
-                    format!("{} at line {line} column {column}", e)
-                } else {
-                    format!("{}", e)
-                }
+        let grm = YaccGrammar::<StorageT>::new_with_storaget(yk, &inc).map_err(|e| {
+            let mut line_cache = NewlineCache::new();
+            line_cache.feed(&inc);
+            if let Some((line, column)) = line_cache.byte_to_line_and_col(&inc, e.span.start()) {
+                format!("{} at line {line} column {column}", e)
+            } else {
+                format!("{}", e)
             }
-            e => e.to_string(),
         })?;
         let rule_ids = grm
             .tokens_map()

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -9,7 +9,7 @@ use std::{
 
 use cfgrammar::{
     newlinecache::NewlineCache,
-    yacc::{YaccGrammar, YaccGrammarError, YaccKind, YaccOriginalActionKind},
+    yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
 };
 use getopts::Options;
 use lrlex::{DefaultLexeme, LRNonStreamingLexerDef, LexerDef};
@@ -126,7 +126,7 @@ fn main() {
     let yacc_src = read_file(yacc_y_path);
     let grm = match YaccGrammar::new(yacckind, &yacc_src) {
         Ok(x) => x,
-        Err(YaccGrammarError::YaccParserError(s)) => {
+        Err(s) => {
             let nlcache = NewlineCache::from_str(&yacc_src).unwrap();
             if let Some((line, column)) = nlcache.byte_to_line_and_col(&yacc_src, s.span.start()) {
                 writeln!(
@@ -139,10 +139,6 @@ fn main() {
             } else {
                 writeln!(stderr(), "{}: {}", &yacc_y_path, &s).ok();
             }
-            process::exit(1);
-        }
-        Err(YaccGrammarError::GrammarValidationError(s)) => {
-            writeln!(stderr(), "{}: {}", &yacc_y_path, &s).ok();
             process::exit(1);
         }
     };


### PR DESCRIPTION
Here is kind of an exploratory patch, which we discussed in #311 
I say exploratory because it hits some rough edges, I had failed to notice there the `sym` field in `GrammarValidationError`,
this causes us 3 issues:

1. `Symbol` isn't `Eq` while `YaccParserError` is.  Used a manually derived `Eq`.
2. `Symbol` has a span, so the errors coming from `GrammarValidationError`, end up with both a span in the symbol,
    and a span in the error.
3. `YaccParserErrorKind` is `Display` and `GrammarValidationErrorKind` is not, I guess we could do better than I did,
   by printing the kind without the associated `Symbol` though.

For my own sanity I went ahead and prefixed all the `GrammarValidationErrorKind`s with `Validation` so, `NoStartRule` becomes `ValidationNoStartRule`, at least as a temporary thing.
