### PR TITLE
Fix panic on empty lex file

### DIFF
--- a/lrlex/src/lib/parser.rs
+++ b/lrlex/src/lib/parser.rs
@@ -157,7 +157,7 @@ impl<StorageT: TryFrom<usize>> LexParser<StorageT> {
         loop {
             i = self.parse_ws(i)?;
             if i == self.src.len() {
-                break Err(self.mk_error(LexErrorKind::PrematureEnd, i - 1));
+                break Err(self.mk_error(LexErrorKind::PrematureEnd, i.saturating_sub(1)));
             }
             if let Some(j) = self.lookahead_is("%%", i) {
                 break Ok(j);
@@ -644,6 +644,16 @@ mod test {
     fn test_minimum() {
         let src = "%%".to_string();
         assert!(LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).is_ok());
+    }
+
+    #[test]
+    fn test_empty() {
+        LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str("").expect_error_at_line_col(
+            "",
+            LexErrorKind::PrematureEnd,
+            1,
+            1,
+        );
     }
 
     #[test]


### PR DESCRIPTION
I hadn't run across any panics while editing after my other PR.  Figured I might run https://rust-fuzz.github.io/book/ with lrlex,
which found one more panic involving empty files.

Fixing that, both AFL and the random input fuzzers have been running lrlex while without incident.
with AFL given a corpus of various input files collected from github, and erroneous inputs from the testsuite.

With both fuzzers catching this and the panic from my previous PR fairly quickly. I haven't really looked at doing so for yacc yet though.