### PR TITLE
Clean up issue #323 by using the quote crate.

### DIFF
--- a/lrlex/Cargo.toml
+++ b/lrlex/Cargo.toml
@@ -28,5 +28,6 @@ lrpar = { path = "../lrpar", version = "0.12" }
 regex = "1"
 regex-syntax = "0.6.27"
 num-traits = "0.2"
+quote = "1.0"
 serde = "1.0"
 try_from = "0.3"

--- a/lrpar/cttests/src/quoting.test
+++ b/lrpar/cttests/src/quoting.test
@@ -1,0 +1,15 @@
+name: Test NoAction using the calculator grammar
+yacckind: Original(YaccOriginalActionKind::NoAction)
+grammar: |
+    %start S 
+    %%
+    S: '\' | '"' | '<' | '+' '🦀' ;
+
+lexer: |
+    %%
+    " '"'
+    \< '<'
+    \\ '\'
+    \+ '+'
+    🦀 '🦀'
+    [\t ]+ ;


### PR DESCRIPTION
Here is an attempt at fixing #323, this uses the quote crate (lrlex already depends upon it non-optionally it seems via serde).

The only other quoting mechanism I could find that seemed like it would work is the `escape_debug` function,
which is not very well described except that it "escapes like the str debug implementation".

After this, there are a couple of uses "{:?}", they are all for StorageT, we could perhaps add a bounds on `T: quote::ToTokens`
and implement `impl ToTokens for IdxNewtype!(T)`?  We can't quite manage it with just num_traits bounds alone.

quote (well proc_macro2 which it returns) also isn't very explicit in it's documentation for it's `Display` impl.
https://docs.rs/proc-macro2/latest/proc_macro2/struct.TokenStream.html#impl-Display-for-TokenStream

It is a bit unfortunate that rust really doesn't seem to have anything quite like python's `repr` function.