### PR TITLE
Ctbuilder warnings

### DIFF
--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -5,7 +5,10 @@ use std::{
 
 use indexmap::{IndexMap, IndexSet};
 
-use super::{parser::YaccParser, Precedence, YaccGrammarError, YaccGrammarErrorKind, YaccKind};
+use super::{
+    parser::YaccParser, Precedence, YaccGrammarError, YaccGrammarErrorKind, YaccGrammarWarning,
+    YaccGrammarWarningKind, YaccKind,
+};
 
 use crate::Span;
 /// Contains a `GrammarAST` structure produced from a grammar source file.
@@ -298,6 +301,21 @@ impl GrammarAST {
             }
         }
         Ok(())
+    }
+
+    pub fn warnings(&self) -> Vec<YaccGrammarWarning> {
+        self.unused_symbols()
+            .map(|symidx| {
+                let (kind, span) = match symidx.symbol(self) {
+                    Symbol::Rule(_, span) => (YaccGrammarWarningKind::UnusedRule, span),
+                    Symbol::Token(_, span) => (YaccGrammarWarningKind::UnusedToken, span),
+                };
+                YaccGrammarWarning {
+                    kind,
+                    spans: vec![span],
+                }
+            })
+            .collect()
     }
 
     /// Return the indices of unexpectedly unused rules (relative to ast.rules)

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -5,13 +5,7 @@ use num_traits::{self, AsPrimitive, PrimInt, Unsigned};
 use serde::{Deserialize, Serialize};
 use vob::Vob;
 
-use super::{
-    ast,
-    firsts::YaccFirsts,
-    follows::YaccFollows,
-    parser::{YaccGrammarResult, YaccParser},
-    YaccKind,
-};
+use super::{ast, firsts::YaccFirsts, follows::YaccFollows, parser::YaccGrammarResult, YaccKind};
 use crate::{PIdx, RIdx, SIdx, Span, Symbol, TIdx};
 
 const START_RULE: &str = "^";
@@ -111,22 +105,18 @@ where
     /// though the actual name is a fresh name that is guaranteed to be unique) that references the
     /// user defined start rule.
     pub fn new_with_storaget(yacc_kind: YaccKind, s: &str) -> YaccGrammarResult<Self> {
-        let ast = match yacc_kind {
-            YaccKind::Original(_) | YaccKind::Grmtools | YaccKind::Eco => {
-                let mut yp = YaccParser::new(yacc_kind, s.to_string());
-                yp.parse()?;
-                let mut ast = yp.ast();
-                let r = ast.complete_and_validate();
-                // TODO emit warnings.
-                let _ = ast.unused_symbols().map(|sym_idx| sym_idx.symbol(&ast));
-                if r.is_err() {
-                    return Err(vec![r.unwrap_err()]);
-                }
+        let ast_validation = ast::ASTWithValidityInfo::new(yacc_kind, s);
+        Self::new_from_ast_with_validity_info(yacc_kind, ast_validation)
+    }
 
-                ast
-            }
-        };
-
+    pub fn new_from_ast_with_validity_info(
+        yacc_kind: YaccKind,
+        ast_validation: ast::ASTWithValidityInfo,
+    ) -> YaccGrammarResult<Self> {
+        if !ast_validation.is_valid() {
+            return Err(ast_validation.errs);
+        }
+        let ast = ast_validation.ast;
         // Check that StorageT is big enough to hold RIdx/PIdx/SIdx/TIdx values; after these
         // checks we can guarantee that things like RIdx(ast.rules.len().as_()) are safe.
         if ast.rules.len() > num_traits::cast(StorageT::max_value()).unwrap() {
@@ -321,7 +311,7 @@ where
             }
         }
 
