### PR TITLE
Issue 364

### DIFF
--- a/doc/src/ast_example.md
+++ b/doc/src/ast_example.md
@@ -15,17 +15,17 @@ guide](quickstart.md). However the `calc.y` file is change as follows:
 %avoid_insert "INT"
 %%
 Expr -> Result<Expr, ()>:
-      Expr '+' Term { Ok(Expr::Add{ span: $span, lhs: Box::new($1?), rhs: Box::new($3?) }) }
+      Expr 'PLUS' Term { Ok(Expr::Add{ span: $span, lhs: Box::new($1?), rhs: Box::new($3?) }) }
     | Term { $1 }
     ;
 
 Term -> Result<Expr, ()>:
-      Term '*' Factor { Ok(Expr::Mul{ span: $span, lhs: Box::new($1?), rhs: Box::new($3?) }) }
+      Term 'MUL' Factor { Ok(Expr::Mul{ span: $span, lhs: Box::new($1?), rhs: Box::new($3?) }) }
     | Factor { $1 }
     ;
 
 Factor -> Result<Expr, ()>:
-      '(' Expr ')' { $2 }
+      'LBRACK' Expr 'RBRACK' { $2 }
     | 'INT' { Ok(Expr::Number{ span: $span }) }
     ;
 %%
@@ -113,7 +113,7 @@ fn main() {
     }
 }
 
-fn eval(lexer: &dyn NonStreamingLexer<u32>, e: Expr) -> Result<u64, (Span, &'static str)> {
+fn eval(lexer: &dyn NonStreamingLexer<'_, DefaultLexeme, u32>, e: Expr) -> Result<u64, (Span, &'static str)> {
     match e {
         Expr::Add { span, lhs, rhs } => eval(lexer, *lhs)?
             .checked_add(eval(lexer, *rhs)?)

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -758,7 +758,7 @@ where
                     outs,
                     "
     #[allow(dead_code)]
-    pub fn parse(lexer: &dyn ::lrpar::NonStreamingLexer<{lexemet}, {storaget}>)
+    pub fn parse(lexer: &dyn ::lrpar::NonStreamingLexer<'_, {lexemet}, {storaget}>)
           -> (::std::option::Option<::lrpar::Node<{lexemet}, {storaget}>>,
               ::std::vec::Vec<::lrpar::LexParseError<{lexemet}, {storaget}>>)
     {{",
@@ -772,7 +772,7 @@ where
                     outs,
                     "
     #[allow(dead_code)]
-    pub fn parse(lexer: &dyn ::lrpar::NonStreamingLexer<{lexemet}, {storaget}>)
+    pub fn parse(lexer: &dyn ::lrpar::NonStreamingLexer<'_, {lexemet}, {storaget}>)
           -> ::std::vec::Vec<::lrpar::LexParseError<{lexemet}, {storaget}>>
     {{",
                     lexemet = type_name::<LexemeT>(),
@@ -818,7 +818,7 @@ where
         let actions: ::std::vec::Vec<&dyn Fn(::cfgrammar::RIdx<{storaget}>,
                        &'lexer dyn ::lrpar::NonStreamingLexer<'input, {lexemet}, {storaget}>,
                        ::cfgrammar::Span,
-                       ::std::vec::Drain<::lrpar::parser::AStackType<{lexemet}, {actionskind}<'input>>>,
+                       ::std::vec::Drain<'_, ::lrpar::parser::AStackType<{lexemet}, {actionskind}<'input>>>,
                        {parse_paramty})
                     -> {actionskind}<'input>> = ::std::vec![{wrappers}];\n",
                     actionskind = ACTIONS_KIND,
@@ -934,7 +934,7 @@ where
                 "    fn {prefix}wrapper_{}<'lexer, 'input: 'lexer>({prefix}ridx: ::cfgrammar::RIdx<{storaget}>,
                       {prefix}lexer: &'lexer dyn ::lrpar::NonStreamingLexer<'input, {lexemet}, {storaget}>,
                       {prefix}span: ::cfgrammar::Span,
-                      mut {prefix}args: ::std::vec::Drain<::lrpar::parser::AStackType<{lexemet}, {actionskind}<'input>>>,
+                      mut {prefix}args: ::std::vec::Drain<'_, ::lrpar::parser::AStackType<{lexemet}, {actionskind}<'input>>>,
                       {parse_paramdef})
                    -> {actionskind}<'input> {{",
                 usize::from(pidx),


### PR DESCRIPTION
I'm not sure if we want to support rust_2018 in generated code, if we do though here is a patch
with this you can add `#![deny(rust_2018_idioms)]` to the ast_example from the book, and it should compile.

Above and beyond that, if you add `#![deny(rust_2018_idioms)]` to the generated code module, it brings up a couple of more errors this fixes those too.

Unfortunately, I'm not exactly sure a good way to test this, as *most* of the time rust emits: `warning: deny(rust_2018_idioms) is ignored unless specified at crate level`.

There were also some general issues with the ast_example regarding the calc.l names `'*'` vs `'MUL'`, missing type parameters, etc.
so if we decide not to support rust_2018_idioms, I should remember to break that out of this patch.