### PR TITLE
add a YaccResult

### DIFF
--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -6,7 +6,11 @@ use serde::{Deserialize, Serialize};
 use vob::Vob;
 
 use super::{
-    ast, firsts::YaccFirsts, follows::YaccFollows, parser::YaccParser, YaccGrammarError, YaccKind,
+    ast,
+    firsts::YaccFirsts,
+    follows::YaccFollows,
+    parser::{YaccGrammarResult, YaccParser},
+    YaccKind,
 };
 use crate::{PIdx, RIdx, SIdx, Span, Symbol, TIdx};
 
@@ -90,7 +94,7 @@ pub struct YaccGrammar<StorageT = u32> {
 // create the start rule ourselves (without relying on user input), this is a safe assumption.
 
 impl YaccGrammar<u32> {
-    pub fn new(yacc_kind: YaccKind, s: &str) -> Result<Self, Vec<YaccGrammarError>> {
+    pub fn new(yacc_kind: YaccKind, s: &str) -> YaccGrammarResult<Self> {
         YaccGrammar::new_with_storaget(yacc_kind, s)
     }
 }
@@ -106,7 +110,7 @@ where
     /// As we're compiling the `YaccGrammar`, we add a new start rule (which we'll refer to as `^`,
     /// though the actual name is a fresh name that is guaranteed to be unique) that references the
     /// user defined start rule.
-    pub fn new_with_storaget(yacc_kind: YaccKind, s: &str) -> Result<Self, Vec<YaccGrammarError>> {
+    pub fn new_with_storaget(yacc_kind: YaccKind, s: &str) -> YaccGrammarResult<Self> {
         let ast = match yacc_kind {
             YaccKind::Original(_) | YaccKind::Grmtools | YaccKind::Eco => {
                 let mut yp = YaccParser::new(yacc_kind, s.to_string());

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -10,6 +10,8 @@ use std::{
     str::FromStr,
 };
 
+pub type YaccGrammarResult<T> = Result<T, Vec<YaccGrammarError>>;
+
 use crate::Span;
 
 use super::{
@@ -186,7 +188,7 @@ impl YaccParser {
         }
     }
 
-    pub(crate) fn parse(&mut self) -> Result<usize, Vec<YaccGrammarError>> {
+    pub(crate) fn parse(&mut self) -> YaccGrammarResult<usize> {
         // We pass around an index into the *bytes* of self.src. We guarantee that at all times
         // this points to the beginning of a UTF-8 character (since multibyte characters exist, not
         // every byte within the string is also a valid character).


### PR DESCRIPTION
It occurred to me we might want to the same internal/public type alias for errors as we do with `LexBuildResult`, for *yacc*.

I'm not sure if this is absolutely necessary, e.g. `YaccResult` is currently private unlike how `LexBuildResult` was already public.
But perhaps it is worthwhile having the crates to conform to similar patterns.

I don't believe that this should conflict with anything in the branch of @SMartinScottLogic , which seems fairly isolated to *lrlex*.
But if in doubt deference to that work, since this is mostly search/replace, I just wanted to bring it up while I was thinking about it, so it didn't slip through the cracks.