-        let avoid_insert = if let Some(ai) = ast.avoid_insert {
+        let avoid_insert = if let Some(ai) = &ast.avoid_insert {
             let mut aiv = Vob::from_elem(false, token_names.len());
             for n in ai.keys() {
                 aiv.set(usize::from(token_map[n]), true);

--- a/lrlex/examples/calc_manual_lex/src/calc.y
+++ b/lrlex/examples/calc_manual_lex/src/calc.y
@@ -1,5 +1,6 @@
 %start Expr
 %avoid_insert "INT"
+%expect-unused Unmatched "UNMATCHED"
 %%
 Expr -> Result<Expr, ()>:
       Expr '+' Term {

--- a/lrlex/src/lib/ctbuilder.rs
+++ b/lrlex/src/lib/ctbuilder.rs
@@ -16,7 +16,7 @@ use std::{
     sync::Mutex,
 };
 
-use cfgrammar::newlinecache::NewlineCache;
+use cfgrammar::{newlinecache::NewlineCache, Spanned};
 use lazy_static::lazy_static;
 use lrpar::{CTParserBuilder, Lexeme};
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
@@ -315,7 +315,7 @@ where
                                 if let Some((line, column)) = line_cache
                                     .byte_to_line_num_and_col_num(
                                         &lex_src,
-                                        e.spans().next().unwrap().start(),
+                                        e.spans().first().unwrap().start(),
                                     )
                                 {
                                     format!("{} at line {line} column {column}", e)

--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -28,7 +28,7 @@ pub use crate::{
 };
 
 use cfgrammar::yacc::parser::SpansKind;
-use cfgrammar::Span;
+use cfgrammar::{Span, Spanned};
 
 pub type LexBuildResult<T> = Result<T, Vec<LexBuildError>>;
 
@@ -57,12 +57,12 @@ pub enum LexErrorKind {
     RegexError,
 }
 
-impl LexBuildError {
-    pub fn spans(&self) -> impl Iterator<Item = Span> + '_ {
-        self.spans.iter().copied()
+impl Spanned for LexBuildError {
+    fn spans(&self) -> &[Span] {
+        self.spans.as_slice()
     }
 
-    pub fn spanskind(&self) -> SpansKind {
+    fn spanskind(&self) -> SpansKind {
         match self.kind {
             LexErrorKind::PrematureEnd
             | LexErrorKind::RoutinesNotSupported

--- a/lrlex/src/lib/parser.rs
+++ b/lrlex/src/lib/parser.rs
@@ -531,6 +531,7 @@ mod test {
         lexer::{LRNonStreamingLexerDef, LexerDef},
         DefaultLexeme,
     };
+    use cfgrammar::Spanned as _;
     use std::fmt::Write as _;
 
     macro_rules! incorrect_errs {
@@ -539,7 +540,7 @@ mod test {
                 let mut line_cache = ::cfgrammar::newlinecache::NewlineCache::new();
                 line_cache.feed(&$src);
                 if let Some((line, column)) = line_cache
-                    .byte_to_line_num_and_col_num(&$src, e.spans().next().unwrap().start())
+                    .byte_to_line_num_and_col_num(&$src, e.spans().first().unwrap().start())
                 {
                     panic!(
                         "Incorrect error returned {} at line {line} column {column}",
@@ -588,7 +589,7 @@ mod test {
                 Ok(_) => panic!("Parsed ok while expecting error"),
                 Err([e])
                     if e.kind == kind
-                        && line_of_offset(src, e.spans().next().unwrap().start()) == line
+                        && line_of_offset(src, e.spans().first().unwrap().start()) == line
                         && e.spans.len() == 1 => {}
                 Err(e) => incorrect_errs!(src, e),
             }
@@ -608,11 +609,12 @@ mod test {
                 Ok(_) => panic!("Parsed ok while expecting error"),
                 Err([e])
                     if e.kind == kind
-                        && line_col!(src, e.spans().next().unwrap())
+                        && line_col!(src, e.spans().first().unwrap())
                             == lines_cols.next().unwrap() =>
                 {
                     assert_eq!(
                         e.spans()
+                            .iter()
                             .skip(1)
                             .map(|span| line_col!(src, span))
                             .collect::<Vec<(usize, usize)>>(),
@@ -645,6 +647,7 @@ mod test {
                             (
                                 e.kind.clone(),
                                 e.spans()
+                                    .iter()
                                     .map(|span| line_col!(src, span))
                                     .collect::<Vec<_>>(),
                             )

--- a/lrlex/src/main.rs
+++ b/lrlex/src/main.rs
@@ -8,7 +8,7 @@ use std::{
     str::FromStr,
 };
 
-use cfgrammar::newlinecache::NewlineCache;
+use cfgrammar::{newlinecache::NewlineCache, Spanned};
 use lrlex::{DefaultLexeme, LRNonStreamingLexerDef, LexerDef};
 use lrpar::{Lexeme, Lexer};
 
@@ -60,7 +60,7 @@ fn main() {
             let nlcache = NewlineCache::from_str(&lex_src).unwrap();
             for e in errs {
                 if let Some((line, column)) = nlcache
-                    .byte_to_line_num_and_col_num(&lex_src, e.spans().next().unwrap().start())
+                    .byte_to_line_num_and_col_num(&lex_src, e.spans().first().unwrap().start())
                 {
                     writeln!(
                         stderr(),

--- a/lrpar/cttests/build.rs
+++ b/lrpar/cttests/build.rs
@@ -15,6 +15,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for entry in glob("src/*.test")? {
         let path = entry.unwrap();
         if path.is_file() {
+            println!("cargo:rerun-if-changed={}", path.display());
             // Parse test file
             let s = fs::read_to_string(&path).unwrap();
             let docs = YamlLoader::load_from_str(&s).unwrap();

--- a/lrpar/cttests/src/warnings.test
+++ b/lrpar/cttests/src/warnings.test
@@ -1,0 +1,13 @@
+name: Test disabling warnings are errors.
+yacckind: Original(YaccOriginalActionKind::GenericParseTree)
+yacc_flags: [ '!warnings_are_errors', '!show_warnings' ]
+grammar: |
+    %start A
+    %token b
+    %%
+    A : 'a';
+    B : 'b';
+lexer: |
+    %%
+    a 'a'
+    b 'b'

--- a/lrpar/examples/calc_ast/src/calc.y
+++ b/lrpar/examples/calc_ast/src/calc.y
@@ -1,5 +1,6 @@
 %start Expr
 %avoid_insert "INT"
+%expect-unused Unmatched "UNMATCHED"
 %%
 Expr -> Result<Expr, ()>:
       Expr '+' Term {

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -150,6 +150,7 @@ where
     yacckind: Option<YaccKind>,
     error_on_conflicts: bool,
     warnings_are_errors: bool,
+    show_warnings: bool,
     visibility: Visibility,
     phantom: PhantomData<(LexemeT, StorageT)>,
 }
@@ -189,6 +190,7 @@ where
             yacckind: None,
             error_on_conflicts: true,
             warnings_are_errors: true,
+            show_warnings: true,
             visibility: Visibility::Private,
             phantom: PhantomData,
         }
@@ -306,6 +308,13 @@ where
         self
     }
 
+    /// If set to true, [CTParserBuilder::build] will print warnings to stderr, or via cargo when
+    /// running under cargo.  Defaults to `true`.
+    pub fn show_warnings(mut self, b: bool) -> Self {
+        self.show_warnings = b;
+        self
+    }
+
     /// Statically compile the Yacc file specified by [CTParserBuilder::grammar_path()] into Rust,
     /// placing the output into the file spec [CTParserBuilder::output_path()]. Note that three
     /// additional files will be created with the same name as specified in [self.output_path] but
@@ -414,9 +423,9 @@ where
                     line_cache.feed(&inc);
                     for w in warnings {
                         // Assume if this variable is set we are running under cargo.
-                        if std::env::var("OUT_DIR").is_ok() {
+                        if std::env::var("OUT_DIR").is_ok() && self.show_warnings {
                             println!("cargo:warning={}", spanned_fmt(&w, &inc, &line_cache));
-                        } else {
+                        } else if self.show_warnings {
                             eprintln!("{}", spanned_fmt(&w, &inc, &line_cache));
                         }
                     }
@@ -613,6 +622,7 @@ where
             yacckind: self.yacckind,
             error_on_conflicts: self.error_on_conflicts,
             warnings_are_errors: self.warnings_are_errors,
+            show_warnings: self.show_warnings,
             visibility: self.visibility.clone(),
             phantom: PhantomData,
         };

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -110,7 +110,7 @@ fn main() {
             let nlcache = NewlineCache::from_str(&lex_src).unwrap();
             for e in errs {
                 if let Some((line, column)) = nlcache
-                    .byte_to_line_num_and_col_num(&lex_src, e.spans().next().unwrap().start())
+                    .byte_to_line_num_and_col_num(&lex_src, e.spans().first().unwrap().start())
                 {
                     writeln!(
                         stderr(),


### PR DESCRIPTION
Here is an alternate minimalist version of PR #353 which removes the Analysis trait, and the extra builder path.
With the `CTBuilder::build()` function is pretty much left as-is except now it directly emits warnings into the `Box<dyn Error>`.

The difference from the previous patch is this one doesn't allow you to get spanned errors/warnings out of the build process,
or interact with `GrammarAST`, `YaccGrammar`, `State*`.  That makes it quite a bit simpler than the previous patch, but lacks some of the flexibility of not being able to run an arbitrary user defined analysis.

Overall, I do struggle to find anything which allows that flexibility which doesn't entail all the complexity therein.