### PR TITLE
Unused symbol 2nd

### DIFF
--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -58,7 +58,7 @@ pub mod span;
 pub mod yacc;
 
 pub use newlinecache::NewlineCache;
-pub use span::Span;
+pub use span::{Span, Spanned, SpannedError, SpannedWarning};
 
 /// A type specifically for rule indices.
 pub use crate::idxnewtype::{PIdx, RIdx, SIdx, TIdx};

--- a/cfgrammar/src/lib/span.rs
+++ b/cfgrammar/src/lib/span.rs
@@ -43,3 +43,20 @@ impl Span {
         self.len() == 0
     }
 }
+
+/// Implemented for errors and warnings to provide access to their spans.
+pub trait Spanned {
+    /// Returns the spans associated with the error, always containing at least 1 span.
+    ///
+    /// Refer to [SpansKind] via [spanskind](Self::spanskind)
+    /// for the meaning and interpretation of spans and their ordering.
+    fn spans(&self) -> &[Span];
+    /// Returns the [SpansKind] associated with this error.
+    fn spanskind(&self) -> crate::yacc::parser::SpansKind;
+}
+
+/// Marker trait for a warning with the `Spanned` and `Display` traits.
+pub trait SpannedWarning: Spanned + std::fmt::Display {}
+/// Marker trait for any automatically derived for any type that implements both `Error` and `Spanned`.
+pub trait SpannedError: Spanned + std::error::Error {}
+impl<T> SpannedError for T where T: Spanned + std::error::Error {}

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -28,6 +28,8 @@ pub struct GrammarAST {
     pub expectrr: Option<(usize, Span)>,
     pub parse_param: Option<(String, String)>,
     pub programs: Option<String>,
+    // Unchecked `Symbol` names, with spans pointing into the `%expect-unused` declaration.
+    pub expect_unused: Vec<Symbol>,
 }
 
 #[derive(Debug)]
@@ -78,6 +80,7 @@ impl GrammarAST {
             expectrr: None,
             parse_param: None,
             programs: None,
+            expect_unused: Vec::new(),
         }
     }
 

--- a/cfgrammar/src/lib/yacc/mod.rs
+++ b/cfgrammar/src/lib/yacc/mod.rs
@@ -6,7 +6,7 @@ pub mod parser;
 
 pub use self::{
     grammar::{AssocKind, Precedence, SentenceGenerator, YaccGrammar},
-    parser::{YaccGrammarError, YaccGrammarErrorKind},
+    parser::{YaccGrammarError, YaccGrammarErrorKind, YaccGrammarWarning, YaccGrammarWarningKind},
 };
 
 #[cfg(feature = "serde")]

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -49,6 +49,7 @@ pub enum YaccGrammarErrorKind {
     ReachedEOL,
     InvalidString,
     NoStartRule,
+    UnknownSymbol,
     InvalidStartRule(String),
     UnknownRuleRef(String),
     UnknownToken(String),
@@ -114,6 +115,7 @@ impl fmt::Display for YaccGrammarErrorKind {
             }
             YaccGrammarErrorKind::InvalidString => "Invalid string",
             YaccGrammarErrorKind::NoStartRule => return write!(f, "No start rule specified"),
+            YaccGrammarErrorKind::UnknownSymbol => "Unknown symbol, expected a rule or token",
             YaccGrammarErrorKind::InvalidStartRule(name) => {
                 return write!(f, "Start rule '{}' does not appear in grammar", name)
             }
@@ -236,6 +238,7 @@ impl YaccGrammarError {
             | YaccGrammarErrorKind::ReachedEOL
             | YaccGrammarErrorKind::InvalidString
             | YaccGrammarErrorKind::NoStartRule
+            | YaccGrammarErrorKind::UnknownSymbol
             | YaccGrammarErrorKind::InvalidStartRule(_)
             | YaccGrammarErrorKind::UnknownRuleRef(_)
             | YaccGrammarErrorKind::UnknownToken(_)
@@ -439,6 +442,33 @@ impl YaccParser {
                     self.ast.expectrr = Some((n, span));
                 }
                 i = self.parse_ws(j, true)?;
+                continue;
+            }
+            if let Some(j) = self.lookahead_is("%expect-unused", i) {
+                i = self.parse_ws(j, false)?;
+                while i < self.src.len() {
+                    if self.lookahead_is("%", i).is_some() {
+                        break;
+                    }
+                    let j = match self.parse_name(i) {
+                        Ok((j, n)) => {
+                            self.ast
+                                .expect_unused
+                                .push(Symbol::Rule(n, Span::new(i, j)));
+                            j
+                        }
+                        Err(_) => match self.parse_token(i) {
+                            Ok((j, n, span)) => {
+                                self.ast.expect_unused.push(Symbol::Token(n, span));
+                                j
+                            }
+                            Err(_) => {
+                                return Err(self.mk_error(YaccGrammarErrorKind::UnknownSymbol, i))
+                            }
+                        },
+                    };
+                    i = self.parse_ws(j, true)?;
+                }
                 continue;
             }
             if let Some(j) = self.lookahead_is("%expect", i) {
@@ -2457,5 +2487,40 @@ x"
         expected_errs.push((YaccGrammarErrorKind::IncompleteComment, vec![(9, 17)]));
         parse(YaccKind::Grmtools, &src)
             .expect_multiple_errors(&src, &mut expected_errs.clone().into_iter());
+    }
+
+    #[test]
+    fn test_expect_unused() {
+        let src = r#"
+        %expect-unused A 'b' "c"
+        %%
+        A: ;
+        "#;
+        let grm = parse(YaccKind::Original(YaccOriginalActionKind::NoAction), src).unwrap();
+        eprintln!("{:?}", grm.expect_unused);
+        assert!(grm
+            .expect_unused
+            .contains(&Symbol::Rule("A".to_string(), Span::new(24, 25))));
+        assert!(grm
+            .expect_unused
+            .contains(&Symbol::Token("b".to_string(), Span::new(27, 28))));
+        assert!(grm
+            .expect_unused
+            .contains(&Symbol::Token("c".to_string(), Span::new(31, 32))));
+    }
+
+    #[test]
+    fn test_bad_expect_unused() {
+        let src = "
+        %expect-unused %
+        %%
+        A: ;
+        ";
+        parse(YaccKind::Original(YaccOriginalActionKind::NoAction), src).expect_error_at_line_col(
+            src,
+            YaccGrammarErrorKind::UnknownDeclaration,
+            2,
+            24,
+        );
     }
 }

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -3,6 +3,8 @@
 use lazy_static::lazy_static;
 use num_traits::PrimInt;
 use regex::Regex;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use std::{
     collections::{hash_map::Entry, HashMap},
     error::Error,
@@ -133,6 +135,68 @@ impl fmt::Display for YaccGrammarErrorKind {
             }
         };
         write!(f, "{}", s)
