### PR TITLE
Remove StIdxStorageT and replace it with StorageT

### DIFF
--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -39,7 +39,7 @@ enum RepairMerge<StorageT> {
 
 #[derive(Clone, Debug)]
 struct PathFNode<StorageT> {
-    pstack: Cactus<StIdx>,
+    pstack: Cactus<StIdx<StorageT>>,
     laidx: usize,
     repairs: Cactus<RepairMerge<StorageT>>,
     cf: u16,
@@ -55,7 +55,7 @@ impl<StorageT: PrimInt + Unsigned> PathFNode<StorageT> {
     }
 }
 
-impl<StorageT: PrimInt + Unsigned> Hash for PathFNode<StorageT> {
+impl<StorageT: Hash + PrimInt + Unsigned> Hash for PathFNode<StorageT> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.pstack.hash(state);
         self.laidx.hash(state);
@@ -144,7 +144,7 @@ where
         finish_by: Instant,
         parser: &Parser<LexemeT, StorageT, ActionT, ParamT>,
         in_laidx: usize,
-        in_pstack: &mut Vec<StIdx>,
+        in_pstack: &mut Vec<StIdx<StorageT>>,
         astack: &mut Vec<AStackType<LexemeT, ActionT>>,
         spans: &mut Vec<Span>,
     ) -> (usize, Vec<Vec<ParseRepair<LexemeT, StorageT>>>) {
@@ -459,7 +459,7 @@ fn apply_repairs<
 >(
     parser: &Parser<LexemeT, StorageT, ActionT, ParamT>,
     mut laidx: usize,
-    pstack: &mut Vec<StIdx>,
+    pstack: &mut Vec<StIdx<StorageT>>,
     astack: &mut Option<&mut Vec<AStackType<LexemeT, ActionT>>>,
     spans: &mut Option<&mut Vec<Span>>,
     repairs: &[ParseRepair<LexemeT, StorageT>],
@@ -559,7 +559,7 @@ fn rank_cnds<
     parser: &Parser<LexemeT, StorageT, ActionT, ParamT>,
     finish_by: Instant,
     in_laidx: usize,
-    in_pstack: &[StIdx],
+    in_pstack: &[StIdx<StorageT>],
     in_cnds: Vec<Vec<Vec<ParseRepair<LexemeT, StorageT>>>>,
 ) -> Vec<Vec<ParseRepair<LexemeT, StorageT>>>
 where

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -147,14 +147,16 @@ where
 {
     /// Create a new `CTParserBuilder`.
     ///
-    /// `StorageT` must be an unsigned integer type (e.g. `u8`, `u16`) which is big enough to index
-    /// (separately) all the tokens, rules, and productions in the grammar and less than or
-    /// equal in size to `usize` (e.g. on a 64-bit machine `u128` would be too big). In other
-    /// words, if you have a grammar with 256 tokens, 256 rules, and 256 productions, you
-    /// can safely specify `u8` here; but if any of those counts becomes 256 you will need to
-    /// specify `u16`. If you are parsing large files, the additional storage requirements of
-    /// larger integer types can be noticeable, and in such cases it can be worth specifying a
-    /// smaller type. `StorageT` defaults to `u32` if unspecified.
+    /// `StorageT` must be an unsigned integer type (e.g. `u8`, `u16`) which is:
+    ///   * big enough to index (separately) all the tokens, rules, productions in the grammar,
+    ///   * big enough to index the state table created from the grammar,
+    ///   * less than or equal in size to `u32`.
+    /// In other words, if you have a grammar with 256 tokens, 256 rules, and 256 productions,
+    /// which creates a state table of 256 states you can safely specify `u8` here; but if any of
+    /// those counts becomes 257 or greater you will need to specify `u16`. If you are parsing
+    /// large files, the additional storage requirements of larger integer types can be noticeable,
+    /// and in such cases it can be worth specifying a smaller type. `StorageT` defaults to `u32`
+    /// if unspecified.
     ///
     /// # Examples
     ///

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -64,7 +64,7 @@ where
     }
 }
 
-type PStack = Vec<StIdx>; // Parse stack
+type PStack<StorageT> = Vec<StIdx<StorageT>>; // Parse stack
 type TokenCostFn<'a, StorageT> = &'a (dyn Fn(TIdx<StorageT>) -> u8 + 'a);
 type ActionFn<'a, 'b, 'input, LexemeT, StorageT, ActionT, ParamT> = &'a dyn Fn(
     RIdx<StorageT>,
@@ -275,7 +275,7 @@ where
     fn lr(
         &self,
         mut laidx: usize,
-        pstack: &mut PStack,
+        pstack: &mut PStack<StorageT>,
         astack: &mut Vec<AStackType<LexemeT, ActionT>>,
         errors: &mut Vec<LexParseError<LexemeT, StorageT>>,
         spans: &mut Vec<Span>,
@@ -389,7 +389,7 @@ where
         lexeme_prefix: Option<LexemeT>,
         mut laidx: usize,
         end_laidx: usize,
-        pstack: &mut PStack,
+        pstack: &mut PStack<StorageT>,
         astack: &mut Option<&mut Vec<AStackType<LexemeT, ActionT>>>,
         spans: &mut Option<&mut Vec<Span>>,
     ) -> usize {
@@ -516,9 +516,9 @@ where
         lexeme_prefix: Option<LexemeT>,
         mut laidx: usize,
         end_laidx: usize,
-        mut pstack: Cactus<StIdx>,
+        mut pstack: Cactus<StIdx<StorageT>>,
         tstack: &mut Option<&mut Vec<Node<LexemeT, StorageT>>>,
-    ) -> (usize, Cactus<StIdx>) {
+    ) -> (usize, Cactus<StIdx<StorageT>>) {
         assert!(lexeme_prefix.is_none() || end_laidx == laidx + 1);
         while laidx != end_laidx {
             let stidx = *pstack.val().unwrap();
@@ -585,7 +585,7 @@ pub(super) trait Recoverer<
         finish_by: Instant,
         parser: &Parser<LexemeT, StorageT, ActionT, ParamT>,
         in_laidx: usize,
-        in_pstack: &mut PStack,
+        in_pstack: &mut PStack<StorageT>,
         astack: &mut Vec<AStackType<LexemeT, ActionT>>,
         spans: &mut Vec<Span>,
     ) -> (usize, Vec<Vec<ParseRepair<LexemeT, StorageT>>>);
@@ -838,7 +838,7 @@ pub enum ParseRepair<LexemeT: Lexeme<StorageT>, StorageT: Hash> {
 /// Records a single parse error.
 #[derive(Clone, Debug, PartialEq)]
 pub struct ParseError<LexemeT: Lexeme<StorageT>, StorageT: Hash> {
-    stidx: StIdx,
+    stidx: StIdx<StorageT>,
     lexeme: LexemeT,
     repairs: Vec<Vec<ParseRepair<LexemeT, StorageT>>>,
 }
@@ -853,7 +853,7 @@ impl<LexemeT: Lexeme<StorageT>, StorageT: Debug + Hash> Error for ParseError<Lex
 
 impl<LexemeT: Lexeme<StorageT>, StorageT: Hash + PrimInt + Unsigned> ParseError<LexemeT, StorageT> {
     /// Return the state table index where this error was detected.
-    pub fn stidx(&self) -> StIdx {
+    pub fn stidx(&self) -> StIdx<StorageT> {
         self.stidx
     }
 

--- a/lrtable/Cargo.toml
+++ b/lrtable/Cargo.toml
@@ -20,4 +20,3 @@ cfgrammar = { path="../cfgrammar", version = "0.12", features=["serde"] }
 serde = { version="1.0", features=["derive"], optional=true }
 vob = { version="3.0", features=["serde"] }
 sparsevec = { version="0.1", features=["serde"] }
-static_assertions = "1.1"

--- a/lrtable/src/lib/pager.rs
+++ b/lrtable/src/lib/pager.rs
@@ -250,7 +250,7 @@ where
                     }
                 }
                 None => {
-                    assert!(core_states.len() <= usize::from(StIdxStorageT::max_value()));
+                    assert!(core_states.len() <= usize::try_from(StIdxStorageT::max_value()).unwrap());
                     // The assert above guarantees that the cast below is safe.
                     let stidx = StIdx(core_states.len() as StIdxStorageT);
                     match sym {

--- a/lrtable/src/lib/pager.rs
+++ b/lrtable/src/lib/pager.rs
@@ -128,9 +128,12 @@ where
     // closed_states also implicitly serves as a todo list.
     let mut closed_states = Vec::new();
     let mut core_states = Vec::new();
-    let mut edges: Vec<HashMap<Symbol<StorageT>, StIdx<StorageT>>> = Vec::new();
+    let mut edges: Vec<HashMap<Symbol<StorageT>, StIdx<usize>>> = Vec::new();
 
-    let start_state = StIdx(StorageT::zero());
+    // Because we GC states later, it's possible that we will end up with more states before GC
+    // than `StorageT` can hold. We thus do all our calculations in this function in terms of
+    // `usize`s before converting them to `StorageT` later.
+    let start_state = StIdx(0usize);
     let mut state0 = Itemset::new(grm);
     let mut ctx = Vob::from_elem(false, usize::from(grm.tokens_len()));
     ctx.set(usize::from(grm.eof_token_idx()), true);
@@ -147,9 +150,9 @@ where
     let mut new_states = Vec::new();
     // cnd_[rule|token]_weaklies represent which states are possible weakly compatible
     // matches for a given symbol.
-    let mut cnd_rule_weaklies: Vec<Vec<StIdx<StorageT>>> =
+    let mut cnd_rule_weaklies: Vec<Vec<StIdx<usize>>> =
         vec![Vec::new(); usize::from(grm.rules_len())];
-    let mut cnd_token_weaklies: Vec<Vec<StIdx<StorageT>>> =
+    let mut cnd_token_weaklies: Vec<Vec<StIdx<usize>>> =
         vec![Vec::new(); usize::from(grm.tokens_len()).checked_add(1).unwrap()];
 
     let mut todo = 1; // How many None values are there in closed_states?
@@ -256,8 +259,9 @@ where
                     if core_states.len() >= num_traits::cast(StorageT::max_value()).unwrap() {
                         panic!("StorageT is not big enough to store this stategraph.");
                     }
-                    // The assert above guarantees that the cast below is safe.
-                    let stidx = StIdx(core_states.len().as_());
+                    // The condition above guarantees that core_states.len() will fit in a StorageT
+                    // and thus the implicit StorageT -> usize cast therein is safe.
+                    let stidx = StIdx(core_states.len());
                     match sym {
                         Symbol::Rule(s_ridx) => {
                             cnd_rule_weaklies[usize::from(s_ridx)].push(stidx);
@@ -291,18 +295,34 @@ where
         edges,
     );
 
-    StateGraph::new(gc_states, start_state, gc_edges)
+    // Check that StorageT is big enough to hold RIdx/PIdx/SIdx/TIdx values; after these
+    // checks we can guarantee that things like RIdx(ast.rules.len().as_()) are safe.
+    if gc_states.len() > num_traits::cast(StorageT::max_value()).unwrap() {
+        panic!("StorageT is not big enough to store this stategraph.");
+    }
+
+    let start_state = StIdx::<StorageT>(start_state.as_storaget().as_());
+    let mut gc_edges_storaget = Vec::with_capacity(gc_edges.len());
+    for x in gc_edges {
+        let mut m = HashMap::with_capacity(x.len());
+        for (k, v) in x {
+            m.insert(k, StIdx::<StorageT>(v.as_storaget().as_()));
+        }
+        gc_edges_storaget.push(m);
+    }
+
+    StateGraph::new(gc_states, start_state, gc_edges_storaget)
 }
 
 /// Garbage collect `zip_states` (of `(core_states, closed_state)`) and `edges`. Returns a new pair
 /// with unused states and their corresponding edges removed.
 fn gc<StorageT: 'static + Eq + Hash + PrimInt + Unsigned>(
     mut states: Vec<(Itemset<StorageT>, Itemset<StorageT>)>,
-    start_state: StIdx<StorageT>,
-    mut edges: Vec<HashMap<Symbol<StorageT>, StIdx<StorageT>>>,
+    start_state: StIdx<usize>,
+    mut edges: Vec<HashMap<Symbol<StorageT>, StIdx<usize>>>,
 ) -> (
     Vec<(Itemset<StorageT>, Itemset<StorageT>)>,
-    Vec<HashMap<Symbol<StorageT>, StIdx<StorageT>>>,
+    Vec<HashMap<Symbol<StorageT>, StIdx<usize>>>,
 )
 where
     usize: AsPrimitive<StorageT>,
@@ -345,12 +365,11 @@ where
     // The way we do this is to first iterate over all states, working out what the mapping
     // from seen states to their new offsets is.
     let mut gc_states = Vec::with_capacity(seen.len());
-    let mut offsets = Vec::<StIdx<StorageT>>::with_capacity(states.len());
+    let mut offsets = Vec::with_capacity(states.len());
     let mut offset = 0;
     for (state_i, zstate) in states.drain(..).enumerate() {
-        // state_i <= states_len(), which fits in StorageT, so state_i.as_() is safe.
-        offsets.push(StIdx((state_i - offset).as_()));
-        if !seen.contains(&StIdx(state_i.as_())) {
+        offsets.push(StIdx(state_i - offset));
+        if !seen.contains(&StIdx(state_i)) {
             offset += 1;
             continue;
         }
@@ -361,9 +380,7 @@ where
     // offset is corrected by looking it up in the offsets list.
     let mut gc_edges = Vec::with_capacity(seen.len());
     for (st_edge_i, st_edges) in edges.drain(..).enumerate() {
-        // edges goes from 0..states_len(), and we know the latter can safely fit into an
-        // StorageT, so the cast is safe.
-        if !seen.contains(&StIdx(st_edge_i.as_())) {
+        if !seen.contains(&StIdx(st_edge_i)) {
             continue;
         }
         gc_edges.push(

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -23,6 +23,7 @@ where
         start_state: StIdx<StorageT>,
         edges: Vec<HashMap<Symbol<StorageT>, StIdx<StorageT>>>,
     ) -> Self {
+        assert!(states.len() < num_traits::cast(StorageT::max_value()).unwrap());
         StateGraph {
             states,
             start_state,

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -3,15 +3,15 @@ use std::{collections::hash_map::HashMap, hash::Hash};
 use cfgrammar::{yacc::YaccGrammar, Symbol, TIdx};
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 
-use crate::{itemset::Itemset, StIdx, StIdxStorageT};
+use crate::{itemset::Itemset, StIdx};
 
 #[derive(Debug)]
 pub struct StateGraph<StorageT: Eq + Hash> {
     /// A vector of `(core_states, closed_states)` tuples.
     states: Vec<(Itemset<StorageT>, Itemset<StorageT>)>,
-    start_state: StIdx,
+    start_state: StIdx<StorageT>,
     /// For each state in `states`, edges is a hashmap from symbols to state offsets.
-    edges: Vec<HashMap<Symbol<StorageT>, StIdx>>,
+    edges: Vec<HashMap<Symbol<StorageT>, StIdx<StorageT>>>,
 }
 
 impl<StorageT: 'static + Hash + PrimInt + Unsigned> StateGraph<StorageT>
@@ -20,12 +20,9 @@ where
 {
     pub(crate) fn new(
         states: Vec<(Itemset<StorageT>, Itemset<StorageT>)>,
-        start_state: StIdx,
-        edges: Vec<HashMap<Symbol<StorageT>, StIdx>>,
+        start_state: StIdx<StorageT>,
+        edges: Vec<HashMap<Symbol<StorageT>, StIdx<StorageT>>>,
     ) -> Self {
-        // states.len() needs to fit into StIdxStorageT; however we don't need to worry about
-        // edges.len() (which merely needs to fit in a usize)
-        assert!(StIdxStorageT::try_from(states.len()).is_ok());
         StateGraph {
             states,
             start_state,
@@ -34,20 +31,20 @@ where
     }
 
     /// Return this state graph's start state.
-    pub fn start_state(&self) -> StIdx {
+    pub fn start_state(&self) -> StIdx<StorageT> {
         self.start_state
     }
 
     /// Return an iterator which produces (in order from `0..self.rules_len()`) all this
     /// grammar's valid `RIdx`s.
-    pub fn iter_stidxs(&self) -> Box<dyn Iterator<Item = StIdx>> {
+    pub fn iter_stidxs(&self) -> Box<dyn Iterator<Item = StIdx<StorageT>>> {
         // We can use as safely, because we know that we're only generating integers from
         // 0..self.states.len() which we've already checked fits within StIdxStorageT.
-        Box::new((0..self.states.len()).map(|x| StIdx(x as StIdxStorageT)))
+        Box::new((0..self.states.len()).map(|x| StIdx(x.as_())))
     }
 
     /// Return the itemset for closed state `stidx`. Panics if `stidx` doesn't exist.
-    pub fn closed_state(&self, stidx: StIdx) -> &Itemset<StorageT> {
+    pub fn closed_state(&self, stidx: StIdx<StorageT>) -> &Itemset<StorageT> {
         &self.states[usize::from(stidx)].1
     }
 
@@ -59,7 +56,7 @@ where
     }
 
     /// Return the itemset for core state `stidx` or `None` if it doesn't exist.
-    pub fn core_state(&self, stidx: StIdx) -> &Itemset<StorageT> {
+    pub fn core_state(&self, stidx: StIdx<StorageT>) -> &Itemset<StorageT> {
         &self.states[usize::from(stidx)].0
     }
 
@@ -70,13 +67,13 @@ where
 
     /// How many states does this `StateGraph` contain? NB: By definition the `StateGraph` contains
     /// the same number of core and closed states.
-    pub fn all_states_len(&self) -> StIdx {
+    pub fn all_states_len(&self) -> StIdx<StorageT> {
         // We checked in the constructor that self.states.len() can fit into StIdxStorageT
-        StIdx::from(self.states.len() as StIdxStorageT)
+        StIdx(self.states.len().as_())
     }
 
     /// Return the state pointed to by `sym` from `stidx` or `None` otherwise.
-    pub fn edge(&self, stidx: StIdx, sym: Symbol<StorageT>) -> Option<StIdx> {
+    pub fn edge(&self, stidx: StIdx<StorageT>, sym: Symbol<StorageT>) -> Option<StIdx<StorageT>> {
         self.edges
             .get(usize::from(stidx))
             .and_then(|x| x.get(&sym))
@@ -84,7 +81,7 @@ where
     }
 
     /// Return the edges for state `stidx`. Panics if `stidx` doesn't exist.
-    pub fn edges(&self, stidx: StIdx) -> &HashMap<Symbol<StorageT>, StIdx> {
+    pub fn edges(&self, stidx: StIdx<StorageT>) -> &HashMap<Symbol<StorageT>, StIdx<StorageT>> {
         &self.edges[usize::from(stidx)]
     }
 
@@ -97,7 +94,10 @@ where
     /// states are pretty printed; if set to false, all states (including non-core states) are
     /// pretty printed.
     pub fn pp(&self, grm: &YaccGrammar<StorageT>, core_states: bool) -> String {
-        fn num_digits(i: StIdx) -> usize {
+        fn num_digits<StorageT: 'static + Hash + PrimInt + Unsigned>(i: StIdx<StorageT>) -> usize
+        where
+            usize: AsPrimitive<StorageT>,
+        {
             if usize::from(i) == 0 {
                 1
             } else {
@@ -125,11 +125,7 @@ where
             }
             {
                 let padding = num_digits(self.all_states_len()) - num_digits(stidx);
-                o.push_str(&format!(
-                    "{}:{}",
-                    StIdxStorageT::from(stidx),
-                    " ".repeat(padding)
-                ));
+                o.push_str(&format!("{}:{}", usize::from(stidx), " ".repeat(padding)));
             }
 
             let st = if core_states { core_st } else { closed_st };


### PR DESCRIPTION
The main bulk of this PR is in https://github.com/softdevteam/grmtools/commit/af8c85ede6bfafe4b6828063a3672519e1833b4c and partially ameliorates a long-time grmtools wart, which is that the maximum number of parsing states was hardcoded to a `u16`. This commit moves that to `StoargeT` maximum states. In one sense that overloads `StorageT` but at least the user now has *some* control over how many states grmtools can deal with.

Thoughts welcome: this is a part of the code I haven't looked at in some time!