### PR TITLE
Unused symbol 3rd

### DIFF
--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -28,6 +28,9 @@ pub struct GrammarAST {
     pub expectrr: Option<(usize, Span)>,
     pub parse_param: Option<(String, String)>,
     pub programs: Option<String>,
+    // The set of symbol names that, if unused in a
+    // grammar, will not cause a warning or error.
+    pub expect_unused: Vec<Symbol>,
 }
 
 #[derive(Debug)]
@@ -78,6 +81,7 @@ impl GrammarAST {
             expectrr: None,
             parse_param: None,
             programs: None,
+            expect_unused: Vec::new(),
         }
     }
 

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -117,6 +117,8 @@ where
                 yp.parse()?;
                 let mut ast = yp.ast();
                 let r = ast.complete_and_validate();
+                // TODO emit warnings.
+                let _ = ast.unused_symbols().map(|sym_idx| sym_idx.symbol(&ast));
                 if r.is_err() {
                     return Err(vec![r.unwrap_err()]);
                 }


### PR DESCRIPTION
From https://github.com/softdevteam/grmtools/pull/347#issuecomment-1236191561

> 1. In an ideal world I'd like to get something like https://github.com/softdevteam/grmtools/commit/75fb27d4902cb1dbc708509488f8413cab3203dc into master straight away (possibly merging https://github.com/softdevteam/grmtools/commit/9e787622c76f0ab6fdf438887807df80fb99d345 into it?), modelling it exactly on the other expect- rules. Let's not worry about warnings for this. I think this should be its own PR.

This brings in the 2 commits mentioned unmodified from the previous series, on top of that is a patch to remove the dependence on warnings. It runs the check (to avoid warnings, and ensure the testsuite runs it) but doesn't do anything with the result yet.  That allowed a small cleanup to remove a temporary vector, since it no longer would capture `self` in the closure.

As such it will need to be squashed, let me know if you prefer that I do that squash before you want to look at it.