### PR TITLE
Enable forbid(unsafe_code) except in parser action code

### DIFF
--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::new_without_default)]
 #![allow(clippy::unnecessary_wraps)]
 #![allow(clippy::upper_case_acronyms)]
+#![forbid(unsafe_code)]
 
 //! A library for manipulating Context Free Grammars (CFG). It is impractical to fully homogenise
 //! all the types of grammars out there, so the aim is for different grammar types

--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -9,6 +9,7 @@
 #![allow(clippy::type_complexity)]
 #![allow(clippy::unnecessary_wraps)]
 #![allow(clippy::upper_case_acronyms)]
+#![forbid(unsafe_code)]
 
 use std::{error::Error, fmt};
 

--- a/lrpar/cttests/src/calc_unsafeaction.test
+++ b/lrpar/cttests/src/calc_unsafeaction.test
@@ -1,0 +1,39 @@
+name: Test basic user actions using the calculator grammar
+yacckind: Original(YaccOriginalActionKind::UserAction)
+grammar: |
+    %start Expr
+    %actiontype Result<u64, ()>
+    %avoid_insert 'INT'
+    %%
+    Expr: Expr '+' Term { unsafe { Ok(Ok::<u64, ()>($1? + $3?).unwrap_unchecked()) } }
+        | Term { $1 }
+        ;
+
+    Term: Term '*' Factor { unsafe { Ok(Ok::<u64, ()>($1? * $3?).unwrap_unchecked()) } }
+        | Factor { $1 }
+        ;
+
+    Factor: '(' Expr ')' { $2 }
+          | 'INT' {
+                let l = $1.map_err(|_| ())?;
+                match $lexer.span_str(l.span()).parse::<u64>() {
+                    Ok(v) => unsafe { Ok(Ok::<u64, ()>(v).unwrap_unchecked()) },
+                    Err(_) => {
+                        let ((_, col), _) = $lexer.line_col(l.span());
+                        eprintln!("Error at column {}: '{}' cannot be represented as a u64",
+                                  col,
+                                  $lexer.span_str(l.span()));
+                        Err(())
+                    }
+                }
+            }
+          ;
+
+lexer: |
+    %%
+    [0-9]+ "INT"
+    \+ "+"
+    \* "*"
+    \( "("
+    \) ")"
+    [\t ]+ ;

--- a/lrpar/cttests/src/lib.rs
+++ b/lrpar/cttests/src/lib.rs
@@ -14,6 +14,9 @@ lrpar_mod!("calc_actiontype.y");
 lrlex_mod!("calc_noactions.l");
 lrpar_mod!("calc_noactions.y");
 
+lrlex_mod!("calc_unsafeaction.l");
+lrpar_mod!("calc_unsafeaction.y");
+
 lrlex_mod!("expect.l");
 lrpar_mod!("expect.y");
 
@@ -59,6 +62,16 @@ fn test_basic_actions() {
     let lexerdef = calc_actiontype_l::lexerdef();
     let lexer = lexerdef.lexer("2+3");
     match calc_actiontype_y::parse(&lexer) {
+        (Some(Ok(5)), ref errs) if errs.is_empty() => (),
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn test_unsafe_actions() {
+    let lexerdef = calc_unsafeaction_l::lexerdef();
+    let lexer = lexerdef.lexer("2+3");
+    match calc_unsafeaction_y::parse(&lexer) {
         (Some(Ok(5)), ref errs) if errs.is_empty() => (),
         _ => unreachable!(),
     }

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -674,7 +674,7 @@ where
         outs.push_str(
             "    #![allow(clippy::type_complexity)]
     #![allow(clippy::unnecessary_wraps)]
-
+    #![deny(unsafe_code)]
     #[allow(unused_imports)]
     use ::lrpar::Lexeme;
 ",
@@ -1148,6 +1148,7 @@ where
             write!(outs,
                 "    // {rulename}
     #[allow(clippy::too_many_arguments)]
+    #[allow(unsafe_code)] // Allow an action to embed unsafe blocks within it.
     fn {prefix}action_{}<'lexer, 'input: 'lexer>({prefix}ridx: ::cfgrammar::RIdx<{storaget}>,
                      {prefix}lexer: &'lexer dyn ::lrpar::NonStreamingLexer<'input, {lexemet}, {storaget}>,
                      {prefix}span: ::cfgrammar::Span,

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -7,6 +7,7 @@
 #![allow(clippy::type_complexity)]
 #![allow(clippy::unnecessary_wraps)]
 #![allow(clippy::upper_case_acronyms)]
+#![forbid(unsafe_code)]
 
 //! `lrpar` provides a Yacc-compatible parser (where grammars can be generated at compile-time or
 //! run-time). It can take in traditional `.y` files and convert them into an idiomatic Rust

--- a/lrtable/src/lib/mod.rs
+++ b/lrtable/src/lib/mod.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::cognitive_complexity)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::type_complexity)]
+#![forbid(unsafe_code)]
 
 use std::{hash::Hash, mem::size_of};
 


### PR DESCRIPTION
I was reading through https://gist.github.com/repi/d98bf9c202ec567fd67ef9e31152f43f,
point 3.1 seemed like it should be easy to do since there isn't any usage of unsafe code.
That said I totally understand if it isn't something you want to merge.

In the generated code, this allows unsafe blocks within user actions, and adds a test for that,
I manually tested by removing the `#[allow(unsafe_code)]` that the new cttest fails.

