### PR TITLE
Return multiple YaccGrammarErrors in YaccGrammarResult.

### DIFF
--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -913,6 +913,12 @@ mod test {
         s[..off].lines().count()
     }
 
+    /// Helper function which tests for equivalence between slices containing YaccGrammarErrors.
+    /// Does not assume that the slices are in the same order.
+    /// `errs` is the `&[YaccGrammarError]` obtained from a call to parse
+    /// `errs_expect` is the expected result of that call
+    /// Returns `false` if `errs` contains duplicates or the slices contain different
+    /// elements using an unordered comparison.
     fn check_errors(errs: &[YaccGrammarError], errs_expect: &[YaccGrammarError]) -> bool {
         let es = errs.iter().collect::<HashSet<&YaccGrammarError>>();
         let es_expect = errs_expect.iter().collect::<HashSet<&YaccGrammarError>>();


### PR DESCRIPTION
So these are an initial pair of commits for returning multiple `YaccGrammarError` in the vector of `YaccGrammarResult`,
It goes through the last 2 errors (from bottom up) and adds test cases for these.

These two patches cover all the changes to flow control, what is left is just calls to `errs.extend(...)` and test additions for the other `YaccGrammarErrorKind`s. And should be similar to the test additions and calls to `es.extend(...)`  for `DuplicateRule` and `DuplicateActiontypeDeclaration` herein.