### PR TITLE
Boxed slice err value

### DIFF
--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -118,7 +118,7 @@ where
                 let mut ast = yp.ast();
                 let r = ast.complete_and_validate();
                 if r.is_err() {
-                    return Err(vec![r.unwrap_err()]);
+                    return Err(vec![r.unwrap_err()].into_boxed_slice());
                 }
 
                 ast

--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -30,7 +30,7 @@ pub use crate::{
 use cfgrammar::yacc::parser::SpansKind;
 use cfgrammar::Span;
 
-pub type LexBuildResult<T> = Result<T, Vec<LexBuildError>>;
+pub type LexBuildResult<T> = Result<T, Box<[LexBuildError]>>;
 
 /// Any error from the Lex parser returns an instance of this struct.
 #[derive(Debug)]

--- a/lrlex/src/main.rs
+++ b/lrlex/src/main.rs
@@ -58,7 +58,7 @@ fn main() {
     let lexerdef =
         LRNonStreamingLexerDef::<DefaultLexeme, _>::from_str(&lex_src).unwrap_or_else(|errs| {
             let nlcache = NewlineCache::from_str(&lex_src).unwrap();
-            for e in errs {
+            for e in errs.iter() {
                 if let Some((line, column)) = nlcache
                     .byte_to_line_num_and_col_num(&lex_src, e.spans().next().unwrap().start())
                 {

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -132,7 +132,7 @@ fn main() {
         Ok(x) => x,
         Err(errs) => {
             let nlcache = NewlineCache::from_str(&yacc_src).unwrap();
-            for e in errs {
+            for e in errs.iter() {
                 if let Some((line, column)) = nlcache
                     .byte_to_line_num_and_col_num(&yacc_src, e.spans().next().unwrap().start())
                 {

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -107,7 +107,7 @@ fn main() {
         Ok(ast) => ast,
         Err(errs) => {
             let nlcache = NewlineCache::from_str(&lex_src).unwrap();
-            for e in errs {
+            for e in errs.iter() {
                 if let Some((line, column)) = nlcache
                     .byte_to_line_num_and_col_num(&lex_src, e.spans().next().unwrap().start())
                 {


### PR DESCRIPTION
It occurred to me that there are some potentially good reasons to use `into_boxed_slice()` instead of returning `Vec`.
I'm not sure if it actually shrinks the `Result` type (probably depends on how big the `Ok` value is I suppose.

The biggest impact seemed to be that it isn't implicitly converted into an iterator, and it requires some boiler plate before we can pattern match on it.  But it seemed worth considering.