+    }
+}
+
+/// The various different possible Yacc parser errors.
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum YaccGrammarWarningKind {
+    UnusedRule,
+    UnusedToken,
+}
+
+/// Any Warning from the Yacc parser returns an instance of this struct.
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct YaccGrammarWarning {
+    /// The specific kind of warning.
+    pub(crate) kind: YaccGrammarWarningKind,
+    /// Always contains at least 1 span.
+    ///
+    /// Refer to [SpansKind] via [spanskind](Self::spanskind)
+    /// For meaning and interpretation of spans and their ordering.
+    pub(crate) spans: Vec<Span>,
+}
+
+impl fmt::Display for YaccGrammarWarning {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.kind)
+    }
+}
+
+impl fmt::Display for YaccGrammarWarningKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let s = match self {
+            YaccGrammarWarningKind::UnusedRule => "Unused rule",
+            YaccGrammarWarningKind::UnusedToken => "Unused token",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+impl YaccGrammarWarning {
+    /// Returns the spans associated with the error, always containing at least 1 span.
+    ///
+    /// Refer to [SpansKind] via [spanskind](Self::spanskind)
+    /// for the meaning and interpretation of spans and their ordering.
+    pub fn spans(&self) -> impl Iterator<Item = Span> + '_ {
+        self.spans.iter().copied()
+    }
+
+    /// Returns the [SpansKind] associated with this error.
+    pub fn spanskind(&self) -> SpansKind {
+        self.kind.spanskind()
+    }
+}
+
+impl YaccGrammarWarningKind {
+    pub fn spanskind(&self) -> SpansKind {
+        match self {
+            YaccGrammarWarningKind::UnusedRule | YaccGrammarWarningKind::UnusedToken => {
+                SpansKind::Error
+            }
+        }
     }
 }
 

