### PR TITLE
Test propagating multiple errors through the routines sections

### DIFF
--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -2362,4 +2362,36 @@ x"
             .into_iter(),
         )
     }
+
+    #[test]
+    fn test_routines_multiple_errors() {
+        let mut src = String::from(
+            "
+        %start A
+        %start B
+        %%
+        A -> () : 'a';
+        A -> () : 'a';
+        %%
+        ",
+        );
+        let mut expected_errs = vec![
+            (
+                YaccGrammarErrorKind::DuplicateStartDeclaration,
+                vec![(2, 16), (3, 16)],
+            ),
+            (YaccGrammarErrorKind::DuplicateRule, vec![(5, 9), (6, 9)]),
+        ];
+        parse(YaccKind::Grmtools, &src)
+            .expect_multiple_errors(&src, &mut expected_errs.clone().into_iter());
+
+        src.push_str(
+            "
+                /* Incomplete comment
+        ",
+        );
+        expected_errs.push((YaccGrammarErrorKind::IncompleteComment, vec![(9, 17)]));
+        parse(YaccKind::Grmtools, &src)
+            .expect_multiple_errors(&src, &mut expected_errs.clone().into_iter());
+    }
 }


### PR DESCRIPTION
Looking through coverage, I had failed to test that errors propagate through the routine section parsing,
these test the cases where there are already errors, then routine parsing either succeeds or fails, for lex and yacc.
