### PR TITLE
Move from usize to u64 backing storage for Vobs.

### DIFF
--- a/lrtable/Cargo.toml
+++ b/lrtable/Cargo.toml
@@ -18,5 +18,5 @@ fnv = "1.0"
 num-traits = "0.2"
 cfgrammar = { path="../cfgrammar", version = "0.12", features=["serde"] }
 serde = { version="1.0", features=["derive"], optional=true }
-vob = { version="3.0", features=["serde"] }
-sparsevec = { version="0.1", features=["serde"] }
+vob = { version=">=3.0.2", features=["serde"] }
+sparsevec = { version="0.2", features=["serde"] }

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -127,12 +127,12 @@ impl<StorageT> fmt::Display for StateTableError<StorageT> {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct StateTable<StorageT> {
     actions: SparseVec<usize>,
-    state_actions: Vob,
+    state_actions: Vob<u64>,
     gotos: SparseVec<usize>,
     start_state: StIdx<StorageT>,
-    core_reduces: Vob,
-    state_shifts: Vob,
-    reduce_states: Vob,
+    core_reduces: Vob<u64>,
+    state_shifts: Vob<u64>,
+    reduce_states: Vob<u64>,
     prods_len: PIdx<StorageT>,
     tokens_len: TIdx<StorageT>,
     conflicts: Option<Conflicts<StorageT>>,
@@ -165,7 +165,7 @@ where
         grm: &YaccGrammar<StorageT>,
         sg: &StateGraph<StorageT>,
     ) -> Result<Self, StateTableError<StorageT>> {
-        let mut state_actions = Vob::from_elem(
+        let mut state_actions = Vob::<u64>::from_elem_with_storage_type(
             false,
             usize::from(sg.all_states_len())
                 .checked_mul(usize::from(grm.tokens_len()))
@@ -289,19 +289,20 @@ where
         assert!(final_state.is_some());
 
         let mut nt_depth = HashMap::new();
-        let mut core_reduces = Vob::from_elem(
+        let mut core_reduces = Vob::<u64>::from_elem_with_storage_type(
             false,
             usize::from(sg.all_states_len())
                 .checked_mul(usize::from(grm.prods_len()))
                 .unwrap(),
         );
-        let mut state_shifts = Vob::from_elem(
+        let mut state_shifts = Vob::<u64>::from_elem_with_storage_type(
             false,
             usize::from(sg.all_states_len())
                 .checked_mul(usize::from(grm.tokens_len()))
                 .unwrap(),
         );
-        let mut reduce_states = Vob::from_elem(false, usize::from(sg.all_states_len()));
+        let mut reduce_states =
+            Vob::<u64>::from_elem_with_storage_type(false, usize::from(sg.all_states_len()));
         for stidx in sg.iter_stidxs() {
             nt_depth.clear();
             let mut only_reduces = true;
@@ -490,7 +491,7 @@ fn actions_offset<StorageT: PrimInt + Unsigned>(
 }
 
 pub struct StateActionsIterator<'a, StorageT> {
-    iter: IterSetBits<'a, usize>,
+    iter: IterSetBits<'a, u64>,
     start: usize,
     phantom: PhantomData<StorageT>,
 }
@@ -509,7 +510,7 @@ where
 }
 
 pub struct CoreReducesIterator<'a, StorageT> {
-    iter: IterSetBits<'a, usize>,
+    iter: IterSetBits<'a, u64>,
     start: usize,
     phantom: PhantomData<StorageT>,
 }


### PR DESCRIPTION
By using variable sized storage, we couldn't serialise a `Vob` on a 64-bit machine and deserialise on a 32-bit machine (i.e. we couldn't cross-compile grmtools to WASM). This relatively simple change makes that possible (since the backing is now always `u64` no matter the machine). [See https://github.com/softdevteam/sparsevec/pull/21 which made this PR possible.]

This may stop people asking me when grmtools will support wasm (it always "has" in the sense that if you compiled it on a 32-bit machine it worked. But, in fairness, I don't have access to a 32-bit development environment any more!