### PR TITLE
Return multiple lexbuildresult

### DIFF
--- a/lrlex/src/lib/ctbuilder.rs
+++ b/lrlex/src/lib/ctbuilder.rs
@@ -313,7 +313,10 @@ where
                         errs.iter()
                             .map(|e| {
                                 if let Some((line, column)) = line_cache
-                                    .byte_to_line_num_and_col_num(&lex_src, e.span.start())
+                                    .byte_to_line_num_and_col_num(
+                                        &lex_src,
+                                        e.spans().next().unwrap().start(),
+                                    )
                                 {
                                     format!("{} at line {line} column {column}", e)
                                 } else {

--- a/lrlex/src/lib/ctbuilder.rs
+++ b/lrlex/src/lib/ctbuilder.rs
@@ -419,8 +419,12 @@ pub fn lexerdef() -> {lexerdef_type} {{
             write!(
                 outs,
                 "
-        StartState::new({}, {:?}, {}),",
-                ss.id, ss.name, ss.exclusive
+        StartState::new({}, {:?}, {}, ::cfgrammar::Span::new({}, {})),",
+                ss.id,
+                ss.name,
+                ss.exclusive,
+                ss.name_span.start(),
+                ss.name_span.end()
             )
             .ok();
         }

--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -750,8 +750,8 @@ b 'B'
     #[test]
     fn test_state_matches_regular_no_rule_states() {
         let all_states = &[
-            StartState::new(0, "INITIAL", false),
-            StartState::new(1, "EXCLUSIVE", true),
+            StartState::new(0, "INITIAL", false, Span::new(0, 0)),
+            StartState::new(1, "EXCLUSIVE", true, Span::new(0, 0)),
         ];
         let rule_states = vec![];
         let current_state = all_states.get(0).unwrap();
@@ -765,8 +765,8 @@ b 'B'
     #[test]
     fn test_state_matches_exclusive_no_rule_states() {
         let all_states = &[
-            StartState::new(0, "INITIAL", false),
-            StartState::new(1, "EXCLUSIVE", true),
+            StartState::new(0, "INITIAL", false, Span::new(0, 0)),
+            StartState::new(1, "EXCLUSIVE", true, Span::new(0, 0)),
         ];
         let rule_states = vec![];
         let current_state = all_states.get(1).unwrap();
@@ -780,8 +780,8 @@ b 'B'
     #[test]
     fn test_state_matches_regular_matching_rule_states() {
         let all_states = &[
-            StartState::new(0, "INITIAL", false),
-            StartState::new(1, "EXCLUSIVE", true),
+            StartState::new(0, "INITIAL", false, Span::new(0, 0)),
+            StartState::new(1, "EXCLUSIVE", true, Span::new(0, 0)),
         ];
         let rule_states = vec![0];
         let current_state = all_states.get(0).unwrap();
@@ -795,8 +795,8 @@ b 'B'
     #[test]
     fn test_state_matches_exclusive_matching_rule_states() {
         let all_states = &[
-            StartState::new(0, "INITIAL", false),
-            StartState::new(1, "EXCLUSIVE", true),
+            StartState::new(0, "INITIAL", false, Span::new(0, 0)),
+            StartState::new(1, "EXCLUSIVE", true, Span::new(0, 0)),
         ];
         let rule_states = vec![1];
         let current_state = all_states.get(1).unwrap();
@@ -810,8 +810,8 @@ b 'B'
     #[test]
     fn test_state_matches_regular_other_rule_states() {
         let all_states = &[
-            StartState::new(0, "INITIAL", false),
-            StartState::new(1, "EXCLUSIVE", true),
+            StartState::new(0, "INITIAL", false, Span::new(0, 0)),
+            StartState::new(1, "EXCLUSIVE", true, Span::new(0, 0)),
         ];
         let rule_states = vec![1];
         let current_state = all_states.get(0).unwrap();
@@ -825,8 +825,8 @@ b 'B'
     #[test]
     fn test_state_matches_exclusive_other_rule_states() {
         let all_states = &[
-            StartState::new(0, "INITIAL", false),
-            StartState::new(1, "EXCLUSIVE", true),
+            StartState::new(0, "INITIAL", false, Span::new(0, 0)),
+            StartState::new(1, "EXCLUSIVE", true, Span::new(0, 0)),
         ];
         let rule_states = vec![0];
         let current_state = all_states.get(1).unwrap();

--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -27,6 +27,7 @@ pub use crate::{
     parser::StartState,
 };
 
+use cfgrammar::yacc::parser::SpansKind;
 use cfgrammar::Span;
 
 pub type LexBuildResult<T> = Result<T, Vec<LexBuildError>>;
@@ -34,8 +35,8 @@ pub type LexBuildResult<T> = Result<T, Vec<LexBuildError>>;
 /// Any error from the Lex parser returns an instance of this struct.
 #[derive(Debug)]
 pub struct LexBuildError {
-    pub kind: LexErrorKind,
-    pub span: Span,
+    pub(crate) kind: LexErrorKind,
+    pub(crate) spans: Vec<Span>,
 }
 
 impl Error for LexBuildError {}
@@ -52,8 +53,34 @@ pub enum LexErrorKind {
     DuplicateStartState,
     InvalidStartState,
     InvalidStartStateName,
-    DuplicateName(Vec<Span>),
+    DuplicateName,
     RegexError,
+}
+
+impl LexBuildError {
+    pub fn spans(&self) -> impl Iterator<Item = Span> + '_ {
+        self.spans.iter().copied()
+    }
+
+    pub fn spanskind(&self) -> SpansKind {
+        match self.kind {
+            LexErrorKind::PrematureEnd
+            | LexErrorKind::RoutinesNotSupported
+            | LexErrorKind::UnknownDeclaration
+            | LexErrorKind::MissingSpace
+            | LexErrorKind::InvalidName
+            | LexErrorKind::UnknownStartState
+            | LexErrorKind::InvalidStartState
+            | LexErrorKind::InvalidStartStateName
+            | LexErrorKind::RegexError
+            // TODO DuplicateStartState should be a DuplicationError,
+            // but currently behaves as a SpansKind::Error.
+            | LexErrorKind::DuplicateStartState => SpansKind::Error,
+            LexErrorKind::DuplicateName => {
+                SpansKind::DuplicationError
+            }
+        }
+    }
 }
 
 impl fmt::Display for LexBuildError {
@@ -68,7 +95,7 @@ impl fmt::Display for LexBuildError {
             LexErrorKind::DuplicateStartState => "Start state already exists",
             LexErrorKind::InvalidStartState => "Invalid start state",
             LexErrorKind::InvalidStartStateName => "Invalid start state name",
-            LexErrorKind::DuplicateName(_) => "Rule name already exists",
+            LexErrorKind::DuplicateName => "Rule name already exists",
             LexErrorKind::RegexError => "Invalid regular expression",
         };
         write!(f, "{s}")

--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -72,11 +72,8 @@ impl LexBuildError {
             | LexErrorKind::UnknownStartState
             | LexErrorKind::InvalidStartState
             | LexErrorKind::InvalidStartStateName
-            | LexErrorKind::RegexError
-            // TODO DuplicateStartState should be a DuplicationError,
-            // but currently behaves as a SpansKind::Error.
-            | LexErrorKind::DuplicateStartState => SpansKind::Error,
-            LexErrorKind::DuplicateName => {
+            | LexErrorKind::RegexError => SpansKind::Error,
+            LexErrorKind::DuplicateName | LexErrorKind::DuplicateStartState => {
                 SpansKind::DuplicationError
             }
         }

--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -42,7 +42,7 @@ pub struct LexBuildError {
 impl Error for LexBuildError {}
 
 /// The various different possible Lex parser errors.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum LexErrorKind {
     PrematureEnd,
     RoutinesNotSupported,

--- a/lrlex/src/main.rs
+++ b/lrlex/src/main.rs
@@ -59,8 +59,8 @@ fn main() {
         LRNonStreamingLexerDef::<DefaultLexeme, _>::from_str(&lex_src).unwrap_or_else(|errs| {
             let nlcache = NewlineCache::from_str(&lex_src).unwrap();
             for e in errs {
-                if let Some((line, column)) =
-                    nlcache.byte_to_line_num_and_col_num(&lex_src, e.span.start())
+                if let Some((line, column)) = nlcache
+                    .byte_to_line_num_and_col_num(&lex_src, e.spans().next().unwrap().start())
                 {
                     writeln!(
                         stderr(),

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -108,8 +108,8 @@ fn main() {
         Err(errs) => {
             let nlcache = NewlineCache::from_str(&lex_src).unwrap();
             for e in errs {
-                if let Some((line, column)) =
-                    nlcache.byte_to_line_num_and_col_num(&lex_src, e.span.start())
+                if let Some((line, column)) = nlcache
+                    .byte_to_line_num_and_col_num(&lex_src, e.spans().next().unwrap().start())
                 {
                     writeln!(
                         stderr(),


### PR DESCRIPTION
This implements the returning of multiple errors for `LexBuildResult`,
The collection of multiple spans for `DuplicateStartState`, and testsuite cleanups.

There is quite a bit of duplicate copy/paste between cfgrammar/lrlex for the testsuite helpers, but I didn't want to undertake something like adding an entire helper crate for tests.

All the TODO/FIXME added get removed by subsequent patches.

@SMartinScottLogic  This modifies your start state code which was recently added, to collect `Span`s, mostly in the last patch, but some parameters are added in the first, if you don't mind having a look.