### PR TITLE
Merge deletes when pretty printing repair sequences

### DIFF
--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -798,4 +798,30 @@ U: 'd';
             ],
         );
     }
+
+    #[test]
+    fn test_unmatched() {
+        let lexs = "
+          blah 'BLAH'
+          . 'UNMATCHED'
+          ";
+
+        let grms = "
+%start S
+%%
+S: 'BLAH';
+Unmatched:
+  'UNMATCHED' { }
+  ;
+";
+
+        let us = "long";
+        let (grm, pr) = do_parse(RecoveryKind::CPCTPlus, lexs, grms, us);
+        let (_, errs) = pr.unwrap_err();
+        check_all_repairs(
+            &grm,
+            &errs[0],
+            &[r#"Insert "BLAH", Delete, Delete, Delete, Delete"#],
+        );
+    }
 }


### PR DESCRIPTION
After various setup, the main bulk of this PR merges together `Delete` repairs when they directly follow on from one another. For example for an input such as:

```
abc
```

where `bc` should be deleted we previously printed:

```
Delete "b", Delete "c"
```

With this commit we print:

```
Delete "bc"
```

For long token names this can be a real win. For example in pizauth's configuration file, which has long token names, I sometimes found myself typing `auth_notify_intervl` instead of `auth_notify_interval` and would then be greeted with this horror:

```
Parsing error at line 5 column 1. Repair sequences found:
   1: Insert AUTH_NOTIFY_INTERVAL, Delete a, Delete u, Delete t, Delete h, Delete _, Delete n, Delete o, Delete t, Delete i, Delete f, Delete y, Delete _, Delete i, Delete n, Delete t, Delete e, Delete r, Delete v, Delete l
   2: Insert REFRESH_RETRY_INTERVAL, Delete a, Delete u, Delete t, Delete h, Delete _, Delete n, Delete o, Delete t, Delete i, Delete f, Delete y, Delete _, Delete i, Delete n, Delete t, Delete e, Delete r, Delete v, Delete l
```

With this commit I get the rather nicer:

```
Parsing error at line 5 column 1. Repair sequences found:
   1: Insert AUTH_NOTIFY_INTERVAL, Delete auth_notify_intervl
   2: Insert REFRESH_RETRY_INTERVAL, Delete auth_notify_intervl
```

Note that this only merges together `Delete`s that directly follow each other: even a single blank space between them will cause them not to be
merged.
