### PR TITLE
move span fields to YaccGrammarError from kind, make fields private

### DIFF
--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -137,14 +137,14 @@ impl GrammarAST {
             None => {
                 return Err(YaccGrammarError {
                     kind: YaccGrammarErrorKind::NoStartRule,
-                    span: Span::new(0, 0),
+                    spans: vec![Span::new(0, 0)],
                 });
             }
             Some((ref s, span)) => {
                 if !self.rules.contains_key(s) {
                     return Err(YaccGrammarError {
                         kind: YaccGrammarErrorKind::InvalidStartRule(s.clone()),
-                        span,
+                        spans: vec![span],
                     });
                 }
             }
@@ -156,13 +156,13 @@ impl GrammarAST {
                     if !self.tokens.contains(n) {
                         return Err(YaccGrammarError {
                             kind: YaccGrammarErrorKind::UnknownToken(n.clone()),
-                            span: Span::new(0, 0),
+                            spans: vec![Span::new(0, 0)],
                         });
                     }
                     if !self.precs.contains_key(n) {
                         return Err(YaccGrammarError {
                             kind: YaccGrammarErrorKind::NoPrecForToken(n.clone()),
-                            span: Span::new(0, 0),
+                            spans: vec![Span::new(0, 0)],
                         });
                     }
                 }
@@ -172,7 +172,7 @@ impl GrammarAST {
                             if !self.rules.contains_key(name) {
                                 return Err(YaccGrammarError {
                                     kind: YaccGrammarErrorKind::UnknownRuleRef(name.clone()),
-                                    span,
+                                    spans: vec![span],
                                 });
                             }
                         }
@@ -180,7 +180,7 @@ impl GrammarAST {
                             if !self.tokens.contains(name) {
                                 return Err(YaccGrammarError {
                                     kind: YaccGrammarErrorKind::UnknownToken(name.clone()),
-                                    span,
+                                    spans: vec![span],
                                 });
                             }
                         }
@@ -199,7 +199,7 @@ impl GrammarAST {
             }
             return Err(YaccGrammarError {
                 kind: YaccGrammarErrorKind::UnknownEPP(k.clone()),
-                span: Span::new(0, 0),
+                spans: vec![Span::new(0, 0)],
             });
         }
         Ok(())

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -364,8 +364,8 @@ where
                 .map(|e| {
                     let mut line_cache = NewlineCache::new();
                     line_cache.feed(&inc);
-                    if let Some((line, column)) =
-                        line_cache.byte_to_line_num_and_col_num(&inc, e.span.start())
+                    if let Some((line, column)) = line_cache
+                        .byte_to_line_num_and_col_num(&inc, e.spans().next().unwrap().start())
                     {
                         format!("{} at line {line} column {column}", e)
                     } else {

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -133,8 +133,8 @@ fn main() {
         Err(errs) => {
             let nlcache = NewlineCache::from_str(&yacc_src).unwrap();
             for e in errs {
-                if let Some((line, column)) =
-                    nlcache.byte_to_line_num_and_col_num(&yacc_src, e.span.start())
+                if let Some((line, column)) = nlcache
+                    .byte_to_line_num_and_col_num(&yacc_src, e.spans().next().unwrap().start())
                 {
                     writeln!(
                         stderr(),


### PR DESCRIPTION
This reorganizes things moving the duplicate spans fields from kind into YaccGrammarError,
and adds an impl to replace direct access to spans. Also adds some subsequent cleanups which this allows.

This is intended to provide a better basis #321 although it doesn't implement that PR yet.
That could be either done here or in a subsequent PR.