### PR TITLE
Rename cfgrammar::yacc::ast::Symbol to ASTSymbol.

### DIFF
--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -40,23 +40,23 @@ pub struct Rule {
 #[derive(Debug)]
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct Production {
-    pub symbols: Vec<Symbol>,
+    pub symbols: Vec<ASTSymbol>,
     pub precedence: Option<String>,
     pub action: Option<String>,
 }
 
 #[derive(Clone, Debug)]
 #[cfg_attr(test, derive(Eq, PartialEq))]
-pub enum Symbol {
+pub enum ASTSymbol {
     Rule(String, Span),
     Token(String, Span),
 }
 
-impl fmt::Display for Symbol {
+impl fmt::Display for ASTSymbol {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Symbol::Rule(ref s, _) => write!(f, "{}", s),
-            Symbol::Token(ref s, _) => write!(f, "{}", s),
+            ASTSymbol::Rule(ref s, _) => write!(f, "{}", s),
+            ASTSymbol::Token(ref s, _) => write!(f, "{}", s),
         }
     }
 }
@@ -95,7 +95,7 @@ impl GrammarAST {
     pub fn add_prod(
         &mut self,
         rule_name: String,
-        symbols: Vec<Symbol>,
+        symbols: Vec<ASTSymbol>,
         precedence: Option<String>,
         action: Option<String>,
     ) {
@@ -168,7 +168,7 @@ impl GrammarAST {
                 }
                 for sym in &prod.symbols {
                     match *sym {
-                        Symbol::Rule(ref name, span) => {
+                        ASTSymbol::Rule(ref name, span) => {
                             if !self.rules.contains_key(name) {
                                 return Err(YaccGrammarError {
                                     kind: YaccGrammarErrorKind::UnknownRuleRef(name.clone()),
@@ -176,7 +176,7 @@ impl GrammarAST {
                                 });
                             }
                         }
-                        Symbol::Token(ref name, span) => {
+                        ASTSymbol::Token(ref name, span) => {
                             if !self.tokens.contains(name) {
                                 return Err(YaccGrammarError {
                                     kind: YaccGrammarErrorKind::UnknownToken(name.clone()),
@@ -210,15 +210,15 @@ impl GrammarAST {
 mod test {
     use super::{
         super::{AssocKind, Precedence},
-        GrammarAST, Span, Symbol, YaccGrammarError, YaccGrammarErrorKind,
+        ASTSymbol, GrammarAST, Span, YaccGrammarError, YaccGrammarErrorKind,
     };
 
-    fn rule(n: &str) -> Symbol {
-        Symbol::Rule(n.to_string(), Span::new(0, 0))
+    fn rule(n: &str) -> ASTSymbol {
+        ASTSymbol::Rule(n.to_string(), Span::new(0, 0))
     }
 
-    fn token(n: &str) -> Symbol {
-        Symbol::Token(n.to_string(), Span::new(0, 0))
+    fn token(n: &str) -> ASTSymbol {
+        ASTSymbol::Token(n.to_string(), Span::new(0, 0))
     }
 
     #[test]

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -281,10 +281,10 @@ where
                 let mut prod = Vec::with_capacity(astprod.symbols.len());
                 for astsym in &astprod.symbols {
                     match *astsym {
-                        ast::Symbol::Rule(ref n, _) => {
+                        ast::ASTSymbol::Rule(ref n, _) => {
                             prod.push(Symbol::Rule(rule_map[n]));
                         }
-                        ast::Symbol::Token(ref n, _) => {
+                        ast::ASTSymbol::Token(ref n, _) => {
                             prod.push(Symbol::Token(token_map[n]));
                             if implicit_rule.is_some() {
                                 prod.push(Symbol::Rule(rule_map[&implicit_rule.clone().unwrap()]));
@@ -297,7 +297,7 @@ where
                     prec = Some(ast.precs[n]);
                 } else {
                     for astsym in astprod.symbols.iter().rev() {
-                        if let ast::Symbol::Token(ref n, _) = *astsym {
+                        if let ast::ASTSymbol::Token(ref n, _) = *astsym {
                             if let Some(p) = ast.precs.get(n) {
                                 prec = Some(*p);
                             }

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -15,7 +15,7 @@ type YaccResult<T> = Result<T, YaccGrammarError>;
 use crate::Span;
 
 use super::{
-    ast::{GrammarAST, Symbol},
+    ast::{ASTSymbol, GrammarAST},
     AssocKind, Precedence, YaccKind,
 };
 
@@ -555,7 +555,7 @@ impl YaccParser {
                 if self.ast.tokens.insert(sym.clone()) {
                     self.ast.spans.push(span);
                 }
-                syms.push(Symbol::Token(sym, span));
+                syms.push(ASTSymbol::Token(sym, span));
             } else if let Some(j) = self.lookahead_is("%prec", i) {
                 i = self.parse_ws(j, true)?;
                 let (k, sym, _) = self.parse_token(i)?;
@@ -572,9 +572,9 @@ impl YaccParser {
             } else {
                 let (j, sym, span) = self.parse_token(i)?;
                 if self.ast.tokens.contains(&sym) {
-                    syms.push(Symbol::Token(sym, span));
+                    syms.push(ASTSymbol::Token(sym, span));
                 } else {
-                    syms.push(Symbol::Rule(sym, span));
+                    syms.push(ASTSymbol::Rule(sym, span));
                 }
                 i = j;
             }
@@ -851,7 +851,7 @@ impl YaccParser {
 mod test {
     use super::{
         super::{
-            ast::{GrammarAST, Production, Symbol},
+            ast::{ASTSymbol, GrammarAST, Production},
             AssocKind, Precedence, YaccKind, YaccOriginalActionKind,
         },
         Span, YaccGrammarError, YaccGrammarErrorKind, YaccParser,
@@ -863,19 +863,19 @@ mod test {
         Ok(yp.ast())
     }
 
-    fn rule(n: &str) -> Symbol {
-        Symbol::Rule(n.to_string(), Span::new(0, 0))
+    fn rule(n: &str) -> ASTSymbol {
+        ASTSymbol::Rule(n.to_string(), Span::new(0, 0))
     }
 
-    fn rule_span(n: &str, span: Span) -> Symbol {
-        Symbol::Rule(n.to_string(), span)
+    fn rule_span(n: &str, span: Span) -> ASTSymbol {
+        ASTSymbol::Rule(n.to_string(), span)
     }
 
-    fn token(n: &str) -> Symbol {
-        Symbol::Token(n.to_string(), Span::new(0, 0))
+    fn token(n: &str) -> ASTSymbol {
+        ASTSymbol::Token(n.to_string(), Span::new(0, 0))
     }
-    fn token_span(n: &str, span: Span) -> Symbol {
-        Symbol::Token(n.to_string(), span)
+    fn token_span(n: &str, span: Span) -> ASTSymbol {
+        ASTSymbol::Token(n.to_string(), span)
     }
 
     fn line_of_offset(s: &str, off: usize) -> usize {
@@ -914,7 +914,10 @@ mod test {
 
     #[test]
     fn test_helper_fn() {
-        assert_eq!(Symbol::Token("A".to_string(), Span::new(0, 0)), token("A"));
+        assert_eq!(
+            ASTSymbol::Token("A".to_string(), Span::new(0, 0)),
+            token("A")
+        );
     }
 
     #[test]


### PR DESCRIPTION
Previously we had both `cfgrammar::Symbol` and
`cfgrammar::yacc::ast::Symbol`. The rename is intended to reduce
confusion this could cause.