### PR TITLE
Add a type for warnings, and a spanned trait for warnings/errors.

### DIFF
--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -58,7 +58,7 @@ pub mod span;
 pub mod yacc;
 
 pub use newlinecache::NewlineCache;
-pub use span::Span;
+pub use span::{Span, Spanned};
 
 /// A type specifically for rule indices.
 pub use crate::idxnewtype::{PIdx, RIdx, SIdx, TIdx};

--- a/cfgrammar/src/lib/span.rs
+++ b/cfgrammar/src/lib/span.rs
@@ -43,3 +43,14 @@ impl Span {
         self.len() == 0
     }
 }
+
+/// Implemented for errors and warnings to provide access to their spans.
+pub trait Spanned: std::fmt::Display {
+    /// Returns the spans associated with the error, always containing at least 1 span.
+    ///
+    /// Refer to [SpansKind](crate::yacc::parser::SpansKind) via [spanskind](Self::spanskind)
+    /// for the meaning and interpretation of spans and their ordering.
+    fn spans(&self) -> &[Span];
+    /// Returns the `SpansKind` associated with this error.
+    fn spanskind(&self) -> crate::yacc::parser::SpansKind;
+}

--- a/cfgrammar/src/lib/yacc/mod.rs
+++ b/cfgrammar/src/lib/yacc/mod.rs
@@ -6,7 +6,7 @@ pub mod parser;
 
 pub use self::{
     grammar::{AssocKind, Precedence, SentenceGenerator, YaccGrammar},
-    parser::{YaccGrammarError, YaccGrammarErrorKind},
+    parser::{YaccGrammarError, YaccGrammarErrorKind, YaccGrammarWarning, YaccGrammarWarningKind},
 };
 
 #[cfg(feature = "serde")]

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -12,7 +12,7 @@ use std::{
 
 pub type YaccGrammarResult<T> = Result<T, Vec<YaccGrammarError>>;
 
-use crate::Span;
+use crate::{Span, Spanned};
 
 use super::{
     ast::{GrammarAST, Symbol},
@@ -146,17 +146,17 @@ pub enum SpansKind {
     Error,
 }
 
-impl YaccGrammarError {
+impl Spanned for YaccGrammarError {
     /// Returns the spans associated with the error, always containing at least 1 span.
     ///
     /// Refer to [SpansKind] via [spanskind](Self::spanskind)
     /// for the meaning and interpretation of spans and their ordering.
-    pub fn spans(&self) -> &[Span] {
+    fn spans(&self) -> &[Span] {
         self.spans.as_slice()
     }
 
     /// Returns the [SpansKind] associated with this error.
-    pub fn spanskind(&self) -> SpansKind {
+    fn spanskind(&self) -> SpansKind {
         match self.kind {
             YaccGrammarErrorKind::IllegalInteger
             | YaccGrammarErrorKind::IllegalName
@@ -946,7 +946,7 @@ mod test {
             ast::{GrammarAST, Production, Symbol},
             AssocKind, Precedence, YaccKind, YaccOriginalActionKind,
         },
-        Span, YaccGrammarError, YaccGrammarErrorKind, YaccParser,
+        Span, Spanned, YaccGrammarError, YaccGrammarErrorKind, YaccParser,
     };
 
     fn parse(yacc_kind: YaccKind, s: &str) -> Result<GrammarAST, Vec<YaccGrammarError>> {

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -151,8 +151,8 @@ impl YaccGrammarError {
     ///
     /// Refer to [SpansKind] via [spanskind](Self::spanskind)
     /// for the meaning and interpretation of spans and their ordering.
-    pub fn spans(&self) -> impl Iterator<Item = Span> + '_ {
-        self.spans.iter().copied()
+    pub fn spans(&self) -> &[Span] {
+        self.spans.as_slice()
     }
 
     /// Returns the [SpansKind] associated with this error.
@@ -1032,7 +1032,7 @@ mod test {
                 Ok(_) => panic!("Parsed ok while expecting error"),
                 Err([e])
                     if e.kind == kind
-                        && line_of_offset(src, e.spans().next().unwrap().start()) == line
+                        && line_of_offset(src, e.spans()[0].start()) == line
                         && e.spans.len() == 1 => {}
                 Err(e) => incorrect_errs!(src, e),
             }
@@ -1058,12 +1058,11 @@ mod test {
                 Ok(_) => panic!("Parsed ok while expecting error"),
                 Err([e])
                     if e.kind == kind
-                        && line_col!(src, e.spans().next().unwrap())
-                            == lines_cols.next().unwrap() =>
+                        && line_col!(src, e.spans()[0]) == lines_cols.next().unwrap() =>
                 {
                     assert_eq!(
-                        e.spans()
-                            .skip(1)
+                        e.spans()[1..]
+                            .iter()
                             .map(|span| line_col!(src, span))
                             .collect::<Vec<(usize, usize)>>(),
                         lines_cols.collect::<Vec<(usize, usize)>>()
@@ -1095,6 +1094,7 @@ mod test {
                             (
                                 e.kind.clone(),
                                 e.spans()
+                                    .iter()
                                     .map(|span| line_col!(src, span))
                                     .collect::<Vec<_>>(),
                             )

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -20,7 +20,7 @@ use bincode::{deserialize, serialize_into};
 use cfgrammar::{
     newlinecache::NewlineCache,
     yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
-    RIdx, Symbol,
+    RIdx, Spanned, Symbol,
 };
 use filetime::FileTime;
 use lazy_static::lazy_static;

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -374,15 +374,14 @@ where
         }
 
         let inc = read_to_string(grmp).unwrap();
-
         let grm = YaccGrammar::<StorageT>::new_with_storaget(yk, &inc)
             .map_err(|errs| {
                 errs.iter()
                     .map(|e| {
                         let mut line_cache = NewlineCache::new();
                         line_cache.feed(&inc);
-                        if let Some((line, column)) = line_cache
-                            .byte_to_line_num_and_col_num(&inc, e.spans().next().unwrap().start())
+                        if let Some((line, column)) =
+                            line_cache.byte_to_line_num_and_col_num(&inc, e.spans()[0].start())
                         {
                             format!("{} at line {line} column {column}", e)
                         } else {

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -133,8 +133,8 @@ fn main() {
         Err(errs) => {
             let nlcache = NewlineCache::from_str(&yacc_src).unwrap();
             for e in errs {
-                if let Some((line, column)) = nlcache
-                    .byte_to_line_num_and_col_num(&yacc_src, e.spans().next().unwrap().start())
+                if let Some((line, column)) =
+                    nlcache.byte_to_line_num_and_col_num(&yacc_src, e.spans()[0].start())
                 {
                     writeln!(
                         stderr(),

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -10,6 +10,7 @@ use std::{
 use cfgrammar::{
     newlinecache::NewlineCache,
     yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
+    Spanned,
 };
 use getopts::Options;
 use lrlex::{DefaultLexeme, LRNonStreamingLexerDef, LexerDef};


### PR DESCRIPTION
This merely adds the types, modifies things so they'll work in a trait, due to traits not support `impl` in return type,
and implements the trait.

For some motivation for the trait, you can see the example using the [ariadne](https://crates.io/crates/ariadne/) crate
included in https://github.com/ratmice/grmtools/commit/eca699f9e2fe48d1030785eae6c2e06a95a8ee45 on a WIP [analysis](https://github.com/ratmice/grmtools/tree/analysis) branch that this has been
cherry-picked from. In that patch, there is a generic function `spanned_report<T: Spanned>`
used to build a report for both errors and warnings. I have included some output below.

```
Error:
   ╭─[erroneous.y:4:1]
   │
 4 │ C -> (): {};
   · ┬
   · ╰── Duplicated rule
 5 │ C -> (): B {};
   · ┬
   · ╰── Duplicate
───╯
Warning:
   ╭─[erroneous.y:4:1]
   │
 4 │ C -> (): {};
   · ┬
   · ╰── Unused rule
───╯
```