### PR TITLE
merge YaccParserError and GrammarValidationError take 2

### DIFF
--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, collections::HashMap, error::Error, fmt};
+use std::{cell::RefCell, collections::HashMap};
 
 use num_traits::{self, AsPrimitive, PrimInt, Unsigned};
 #[cfg(feature = "serde")]
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use vob::Vob;
 
 use super::{
-    ast::{self, GrammarValidationError},
+    ast,
     firsts::YaccFirsts,
     follows::YaccFollows,
     parser::{YaccParser, YaccParserError},
@@ -94,7 +94,7 @@ pub struct YaccGrammar<StorageT = u32> {
 // create the start rule ourselves (without relying on user input), this is a safe assumption.
 
 impl YaccGrammar<u32> {
-    pub fn new(yacc_kind: YaccKind, s: &str) -> Result<Self, YaccGrammarError> {
+    pub fn new(yacc_kind: YaccKind, s: &str) -> Result<Self, YaccParserError> {
         YaccGrammar::new_with_storaget(yacc_kind, s)
     }
 }
@@ -105,12 +105,12 @@ where
 {
     /// Takes as input a Yacc grammar of [`YaccKind`](enum.YaccKind.html) as a `String` `s` and returns a
     /// [`YaccGrammar`](grammar/struct.YaccGrammar.html) (or
-    /// ([`YaccGrammarError`](grammar/enum.YaccGrammarError.html) on error).
+    /// ([`YaccParserError`](grammar/enum.YaccParserError.html) on error).
     ///
     /// As we're compiling the `YaccGrammar`, we add a new start rule (which we'll refer to as `^`,
     /// though the actual name is a fresh name that is guaranteed to be unique) that references the
     /// user defined start rule.
-    pub fn new_with_storaget(yacc_kind: YaccKind, s: &str) -> Result<Self, YaccGrammarError> {
+    pub fn new_with_storaget(yacc_kind: YaccKind, s: &str) -> Result<Self, YaccParserError> {
         let ast = match yacc_kind {
             YaccKind::Original(_) | YaccKind::Grmtools | YaccKind::Eco => {
                 let mut yp = YaccParser::new(yacc_kind, s.to_string());
@@ -1021,35 +1021,6 @@ where
         }
     }
     costs
-}
-
-#[derive(Debug)]
-pub enum YaccGrammarError {
-    YaccParserError(YaccParserError),
-    GrammarValidationError(GrammarValidationError),
-}
-
-impl Error for YaccGrammarError {}
-
-impl From<YaccParserError> for YaccGrammarError {
-    fn from(err: YaccParserError) -> YaccGrammarError {
-        YaccGrammarError::YaccParserError(err)
-    }
-}
-
-impl From<GrammarValidationError> for YaccGrammarError {
-    fn from(err: GrammarValidationError) -> YaccGrammarError {
-        YaccGrammarError::GrammarValidationError(err)
-    }
-}
-
-impl fmt::Display for YaccGrammarError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            YaccGrammarError::YaccParserError(ref e) => e.fmt(f),
-            YaccGrammarError::GrammarValidationError(ref e) => e.fmt(f),
-        }
-    }
 }
 
 #[cfg(test)]

--- a/cfgrammar/src/lib/yacc/mod.rs
+++ b/cfgrammar/src/lib/yacc/mod.rs
@@ -5,8 +5,7 @@ pub mod grammar;
 pub mod parser;
 
 pub use self::{
-    ast::{GrammarValidationError, GrammarValidationErrorKind},
-    grammar::{AssocKind, Precedence, SentenceGenerator, YaccGrammar, YaccGrammarError},
+    grammar::{AssocKind, Precedence, SentenceGenerator, YaccGrammar},
     parser::{YaccParserError, YaccParserErrorKind},
 };
 

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -55,6 +55,12 @@ pub enum YaccParserErrorKind {
     DuplicateEPP(Vec<Span>),
     ReachedEOL,
     InvalidString,
+    NoStartRule,
+    InvalidStartRule(String),
+    UnknownRuleRef(String),
+    UnknownToken(String),
+    NoPrecForToken(String),
+    UnknownEPP(String),
 }
 
 /// Any error from the Yacc parser returns an instance of this struct.
@@ -111,6 +117,26 @@ impl fmt::Display for YaccParserErrorKind {
                 "Reached end of line without finding expected content"
             }
             YaccParserErrorKind::InvalidString => "Invalid string",
+            YaccParserErrorKind::NoStartRule => return write!(f, "No start rule specified"),
+            YaccParserErrorKind::InvalidStartRule(name) => {
+                return write!(f, "Start rule '{}' does not appear in grammar", name)
+            }
+            YaccParserErrorKind::UnknownRuleRef(name) => {
+                return write!(f, "Unknown reference to rule '{}'", name)
+            }
+            YaccParserErrorKind::UnknownToken(name) => {
+                return write!(f, "Unknown token '{}'", name)
+            }
+            YaccParserErrorKind::NoPrecForToken(name) => {
+                return write!(
+                    f,
+                    "Token '{}' used in %prec has no precedence attached",
+                    name
+                )
+            }
+            YaccParserErrorKind::UnknownEPP(name) => {
+                return write!(f, "Unknown token '{}' in %epp declaration", name)
+            }
         };
         write!(f, "{}", s)
     }

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -19,7 +19,7 @@ use std::{
 use bincode::{deserialize, serialize_into};
 use cfgrammar::{
     newlinecache::NewlineCache,
-    yacc::{YaccGrammar, YaccGrammarError, YaccKind, YaccOriginalActionKind},
+    yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
     RIdx, Symbol,
 };
 use filetime::FileTime;
@@ -359,19 +359,16 @@ where
 
         let inc = read_to_string(grmp).unwrap();
 
-        let grm = YaccGrammar::<StorageT>::new_with_storaget(yk, &inc).map_err(|e| match e {
-            YaccGrammarError::YaccParserError(e) => {
-                let mut line_cache = NewlineCache::new();
-                line_cache.feed(&inc);
-                if let Some((line, column)) =
-                    line_cache.byte_to_line_num_and_col_num(&inc, e.span.start())
-                {
-                    format!("{} at line {line} column {column}", e)
-                } else {
-                    format!("{}", e)
-                }
+        let grm = YaccGrammar::<StorageT>::new_with_storaget(yk, &inc).map_err(|e| {
+            let mut line_cache = NewlineCache::new();
+            line_cache.feed(&inc);
+            if let Some((line, column)) =
+                line_cache.byte_to_line_num_and_col_num(&inc, e.span.start())
+            {
+                format!("{} at line {line} column {column}", e)
+            } else {
+                format!("{}", e)
             }
-            e => e.to_string(),
         })?;
         let rule_ids = grm
             .tokens_map()

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -9,7 +9,7 @@ use std::{
 
 use cfgrammar::{
     newlinecache::NewlineCache,
-    yacc::{YaccGrammar, YaccGrammarError, YaccKind, YaccOriginalActionKind},
+    yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
 };
 use getopts::Options;
 use lrlex::{DefaultLexeme, LRNonStreamingLexerDef, LexerDef};
@@ -128,7 +128,7 @@ fn main() {
     let yacc_src = read_file(yacc_y_path);
     let grm = match YaccGrammar::new(yacckind, &yacc_src) {
         Ok(x) => x,
-        Err(YaccGrammarError::YaccParserError(s)) => {
+        Err(s) => {
             let nlcache = NewlineCache::from_str(&yacc_src).unwrap();
             if let Some((line, column)) =
                 nlcache.byte_to_line_num_and_col_num(&yacc_src, s.span.start())
@@ -143,10 +143,6 @@ fn main() {
             } else {
                 writeln!(stderr(), "{}: {}", &yacc_y_path, &s).ok();
             }
-            process::exit(1);
-        }
-        Err(YaccGrammarError::GrammarValidationError(s)) => {
-            writeln!(stderr(), "{}: {}", &yacc_y_path, &s).ok();
             process::exit(1);
         }
     };


### PR DESCRIPTION
Here is basically take 2, I think this is the simplest way to merge these 2 structures, and remove the enum combining them.
I did it over 2 commits.  If we really don't want the `String` maybe we could remove that in a follow up, but it shouldn't affect the size of `YaccParserError` in the 2nd commit.

I'm thinking perhaps this combined structure should be named `YaccGrammarError` rather than `YaccParserError`,
It would be easy to do that in a additional commit with search/replace.

I didn't want to rename it here, because it would add a lot of noise due to the prevalence of `YaccParserError`.