### PR TITLE
Test for start state operators at start of regex

### DIFF
--- a/doc/src/lexcompatibility.md
+++ b/doc/src/lexcompatibility.md
@@ -30,3 +30,30 @@ There are several major differences between Lex and grmtools:
    use a token name prefix.
 
  * Character sets, and changes to internal array sizes are not supported by grmtools.
+
+ * Escape sequences:
+
+   In addition to escape sequences involved in the escaping of regular expressions.
+   Lex and grmtools support the escape sequences `\123` (octal) `\x1234` (hexadecimal)
+   and ASCII escape sequences. `\\` `\a` `\f` `\n` `\r` `\t` `\v`.
+
+   Lex also interprets the escape sequence `\b` as `backspace`.  While regex treats `\b`
+   as a word boundary subsequently grmtools will too.
+
+   Additional escape sequences supported by regex:
+
+   The `\u1234` and `\U12345678` escape sequences for unicode characters,
+   the `\p`,`\P` unicode character classes, as well as the `\d` `\D` `\s` `\S`
+   `\w` `\W` perl character classes, and `\A` `\b` `\B` `\z` escape sequences.
+
+   Both Lex and grmtools support escaping arbitrary characters, for all other characters
+   besides those listed above, when given an escaped character `\c` it will be passed to
+   the regex engine as the character `c`.  This is useful when a character is used within
+   the lex format.
+
+   An example of this is when the character `<` is used at the beginning of a regex. Both Lex
+   and grmtools interpret this as the beginning of a start condition prefix. Which can be
+   escaped with `\<` to ensure it is treated as the start of a regular expression.
+
+   But the characters to which this behavior applies is impacted by the escape sequence
+   differences listed above.

--- a/lrlex/Cargo.toml
+++ b/lrlex/Cargo.toml
@@ -26,6 +26,7 @@ getopts = "0.2" # only needed for src/main.rs
 lazy_static = "1.4"
 lrpar = { path = "../lrpar", version = "0.12" }
 regex = "1"
+regex-syntax = "0.6.27"
 num-traits = "0.2"
 serde = "1.0"
 try_from = "0.3"

--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -51,6 +51,7 @@ impl<StorageT> Rule<StorageT> {
         target_state: Option<usize>,
     ) -> Result<Rule<StorageT>, regex::Error> {
         let re = RegexBuilder::new(&format!("\\A(?:{})", re_str))
+            .octal(true)
             .multi_line(true)
             .dot_matches_new_line(true)
             .build()?;


### PR DESCRIPTION
Updating my various projects to run on master, in one of my projects,
I noticed that the addition of start states has caused a change in parsing lex files I hadn't anticipated.

https://github.com/ratmice/crimson/blob/main/src/crimson.l#L12

There is a comment in posix lex specification about this, which I've quoted in the test.

One workaround which should work with both old and new versions of lrlex is using `[<]` instead of `<`.
which would be one way of avoiding special casing the escaping of '\<'.

It also seems from the posix spec they mention '\>' I guess that is just for parity with '\<' I don't see why it is actually required, or why `>` wouldn't be able to start a regex.

I haven't looked yet at where might be the right place to add this special cased escaping though.