### PR TITLE
Clippy fixes

### DIFF
--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, collections::HashMap};
+use std::{cell::RefCell, collections::HashMap, fmt::Write};
 
 use num_traits::{self, AsPrimitive, PrimInt, Unsigned};
 #[cfg(feature = "serde")]
@@ -611,7 +611,7 @@ where
                 Symbol::Token(tidx) => self.token_name(*tidx).unwrap(),
                 Symbol::Rule(ridx) => self.rule_name_str(*ridx),
             };
-            sprod.push_str(&format!(" \"{}\"", s));
+            write!(sprod, " \"{}\"", s).ok();
         }
         sprod
     }

--- a/lrlex/src/lib/parser.rs
+++ b/lrlex/src/lib/parser.rs
@@ -329,6 +329,7 @@ mod test {
         lexer::{LRNonStreamingLexerDef, LexerDef},
         DefaultLexeme,
     };
+    use std::fmt::Write as _;
 
     macro_rules! incorrect_errs {
         ($src:ident, $errs:expr) => {{
@@ -925,6 +926,7 @@ mod test {
             Err(e) => incorrect_errs!(src, e),
         }
     }
+
     #[test]
     #[should_panic]
     fn exceed_tok_id_capacity() {
@@ -932,7 +934,7 @@ mod test {
 "
         .to_string();
         for i in 0..257 {
-            src.push_str(&format!("x 'x{}'\n", i));
+            writeln!(src, "x 'x{}'\n", i).ok();
         }
         LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).ok();
     }

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -222,7 +222,7 @@ where
             .to_str()
             .unwrap()
             .to_owned();
-        leaf.push_str(&format!(".{}", RUST_FILE_EXT));
+        write!(leaf, ".{}", RUST_FILE_EXT).ok();
         outp.push(leaf);
         Ok(self.output_path(outp))
     }
@@ -490,7 +490,7 @@ where
             .to_str()
             .unwrap()
             .to_owned();
-        leaf.push_str(&format!(".{}", RUST_FILE_EXT));
+        write!(leaf, ".{}", RUST_FILE_EXT).ok();
         outp.push(leaf);
         self.process_file(inp, outp)
     }
@@ -568,11 +568,7 @@ where
         cache: &str,
     ) -> Result<(), Box<dyn Error>> {
         let mut outs = String::new();
-        outs.push_str(&format!(
-            "{} mod {} {{\n",
-            self.visibility.cow_str(),
-            mod_name
-        ));
+        writeln!(outs, "{} mod {} {{", self.visibility.cow_str(), mod_name).ok();
         outs.push_str(
             "    #![allow(clippy::type_complexity)]
     #![allow(clippy::unnecessary_wraps)]
@@ -616,20 +612,19 @@ where
         // Record the time that this version of lrpar was built. If the source code changes and
         // rustc forces a recompile, this will change this value, causing anything which depends on
         // this build of lrpar to be recompiled too.
-        cache.push_str(&format!(
-            "   Build time: {:?}\n",
-            env!("VERGEN_BUILD_TIMESTAMP")
-        ));
+        writeln!(cache, "   Build time: {:?}", env!("VERGEN_BUILD_TIMESTAMP")).ok();
 
-        cache.push_str(&format!("   Grammar path: {:?}\n", self.grammar_path));
-        cache.push_str(&format!("   Mod name: {:?}\n", self.mod_name));
-        cache.push_str(&format!("   Recoverer: {:?}\n", self.recoverer));
-        cache.push_str(&format!("   YaccKind: {:?}\n", self.yacckind));
-        cache.push_str(&format!("   Visibility: {:?}\n", self.visibility.cow_str()));
-        cache.push_str(&format!(
+        writeln!(cache, "   Grammar path: {:?}", self.grammar_path).ok();
+        writeln!(cache, "   Mod name: {:?}", self.mod_name).ok();
+        writeln!(cache, "   Recoverer: {:?}", self.recoverer).ok();
+        writeln!(cache, "   YaccKind: {:?}", self.yacckind).ok();
+        writeln!(cache, "   Visibility: {:?}", self.visibility.cow_str()).ok();
+        writeln!(
+            cache,
             "   Error on conflicts: {:?}\n",
             self.error_on_conflicts
-        ));
+        )
+        .ok();
 
         // Record the rule IDs map
         for tidx in grm.iter_tidxs() {
@@ -637,7 +632,7 @@ where
                 Some(n) => format!("'{}'", n),
                 None => "<unknown>".to_string(),
             };
-            cache.push_str(&format!("   {} {}\n", usize::from(tidx), n));
+            writeln!(cache, "   {} {}", usize::from(tidx), n).ok();
         }
 
         cache.push_str("*/\n");
@@ -663,7 +658,7 @@ where
                     Some((name, tyname)) => format!(", {}: {}", name, tyname),
                     None => "".to_owned(),
                 };
