### PR TITLE
Minimal changes to return Vec<LexBuildError>.

### DIFF
--- a/lrlex/src/lib/ctbuilder.rs
+++ b/lrlex/src/lib/ctbuilder.rs
@@ -12,6 +12,7 @@ use std::{
     hash::Hash,
     io::Write,
     path::{Path, PathBuf},
+    str::FromStr,
     sync::Mutex,
 };
 
@@ -304,14 +305,13 @@ where
         }
 
         let lex_src = read_to_string(&lexerp)?;
+        let line_cache = NewlineCache::from_str(&lex_src).unwrap();
         let mut lexerdef: Box<dyn LexerDef<StorageT>> = match self.lexerkind {
             LexerKind::LRNonStreamingLexer => Box::new(
                 LRNonStreamingLexerDef::<LexemeT, StorageT>::from_str(&lex_src).map_err(
                     |errs| {
                         errs.iter()
                             .map(|e| {
-                                let mut line_cache = NewlineCache::new();
-                                line_cache.feed(&lex_src);
                                 if let Some((line, column)) = line_cache
                                     .byte_to_line_num_and_col_num(&lex_src, e.span.start())
                                 {

--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -10,10 +10,7 @@
 #![allow(clippy::unnecessary_wraps)]
 #![allow(clippy::upper_case_acronyms)]
 
-use std::{error::Error, fmt, hash::Hash};
-
-use num_traits::{PrimInt, Unsigned};
-use try_from::TryFrom;
+use std::{error::Error, fmt};
 
 mod ctbuilder;
 #[doc(hidden)]
@@ -31,7 +28,7 @@ pub use crate::{
 
 use cfgrammar::Span;
 
-pub type LexBuildResult<T> = Result<T, LexBuildError>;
+pub type LexBuildResult<T> = Result<T, Vec<LexBuildError>>;
 
 /// Any error from the Lex parser returns an instance of this struct.
 #[derive(Debug)]
@@ -67,16 +64,6 @@ impl fmt::Display for LexBuildError {
         };
         write!(f, "{s}")
     }
-}
-
-#[deprecated(since = "0.8.0", note = "Please use LRNonStreamingLexerDef::from_str")]
-pub fn build_lex<
-    LexemeT: lrpar::Lexeme<StorageT>,
-    StorageT: Copy + Eq + Hash + PrimInt + TryFrom<usize> + Unsigned,
->(
-    s: &str,
-) -> Result<LRNonStreamingLexerDef<LexemeT, StorageT>, LexBuildError> {
-    LRNonStreamingLexerDef::from_str(s)
 }
 
 #[deprecated(

--- a/lrlex/src/lib/parser.rs
+++ b/lrlex/src/lib/parser.rs
@@ -4,6 +4,8 @@ use try_from::TryFrom;
 
 use crate::{lexer::Rule, LexBuildError, LexBuildResult, LexErrorKind};
 
+type LexInternalBuildResult<T> = Result<T, LexBuildError>;
+
 pub(super) struct LexParser<StorageT> {
     src: String,
     pub(super) rules: Vec<Rule<StorageT>>,
@@ -45,7 +47,7 @@ impl<StorageT: TryFrom<usize>> LexParser<StorageT> {
         }
     }
 
-    fn parse_declarations(&mut self, mut i: usize) -> LexBuildResult<usize> {
+    fn parse_declarations(&mut self, mut i: usize) -> LexInternalBuildResult<usize> {
         i = self.parse_ws(i)?;
         if let Some(j) = self.lookahead_is("%%", i) {
             return Ok(j);
@@ -57,7 +59,7 @@ impl<StorageT: TryFrom<usize>> LexParser<StorageT> {
         }
     }
 
-    fn parse_rules(&mut self, mut i: usize) -> LexBuildResult<usize> {
+    fn parse_rules(&mut self, mut i: usize) -> LexInternalBuildResult<usize> {
         loop {
             i = self.parse_ws(i)?;
             if i == self.src.len() {
@@ -77,7 +79,7 @@ impl<StorageT: TryFrom<usize>> LexParser<StorageT> {
         Ok(i)
     }
 
-    fn parse_rule(&mut self, i: usize) -> LexBuildResult<usize> {
+    fn parse_rule(&mut self, i: usize) -> LexInternalBuildResult<usize> {
         let line_len = self.src[i..]
             .find(|c| c == '\n')
             .unwrap_or(self.src.len() - i);
@@ -132,7 +134,7 @@ impl<StorageT: TryFrom<usize>> LexParser<StorageT> {
         Ok(i + line_len)
     }
 
-    fn parse_ws(&mut self, i: usize) -> LexBuildResult<usize> {
+    fn parse_ws(&mut self, i: usize) -> LexInternalBuildResult<usize> {
         let mut j = i;
         for c in self.src[i..].chars() {
             match c {

--- a/lrlex/src/main.rs
+++ b/lrlex/src/main.rs
@@ -56,20 +56,22 @@ fn main() {
     let lex_l_path = &matches.free[0];
     let lex_src = read_file(lex_l_path);
     let lexerdef =
-        LRNonStreamingLexerDef::<DefaultLexeme, _>::from_str(&lex_src).unwrap_or_else(|s| {
+        LRNonStreamingLexerDef::<DefaultLexeme, _>::from_str(&lex_src).unwrap_or_else(|errs| {
             let nlcache = NewlineCache::from_str(&lex_src).unwrap();
-            if let Some((line, column)) =
-                nlcache.byte_to_line_num_and_col_num(&lex_src, s.span.start())
-            {
-                writeln!(
-                    stderr(),
-                    "{}: {} at line {line} column {column}",
-                    &lex_l_path,
-                    &s
-                )
-                .ok();
-            } else {
-                writeln!(stderr(), "{}: {}", &lex_l_path, &s).ok();
+            for e in errs {
+                if let Some((line, column)) =
+                    nlcache.byte_to_line_num_and_col_num(&lex_src, e.span.start())
+                {
+                    writeln!(
+                        stderr(),
+                        "{}: {} at line {line} column {column}",
+                        &lex_l_path,
+                        &e
+                    )
+                    .ok();
+                } else {
+                    writeln!(stderr(), "{}: {}", &lex_l_path, &e).ok();
+                }
             }
             process::exit(1);
         });

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -105,20 +105,22 @@ fn main() {
     let lex_src = read_file(lex_l_path);
     let mut lexerdef = match LRNonStreamingLexerDef::<DefaultLexeme<u32>, u32>::from_str(&lex_src) {
         Ok(ast) => ast,
-        Err(s) => {
+        Err(errs) => {
             let nlcache = NewlineCache::from_str(&lex_src).unwrap();
-            if let Some((line, column)) =
-                nlcache.byte_to_line_num_and_col_num(&lex_src, s.span.start())
-            {
-                writeln!(
-                    stderr(),
-                    "{}: {} at line {line} column: {column}",
-                    &lex_l_path,
-                    &s
-                )
-                .ok();
-            } else {
-                writeln!(stderr(), "{}: {}", &lex_l_path, &s).ok();
+            for e in errs {
+                if let Some((line, column)) =
+                    nlcache.byte_to_line_num_and_col_num(&lex_src, e.span.start())
+                {
+                    writeln!(
+                        stderr(),
+                        "{}: {} at line {line} column: {column}",
+                        &lex_l_path,
+                        &e
+                    )
+                    .ok();
+                } else {
+                    writeln!(stderr(), "{}: {}", &lex_l_path, &e).ok();
+                }
             }
             process::exit(1);
         }


### PR DESCRIPTION
While we now return a vector, it currently never contains more than
a single error within that vector, in preparation to eventually return
multiple errors at a time.

In support of this:
* The `LexerDef` trait's `from_str` method, has been changed to
  return a `Result<.., Vec<LexBuildError>` instead of a `LexBuildResult`.
* The deprecated function `build_lex` has been removed.
* Existing tests expecting the current behavior `LexBuildError`
  now expect a vector with a single error.