### PR TITLE
Fix yacc panics with YaccKind::Grmtools

### DIFF
--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -796,8 +796,8 @@ impl YaccParser {
                 }
                 '\\' => {
                     debug_assert!('\\'.len_utf8() == 1);
-                    match self.src[j + 1..].chars().next().unwrap() {
-                        '\'' | '"' => {
+                    match self.src[j + 1..].chars().next() {
+                        Some(c) if c == '\'' || c == '"' => {
                             s.push_str(&self.src[i..j]);
                             i = j + 1;
                             j += 2;
@@ -1361,6 +1361,16 @@ mod test {
             &src,
         )
         .expect_error_at_line_col(&src, YaccGrammarErrorKind::IllegalString, 3, 11);
+    }
+
+    #[test]
+    fn test_missing_end_quote() {
+        let src = "%epp X \"f\\".to_string();
+        parse(
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            &src,
+        )
+        .expect_error_at_line_col(&src, YaccGrammarErrorKind::InvalidString, 1, 10);
     }
 
     #[test]

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -1364,14 +1364,13 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
     fn test_simple_decl_fail() {
         let src = "%fail x\n%%\nA : a".to_string();
         parse(
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             &src,
         )
-        .unwrap();
+        .expect_error_at_line_col(&src, YaccGrammarErrorKind::UnknownDeclaration, 1, 1);
     }
 
     #[test]


### PR DESCRIPTION
This fixes yacc panics some were caught by fuzzing, the others move from expecting a panic during `unwrap()` to expecting error kinds.

The action parsing https://github.com/softdevteam/grmtools/commit/fcafb448335bb51f58faed35349522925d8ea67d, I believe that as it was represents a real bug,
because the slicing was actually dropping the last character of the action (or the last byte of a multibyte character) rather than a trailing `}` character.

But it seems like a real possibility that I am misunderstanding something about the intended behavior loop.
And I'm not terribly familiar with action parsing, as I tend to mostly use the `NoActions` Kind.