-                outs.push_str(&format!(
+                write!(outs,
                     "
     #[allow(dead_code)]
     pub fn parse<'lexer, 'input: 'lexer>(
@@ -674,10 +669,11 @@ where
                     storaget = type_name::<StorageT>(),
                     parse_param = parse_param,
                     actiont = grm.actiontype(self.user_start_ridx(grm)).as_ref().unwrap(),
-                ));
+                ).ok();
             }
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree) => {
-                outs.push_str(&format!(
+                write!(
+                    outs,
                     "
     #[allow(dead_code)]
     pub fn parse(lexer: &dyn ::lrpar::NonStreamingLexer<{lexemet}, {storaget}>)
@@ -686,10 +682,12 @@ where
     {{",
                     lexemet = type_name::<LexemeT>(),
                     storaget = type_name::<StorageT>()
-                ));
+                )
+                .ok();
             }
             YaccKind::Original(YaccOriginalActionKind::NoAction) => {
-                outs.push_str(&format!(
+                write!(
+                    outs,
                     "
     #[allow(dead_code)]
     pub fn parse(lexer: &dyn ::lrpar::NonStreamingLexer<{lexemet}, {storaget}>)
@@ -697,16 +695,19 @@ where
     {{",
                     lexemet = type_name::<LexemeT>(),
                     storaget = type_name::<StorageT>()
-                ));
+                )
+                .ok();
             }
             YaccKind::Eco => unreachable!(),
         };
 
-        outs.push_str(&format!(
+        write!(
+            outs,
             "
         let (grm, stable) = ::lrpar::ctbuilder::_reconstitute({}, {});",
             GRM_CONST_NAME, STABLE_CONST_NAME
-        ));
+        )
+        .ok();
 
         let recoverer = match self.recoverer {
             RecoveryKind::CPCTPlus => "CPCTPlus",
@@ -730,7 +731,7 @@ where
                     Some((name, tyname)) => (name.clone(), tyname.clone()),
                     None => ("()".to_owned(), "()".to_owned()),
                 };
-                outs.push_str(&format!(
+                write!(outs,
                     "\n        #[allow(clippy::type_complexity)]
         let actions: ::std::vec::Vec<&dyn Fn(::cfgrammar::RIdx<{storaget}>,
                        &'lexer dyn ::lrpar::NonStreamingLexer<'input, {lexemet}, {storaget}>,
@@ -743,8 +744,9 @@ where
                     storaget = type_name::<StorageT>(),
                     parse_paramty = parse_paramty,
                     wrappers = wrappers
-                ));
-                outs.push_str(&format!(
+                ).ok();
+                write!(
+                    outs,
                     "
         match ::lrpar::RTParserBuilder::new(&grm, &stable)
             .recoverer(::lrpar::RecoveryKind::{recoverer})
@@ -758,25 +760,30 @@ where
                     actionskindprefix = ACTIONS_KIND_PREFIX,
                     ridx = usize::from(self.user_start_ridx(grm)),
                     recoverer = recoverer,
-                ));
+                )
+                .ok();
             }
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree) => {
-                outs.push_str(&format!(
+                write!(
+                    outs,
                     "
         ::lrpar::RTParserBuilder::new(&grm, &stable)
             .recoverer(::lrpar::RecoveryKind::{})
             .parse_generictree(lexer)\n",
                     recoverer
-                ));
+                )
+                .ok();
             }
             YaccKind::Original(YaccOriginalActionKind::NoAction) => {
-                outs.push_str(&format!(
+                write!(
+                    outs,
                     "
         ::lrpar::RTParserBuilder::new(&grm, &stable)
             .recoverer(::lrpar::RecoveryKind::{})
             .parse_noaction(lexer)\n",
                     recoverer
-                ));
+                )
+                .ok();
             }
             YaccKind::Eco => unreachable!(),
         };
@@ -789,12 +796,14 @@ where
         let mut outs = String::new();
         for ridx in grm.iter_rules() {
             if !grm.rule_to_prods(ridx).contains(&grm.start_prod()) {
-                outs.push_str(&format!(
+                write!(
+                    outs,
                     "    #[allow(dead_code)]\n    pub const R_{}: {} = {:?};\n",
                     grm.rule_name_str(ridx).to_ascii_uppercase(),
                     type_name::<StorageT>(),
                     usize::from(ridx)
-                ));
+                )
+                .ok();
             }
         }
         outs
@@ -839,7 +848,7 @@ where
             // Iterate over all $-arguments and replace them with their respective
             // element from the argument vector (e.g. $1 is replaced by args[0]). At
             // the same time extract &str from tokens and actiontype from nonterminals.
-            outs.push_str(&format!(
+            write!(outs,
                 "    fn {prefix}wrapper_{}<'lexer, 'input: 'lexer>({prefix}ridx: ::cfgrammar::RIdx<{storaget}>,
                       {prefix}lexer: &'lexer dyn ::lrpar::NonStreamingLexer<'input, {lexemet}, {storaget}>,
                       {prefix}span: ::cfgrammar::Span,
@@ -852,13 +861,14 @@ where
                 prefix = ACTION_PREFIX,
                 parse_paramdef = parse_paramdef,
                 actionskind = ACTIONS_KIND,
-            ));
+            ).ok();
 
             if grm.action(pidx).is_some() {
                 // Unpack the arguments passed to us by the drain
                 for i in 0..grm.prod(pidx).len() {
                     match grm.prod(pidx)[i] {
-                        Symbol::Rule(ref_ridx) => outs.push_str(&format!(
+                        Symbol::Rule(ref_ridx) => {
+                            write!(outs,
                             "
         let {prefix}arg_{i} = match {prefix}args.next().unwrap() {{
             ::lrpar::parser::AStackType::ActionType({actionskind}::{actionskindprefix}{ref_ridx}(x)) => x,
@@ -869,9 +879,12 @@ where
                             prefix = ACTION_PREFIX,
                             actionskind = ACTIONS_KIND,
                             actionskindprefix = ACTIONS_KIND_PREFIX
-                        )),
-                        Symbol::Token(_) => outs.push_str(&format!(
-                            "
+                        ).ok();
+                        }
+                        Symbol::Token(_) => {
+                            write!(
+                                outs,
+                                "
         let {prefix}arg_{} = match {prefix}args.next().unwrap() {{
             ::lrpar::parser::AStackType::Lexeme(l) => {{
                 if l.faulty() {{
@@ -882,9 +895,11 @@ where
             }},
             ::lrpar::parser::AStackType::ActionType(_) => unreachable!()
         }};",
-                            i + 1,
-                            prefix = ACTION_PREFIX
-                        ))
+                                i + 1,
+                                prefix = ACTION_PREFIX
+                            )
+                            .ok();
+                        }
                     }
                 }
 
@@ -897,7 +912,7 @@ where
                 // `wrapper_r(); enum::A(())`.
                 match grm.actiontype(ridx) {
                     Some(s) if s == "()" => {
-                        outs.push_str(&format!("\n        {prefix}action_{pidx}({prefix}ridx, {prefix}lexer, {prefix}span, {parse_paramname}, {args});
+                        write!(outs, "\n        {prefix}action_{pidx}({prefix}ridx, {prefix}lexer, {prefix}span, {parse_paramname}, {args});
         {actionskind}::{actionskindprefix}{ridx}(())",
                             actionskind = ACTIONS_KIND,
                             actionskindprefix = ACTIONS_KIND_PREFIX,
@@ -905,17 +920,17 @@ where
                             ridx = usize::from(ridx),
                             pidx = usize::from(pidx),
                             parse_paramname = parse_paramname,
-                            args = args.join(", ")));
+                            args = args.join(", ")).ok();
                     }
                     _ => {
-                        outs.push_str(&format!("\n        {actionskind}::{actionskindprefix}{ridx}({prefix}action_{pidx}({prefix}ridx, {prefix}lexer, {prefix}span, {parse_paramname}, {args}))",
+                        write!(outs, "\n        {actionskind}::{actionskindprefix}{ridx}({prefix}action_{pidx}({prefix}ridx, {prefix}lexer, {prefix}span, {parse_paramname}, {args}))",
                             actionskind = ACTIONS_KIND,
                             actionskindprefix = ACTIONS_KIND_PREFIX,
                             prefix = ACTION_PREFIX,
                             ridx = usize::from(ridx),
                             pidx = usize::from(pidx),
                             parse_paramname = parse_paramname,
-                            args = args.join(", ")));
+                            args = args.join(", ")).ok();
                     }
                 }
             } else if pidx == grm.start_prod() {
@@ -926,7 +941,7 @@ where
                 if parse_paramname != "()" {
                     // If the parse parameter is the unit type, `let _ = ();` leads to Clippy
                     // warnings.
-                    outs.push_str(&format!("\n        let _ = {parse_paramname:};"));
+                    write!(outs, "\n        let _ = {parse_paramname:};").ok();
                 }
                 outs.push_str("\n        unreachable!()");
             } else {
@@ -940,28 +955,34 @@ where
 
         // Wrappers enum
 
-        outs.push_str(&format!(
+        write!(
+            outs,
             "    #[allow(dead_code)]
     enum {}<'input> {{\n",
             ACTIONS_KIND
-        ));
+        )
+        .ok();
         for ridx in grm.iter_rules() {
             if grm.actiontype(ridx).is_none() {
                 continue;
             }
 
-            outs.push_str(&format!(
-                "        {actionskindprefix}{ridx}({actiont}),\n",
+            writeln!(
+                outs,
+                "        {actionskindprefix}{ridx}({actiont}),",
                 actionskindprefix = ACTIONS_KIND_PREFIX,
                 ridx = usize::from(ridx),
                 actiont = grm.actiontype(ridx).as_ref().unwrap()
-            ));
+            )
+            .ok();
         }
-        outs.push_str(&format!(
+        write!(
+            outs,
             "    _{actionskindhidden}(::std::marker::PhantomData<&'input ()>)
     }}\n\n",
             actionskindhidden = ACTIONS_KIND_HIDDEN
-        ));
+        )
+        .ok();
 
         outs
     }
@@ -1010,7 +1031,7 @@ where
                     format!("\n                 -> {}", actiont)
                 }
             };
-            outs.push_str(&format!(
+            write!(outs,
                 "    // {rulename}
     #[allow(clippy::too_many_arguments)]
     fn {prefix}action_{}<'lexer, 'input: 'lexer>({prefix}ridx: ::cfgrammar::RIdx<{storaget}>,
@@ -1026,12 +1047,12 @@ where
                 returnt = returnt,
                 parse_paramdef = parse_paramdef,
                 args = args.join(",\n                     ")
-            ));
+            ).ok();
 
             if parse_paramname != "()" {
                 // If the parse parameter is the unit type, `let _ = ();` leads to Clippy
                 // warnings.
-                outs.push_str(&format!("        let _ = {parse_paramname:};\n"));
+                writeln!(outs, "        let _ = {parse_paramname:};").ok();
             }
 
             // Iterate over all $-arguments and replace them with their respective
@@ -1046,19 +1067,17 @@ where
                             last = last + off + "$$".len();
                         } else if pre_action[last + off..].starts_with("$lexer") {
                             outs.push_str(&pre_action[last..last + off]);
-                            outs.push_str(
-                                format!("{prefix}lexer", prefix = ACTION_PREFIX).as_str(),
-                            );
+                            write!(outs, "{prefix}lexer", prefix = ACTION_PREFIX).ok();
                             last = last + off + "$lexer".len();
                         } else if pre_action[last + off..].starts_with("$span") {
                             outs.push_str(&pre_action[last..last + off]);
-                            outs.push_str(format!("{prefix}span", prefix = ACTION_PREFIX).as_str());
+                            write!(outs, "{prefix}span", prefix = ACTION_PREFIX).ok();
                             last = last + off + "$span".len();
                         } else if last + off + 1 < pre_action.len()
                             && pre_action[last + off + 1..].starts_with(|c: char| c.is_numeric())
                         {
                             outs.push_str(&pre_action[last..last + off]);
-                            outs.push_str(format!("{prefix}arg_", prefix = ACTION_PREFIX).as_str());
+                            write!(outs, "{prefix}arg_", prefix = ACTION_PREFIX).ok();
                             last = last + off + "$".len();
                         } else {
                             panic!(

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -1,6 +1,6 @@
 use std::{
     error::Error,
-    fmt::{self, Debug, Display},
+    fmt::{self, Debug, Display, Write as _},
     hash::Hash,
     marker::PhantomData,
     time::{Duration, Instant},
@@ -50,10 +50,10 @@ where
                     let tidx = TIdx(lexeme.tok_id());
                     let tn = grm.token_name(tidx).unwrap();
                     let lt = &input[lexeme.span().start()..lexeme.span().end()];
-                    s.push_str(&format!("{} {}\n", tn, lt));
+                    writeln!(s, "{} {}", tn, lt).ok();
                 }
                 Node::Nonterm { ridx, ref nodes } => {
-                    s.push_str(&format!("{}\n", grm.rule_name_str(ridx)));
+                    writeln!(s, "{}", grm.rule_name_str(ridx)).ok();
                     for x in nodes.iter().rev() {
                         st.push((indent + 1, x));
                     }
@@ -651,7 +651,7 @@ impl<LexemeT: Lexeme<StorageT>, StorageT: Hash + PrimInt + Unsigned>
                         let padding = ((repairs_len as f64).log10() as usize)
                             - (((i + 1) as f64).log10() as usize)
                             + 1;
-                        out.push_str(&format!("\n  {}{}: ", " ".repeat(padding), i + 1));
+                        write!(out, "\n  {}{}: ", " ".repeat(padding), i + 1).ok();
                         let mut rs_out = Vec::new();
                         for r in rs {
                             match r {

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -1,4 +1,4 @@
-use std::{collections::hash_map::HashMap, hash::Hash};
+use std::{collections::hash_map::HashMap, fmt::Write, hash::Hash};
 
 use cfgrammar::{yacc::YaccGrammar, Symbol, TIdx};
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
@@ -126,7 +126,7 @@ where
             }
             {
                 let padding = num_digits(self.all_states_len()) - num_digits(stidx);
-                o.push_str(&format!("{}:{}", usize::from(stidx), " ".repeat(padding)));
+                write!(o, "{}:{}", usize::from(stidx), " ".repeat(padding)).ok();
             }
 
             let st = if core_states { core_st } else { closed_st };
@@ -137,16 +137,18 @@ where
                     o.push_str("\n "); // Extra space to compensate for ":" printed above
                     num_digits(self.all_states_len())
                 };
-                o.push_str(&format!(
+                write!(
+                    o,
                     "{} [{} ->",
                     " ".repeat(padding),
                     grm.rule_name_str(grm.prod_to_rule(pidx))
-                ));
+                )
+                .ok();
                 for (i_sidx, i_ssym) in grm.prod(pidx).iter().enumerate() {
                     if i_sidx == usize::from(sidx) {
                         o.push_str(" .");
                     }
-                    o.push_str(&format!(" {}", fmt_sym(grm, *i_ssym)));
+                    write!(o, " {}", fmt_sym(grm, *i_ssym)).ok();
                 }
                 if usize::from(sidx) == grm.prod(pidx).len() {
                     o.push_str(" .");
@@ -164,18 +166,20 @@ where
                     if tidx == grm.eof_token_idx() {
                         o.push_str("'$'");
                     } else {
-                        o.push_str(&format!("'{}'", grm.token_name(tidx).unwrap()));
+                        write!(o, "'{}'", grm.token_name(tidx).unwrap()).ok();
                     }
                 }
                 o.push_str("}]");
             }
             for (esym, e_stidx) in self.edges(stidx).iter() {
-                o.push_str(&format!(
+                write!(
+                    o,
                     "\n{}{} -> {}",
                     " ".repeat(num_digits(self.all_states_len()) + 2),
                     fmt_sym(grm, *esym),
                     usize::from(*e_stidx)
-                ));
+                )
+                .ok();
             }
         }
         o

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -2,7 +2,7 @@ use std::{
     cmp::Ordering,
     collections::hash_map::HashMap,
     error::Error,
-    fmt::{self, Debug},
+    fmt::{self, Debug, Write},
     hash::Hash,
     marker::PhantomData,
 };
@@ -69,12 +69,14 @@ where
         if self.rr_len() > 0 {
             s.push_str("Reduce/Reduce conflicts:\n");
             for (pidx, r_pidx, stidx) in self.rr_conflicts() {
-                s.push_str(&format!(
-                    "   State {:?}: Reduce({}) / Reduce({})\n",
+                writeln!(
+                    s,
+                    "   State {:?}: Reduce({}) / Reduce({})",
                     usize::from(*stidx),
                     grm.pp_prod(*pidx),
                     grm.pp_prod(*r_pidx)
-                ));
+                )
+                .ok();
             }
         }
         s
@@ -86,12 +88,14 @@ where
         if self.sr_len() > 0 {
             s.push_str("Shift/Reduce conflicts:\n");
             for (tidx, pidx, stidx) in self.sr_conflicts() {
-                s.push_str(&format!(
-                    "   State {:?}: Shift(\"{}\") / Reduce({})\n",
+                writeln!(
+                    s,
+                    "   State {:?}: Shift(\"{}\") / Reduce({})",
                     usize::from(*stidx),
                     grm.token_name(*tidx).unwrap(),
                     grm.pp_prod(*pidx)
-                ));
+                )
+                .ok();
             }
         }
         s


### PR DESCRIPTION
https://github.com/softdevteam/grmtools/commit/f4c2fbf6ad943e27f44c0908eb9e075e26769649 is more extensive than usual, but I generally prefer to keep Clippy warnings to zero, because it does highlight some useful things, and it's worth not losing them amongst the noise.