### PR TITLE
Fix warnings triggered by new version of cargo doc.

### DIFF
--- a/lrlex/src/lib/ctbuilder.rs
+++ b/lrlex/src/lib/ctbuilder.rs
@@ -218,8 +218,8 @@ where
 
     /// Set the output lexer path to `outp`. Note that there are no requirements on `outp`: the
     /// file can exist anywhere you can create a valid [Path] to. However, if you wish to use
-    /// [lrlex_mod!] you will need to make sure that `outp` is in [std::env::var]`("OUT_DIR")` or
-    /// one of its subdirectories.
+    /// [crate::lrlex_mod!] you will need to make sure that `outp` is in
+    /// [std::env::var]`("OUT_DIR")` or one of its subdirectories.
     pub fn output_path<P>(mut self, outp: P) -> Self
     where
         P: AsRef<Path>,
@@ -620,10 +620,10 @@ impl CTLexer {
 }
 
 /// Create a Rust module named `mod_name` that can be imported with
-/// [`lrlex_mod!(mod_name)`](lrlex_mod). The module contains one `const` `StorageT` per token in
-/// `token_map`, with the token prefixed by `T_`. For example with `StorageT` `u8`, `mod_name` `x`,
-/// and `token_map` `HashMap{"ID": 0, "INT": 1}` the generated module will look roughly as
-/// follows:
+/// [`lrlex_mod!(mod_name)`](crate::lrlex_mod). The module contains one `const` `StorageT` per
+/// token in `token_map`, with the token prefixed by `T_`. For example with `StorageT` `u8`,
+/// `mod_name` `x`, and `token_map` `HashMap{"ID": 0, "INT": 1}` the generated module will look
+/// roughly as follows:
 ///
 /// ```rust,ignore
 /// mod x {

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -240,8 +240,8 @@ where
 
     /// Set the output grammar path to `outp`. Note that there are no requirements on `outp`: the
     /// file can exist anywhere you can create a valid [Path] to. However, if you wish to use
-    /// [lrpar_mod!] you will need to make sure that `outp` is in [std::env::var]`("OUT_DIR")` or
-    /// one of its subdirectories.
+    /// [crate::lrpar_mod!] you will need to make sure that `outp` is in
+    /// [std::env::var]`("OUT_DIR")` or one of its subdirectories.
     pub fn output_path<P>(mut self, outp: P) -> Self
     where
         P: AsRef<Path>,


### PR DESCRIPTION
I *think* these are triggered by rust 1.63.0 which is why we're only just seeing them in CI.