### PR TITLE
minimal changes to return Vec<YaccGrammarError> from parse.

### DIFF
--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -359,16 +359,21 @@ where
 
         let inc = read_to_string(grmp).unwrap();
 
-        let grm = YaccGrammar::<StorageT>::new_with_storaget(yk, &inc).map_err(|e| {
-            let mut line_cache = NewlineCache::new();
-            line_cache.feed(&inc);
-            if let Some((line, column)) =
-                line_cache.byte_to_line_num_and_col_num(&inc, e.span.start())
-            {
-                format!("{} at line {line} column {column}", e)
-            } else {
-                format!("{}", e)
-            }
+        let grm = YaccGrammar::<StorageT>::new_with_storaget(yk, &inc).map_err(|errs| {
+            errs.iter()
+                .map(|e| {
+                    let mut line_cache = NewlineCache::new();
+                    line_cache.feed(&inc);
+                    if let Some((line, column)) =
+                        line_cache.byte_to_line_num_and_col_num(&inc, e.span.start())
+                    {
+                        format!("{} at line {line} column {column}", e)
+                    } else {
+                        format!("{}", e)
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
         })?;
         let rule_ids = grm
             .tokens_map()

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -128,20 +128,22 @@ fn main() {
     let yacc_src = read_file(yacc_y_path);
     let grm = match YaccGrammar::new(yacckind, &yacc_src) {
         Ok(x) => x,
-        Err(s) => {
+        Err(errs) => {
             let nlcache = NewlineCache::from_str(&yacc_src).unwrap();
-            if let Some((line, column)) =
-                nlcache.byte_to_line_num_and_col_num(&yacc_src, s.span.start())
-            {
-                writeln!(
-                    stderr(),
-                    "{}: {} at line {line} column {column}",
-                    &yacc_y_path,
-                    &s
-                )
-                .ok();
-            } else {
-                writeln!(stderr(), "{}: {}", &yacc_y_path, &s).ok();
+            for e in errs {
+                if let Some((line, column)) =
+                    nlcache.byte_to_line_num_and_col_num(&yacc_src, e.span.start())
+                {
+                    writeln!(
+                        stderr(),
+                        "{}: {} at line {line} column {column}",
+                        &yacc_y_path,
+                        &e
+                    )
+                    .ok();
+                } else {
+                    writeln!(stderr(), "{}: {}", &yacc_y_path, &e).ok();
+                }
             }
             process::exit(1);
         }


### PR DESCRIPTION
This changes the return value of `YaccParser::parse` from
`YaccGrammarError` to `Vec<YaccGrammarError>, currently
this vector will contain a single `YaccGrammarError`.

Existing tests are changed to expect one error,
callers are changed to now loop over the vector.

And the creation of `DuplicateRule` errors was moved from
`parse_rules` into `parse`.

supercedes #311 