### PR TITLE
Fix doc links to macros

### DIFF
--- a/lrlex/src/lib/ctbuilder.rs
+++ b/lrlex/src/lib/ctbuilder.rs
@@ -218,7 +218,7 @@ where
 
     /// Set the output lexer path to `outp`. Note that there are no requirements on `outp`: the
     /// file can exist anywhere you can create a valid [Path] to. However, if you wish to use
-    /// [lrlex_mod!] you will need to make sure that `outp` is in [std::env::var]`("OUT_DIR")` or
+    /// [lrlex_mod!](crate::lrlex_mod) you will need to make sure that `outp` is in [std::env::var]`("OUT_DIR")` or
     /// one of its subdirectories.
     pub fn output_path<P>(mut self, outp: P) -> Self
     where
@@ -620,7 +620,7 @@ impl CTLexer {
 }
 
 /// Create a Rust module named `mod_name` that can be imported with
-/// [`lrlex_mod!(mod_name)`](lrlex_mod). The module contains one `const` `StorageT` per token in
+/// [`lrlex_mod!(mod_name)`](crate::lrlex_mod). The module contains one `const` `StorageT` per token in
 /// `token_map`, with the token prefixed by `T_`. For example with `StorageT` `u8`, `mod_name` `x`,
 /// and `token_map` `HashMap{"ID": 0, "INT": 1}` the generated module will look roughly as
 /// follows:

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -240,7 +240,7 @@ where
 
     /// Set the output grammar path to `outp`. Note that there are no requirements on `outp`: the
     /// file can exist anywhere you can create a valid [Path] to. However, if you wish to use
-    /// [lrpar_mod!] you will need to make sure that `outp` is in [std::env::var]`("OUT_DIR")` or
+    /// [lrpar_mod!](crate::lrpar_mod) you will need to make sure that `outp` is in [std::env::var]`("OUT_DIR")` or
     /// one of its subdirectories.
     pub fn output_path<P>(mut self, outp: P) -> Self
     where


### PR DESCRIPTION
This should fix the build failure encountered in https://github.com/softdevteam/grmtools/pull/335
I was able to reproduce it after updating my toolchain..