--- a/doc/src/errorrecovery.md
+++ b/doc/src/errorrecovery.md
@@ -368,6 +368,12 @@ Unmatched -> ():
   ;
 ```
 
+Since this rule is not reachable from the start state, to avoid any warnings
+caused by that, we should add a `%expect-unused` declaration for it at the top.
+```
+%expect-unused Unmatched
+```
+
 With this done, all possible input will be lexed, and what were previously
 lexing errors are now parsing errors. This means that [error recovery
 section](errorrecovery.html) kicks in, giving us more detailed and informative

--- a/lrlex/examples/calc_manual_lex/src/calc.y
+++ b/lrlex/examples/calc_manual_lex/src/calc.y
@@ -1,3 +1,4 @@
+%expect-unused Unmatched "UNMATCHED"
 %start Expr
 %avoid_insert "INT"
 %%

--- a/lrpar/examples/calc_ast/src/calc.y
+++ b/lrpar/examples/calc_ast/src/calc.y
@@ -1,3 +1,4 @@
+%expect-unused Unmatched "UNMATCHED"
 %start Expr
 %avoid_insert "INT"
 %%

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -20,7 +20,7 @@ use bincode::{deserialize, serialize_into};
 use cfgrammar::{
     newlinecache::NewlineCache,
     yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
-    RIdx, Symbol,
+    RIdx, Spanned, Symbol,
 };
 use filetime::FileTime;
 use lazy_static::lazy_static;
@@ -367,8 +367,8 @@ where
                 line_cache.feed(&inc);
                 errs.iter()
                     .map(|e| {
-                        if let Some((line, column)) = line_cache
-                            .byte_to_line_num_and_col_num(&inc, e.spans().next().unwrap().start())
+                        if let Some((line, column)) =
+                            line_cache.byte_to_line_num_and_col_num(&inc, e.spans()[0].start())
                         {
                             format!("{} at line {line} column {column}", e)
                         } else {
@@ -376,8 +376,8 @@ where
                         }
                     })
                     .chain(warnings.iter().map(|w| {
-                        if let Some((line, column)) = line_cache
-                            .byte_to_line_num_and_col_num(&inc, w.spans().next().unwrap().start())
+                        if let Some((line, column)) =
+                            line_cache.byte_to_line_num_and_col_num(&inc, w.spans()[0].start())
                         {
                             format!("{} at line {line} column {column}", w)
                         } else {

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -130,7 +130,7 @@ fn main() {
     let yacc_src = read_file(yacc_y_path);
     let grm = match YaccGrammar::new(yacckind, &yacc_src) {
         Ok(x) => x,
-        Err(errs) => {
+        Err((warnings, errs)) => {
             let nlcache = NewlineCache::from_str(&yacc_src).unwrap();
             for e in errs {
                 if let Some((line, column)) = nlcache
@@ -145,6 +145,22 @@ fn main() {
                     .ok();
                 } else {
                     writeln!(stderr(), "{}: {}", &yacc_y_path, &e).ok();
+                }
+            }
+
+            for w in warnings {
+                if let Some((line, column)) = nlcache
+                    .byte_to_line_num_and_col_num(&yacc_src, w.spans().next().unwrap().start())
+                {
+                    writeln!(
+                        stderr(),
+                        "{}: {} at line {line} column {column}",
+                        &yacc_y_path,
+                        &w
+                    )
+                    .ok();
+                } else {
+                    writeln!(stderr(), "{}: {}", &yacc_y_path, &w).ok();
                 }
             }
             process::exit(1);

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -10,6 +10,7 @@ use std::{
 use cfgrammar::{
     newlinecache::NewlineCache,
     yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
+    Spanned,
 };
 use getopts::Options;
 use lrlex::{DefaultLexeme, LRNonStreamingLexerDef, LexerDef};
@@ -133,8 +134,8 @@ fn main() {
         Err((warnings, errs)) => {
             let nlcache = NewlineCache::from_str(&yacc_src).unwrap();
             for e in errs {
-                if let Some((line, column)) = nlcache
-                    .byte_to_line_num_and_col_num(&yacc_src, e.spans().next().unwrap().start())
+                if let Some((line, column)) =
+                    nlcache.byte_to_line_num_and_col_num(&yacc_src, e.spans()[0].start())
                 {
                     writeln!(
                         stderr(),
@@ -149,8 +150,8 @@ fn main() {
             }
 
             for w in warnings {
-                if let Some((line, column)) = nlcache
-                    .byte_to_line_num_and_col_num(&yacc_src, w.spans().next().unwrap().start())
+                if let Some((line, column)) =
+                    nlcache.byte_to_line_num_and_col_num(&yacc_src, w.spans()[0].start())
                 {
                     writeln!(
                         stderr(),


### PR DESCRIPTION
For me at least, this has been the implementation that has ticked the most boxes.
Here are some of the reasons I like this version

* Relatively source compatible, a few error return types are changed, parameters largely stay the same.
* While there are currently no Spanned error/warning types in lrtable or lrpar, this paves the way for being
   able to return them along side yacc errors/warnings.  E.g. we could consider turning the `CTConflictsError`.
   into a spanned error, adding it to the `CTParserError` type, and the dyn iterators.  Once that is in place, it seems
   possible we could deprecate `conflicts()` without replacement.
* I like that in the Ok branch of `new_with_storaget` the warnings are hidden within the `YaccGrammar`, and we don't have to deal with tuple return types.  But it isn't really that important they could easily be returned along with the `YaccGrammar`.

I'm less thrilled with the whole `CTParserError::{PreBuild, Build}` and `BuildErrorData`, but seemed like the least terrible
thing I could come up with that allowed us to keep e.g. `token_map` the same.

Anyhow sorry if in fact I am a bit too noisy. :(