### PR TITLE
Generic `LexError`

### DIFF
--- a/doc/src/ast_example.md
+++ b/doc/src/ast_example.md
@@ -67,7 +67,7 @@ Our `main.rs` file then looks as follows:
 ```rust,noplaypen
 use std::io::{self, BufRead, Write};
 
-use lrlex::{lrlex_mod, DefaultLexeme};
+use lrlex::{lrlex_mod, DefaultLexeme, LRLexError};
 use lrpar::{lrpar_mod, NonStreamingLexer, Span};
 
 lrlex_mod!("calc.l");
@@ -113,7 +113,11 @@ fn main() {
     }
 }
 
-fn eval(lexer: &dyn NonStreamingLexer<DefaultLexeme, u32>, e: Expr) -> Result<u64, (Span, &'static str)> {
+fn eval(
+    lexer: &dyn NonStreamingLexer<DefaultLexeme, u32>,
+    e: Expr,
+    LRLexError)
+-> Result<u64, (Span, &'static str)> {
     match e {
         Expr::Add { span, lhs, rhs } => eval(lexer, *lhs)?
             .checked_add(eval(lexer, *rhs)?)

--- a/doc/src/errorrecovery.md
+++ b/doc/src/errorrecovery.md
@@ -537,11 +537,15 @@ the first parsing error, with the `recoverer` method in `CTParserBuilder` or
 `RTParserBuilder`. For example, we can change `calc`'s `build.rs` file to:
 
 ```rust,noplaypen
-    let lex_rule_ids_map = CTParserBuilder::new()
-        .yacckind(YaccKind::Grmtools)
-        .recoverer(lrpar::RecoveryKind::None)
-        .grammar_path_in_src("calc.y")?
-        .process()?;
+CTLexerBuilder::new()
+    .lrpar_config(|ctp| {
+        ctp.yacckind(YaccKind::Grmtools)
+            .recoverer(lrpar::RecoveryKind::None)
+            .grammar_in_src_dir("calc.y")
+            .unwrap()
+    })
+    .lexer_in_src_dir("calc.l")?
+    .build()?;
 ```
 
 and then no matter how many syntax errors we make, only one is reported:

--- a/doc/src/manuallexer.md
+++ b/doc/src/manuallexer.md
@@ -39,11 +39,11 @@ hand-written lexer will look roughly as follows:
 
 ```rust
 use cfgrammar::yacc::YaccKind;
-use lrlex::{ct_token_map, DefaultLexeme};
+use lrlex::{ct_token_map, DefaultLexeme, LRLexError};
 use lrpar::CTParserBuilder;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let ctp = CTParserBuilder::<DefaultLexeme<u8>, u8>::new()
+    let ctp = CTParserBuilder::<DefaultLexeme<u8>, u8, LRLexError>::new()
         .yacckind(YaccKind::Grmtools)
         .grammar_in_src_dir("grammar.y")?
         .build()?;

--- a/lrlex/examples/calc_manual_lex/build.rs
+++ b/lrlex/examples/calc_manual_lex/build.rs
@@ -1,5 +1,5 @@
 use cfgrammar::yacc::YaccKind;
-use lrlex::{ct_token_map, DefaultLexeme};
+use lrlex::{ct_token_map, DefaultLexeme, LRLexError};
 use lrpar::CTParserBuilder;
 
 // Some of the token names in the parser do not lead to valid Rust identifiers, so we map them to
@@ -12,7 +12,7 @@ const TOKENS_MAP: &[(&str, &str)] = &[
 ];
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let ctp = CTParserBuilder::<DefaultLexeme<u8>, u8>::new()
+    let ctp = CTParserBuilder::<DefaultLexeme<u8>, u8, LRLexError>::new()
         .yacckind(YaccKind::Grmtools)
         .grammar_in_src_dir("calc.y")?
         .build()?;

--- a/lrlex/examples/calc_manual_lex/src/main.rs
+++ b/lrlex/examples/calc_manual_lex/src/main.rs
@@ -3,7 +3,7 @@
 use std::io::{self, BufRead, Write};
 
 use cfgrammar::{NewlineCache, Span};
-use lrlex::{lrlex_mod, DefaultLexeme, LRNonStreamingLexer};
+use lrlex::{lrlex_mod, DefaultLexeme, LRLexError, LRNonStreamingLexer};
 use lrpar::{lrpar_mod, Lexeme, NonStreamingLexer};
 
 lrlex_mod!("token_map");
@@ -102,7 +102,7 @@ fn lex(s: &str) -> LRNonStreamingLexer<DefaultLexeme<u8>, u8> {
 }
 
 fn eval(
-    lexer: &dyn NonStreamingLexer<DefaultLexeme<u8>, u8>,
+    lexer: &dyn NonStreamingLexer<DefaultLexeme<u8>, u8, LRLexError>,
     e: Expr,
 ) -> Result<u64, (Span, &'static str)> {
     match e {

--- a/lrpar/cttests/build.rs
+++ b/lrpar/cttests/build.rs
@@ -1,6 +1,6 @@
 use cfgrammar::yacc::{YaccKind, YaccOriginalActionKind};
 use glob::glob;
-use lrlex::{CTLexerBuilder, DefaultLexeme};
+use lrlex::{CTLexerBuilder, DefaultLexeme, LRLexError};
 use lrpar::CTParserBuilder;
 use std::{env, fs, path::PathBuf};
 use yaml_rust::YamlLoader;
@@ -95,7 +95,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let mut outp = PathBuf::from(&out_dir);
             outp.push(format!("{}.y.rs", base));
             outp.set_extension("rs");
-            let cp_build = CTParserBuilder::<DefaultLexeme<u32>, _>::new()
+            let cp_build = CTParserBuilder::<DefaultLexeme<u32>, _, LRLexError>::new()
                 .yacckind(yacckind)
                 .grammar_path(pg.to_str().unwrap())
                 .output_path(&outp);

--- a/lrpar/examples/calc_ast/src/main.rs
+++ b/lrpar/examples/calc_ast/src/main.rs
@@ -3,7 +3,7 @@
 use std::io::{self, BufRead, Write};
 
 use cfgrammar::Span;
-use lrlex::{lrlex_mod, DefaultLexeme};
+use lrlex::{lrlex_mod, DefaultLexeme, LRLexError};
 use lrpar::{lrpar_mod, NonStreamingLexer};
 
 // Using `lrlex_mod!` brings the lexer for `calc.l` into scope. By default the module name will be
@@ -56,7 +56,7 @@ fn main() {
 }
 
 fn eval(
-    lexer: &dyn NonStreamingLexer<DefaultLexeme<u32>, u32>,
+    lexer: &dyn NonStreamingLexer<DefaultLexeme<u32>, u32, LRLexError>,
     e: Expr,
 ) -> Result<u64, (Span, &'static str)> {
     match e {

--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -107,8 +107,9 @@ struct CPCTPlus<
     StorageT: 'static + Eq + Hash,
     ActionT: 'a,
     ParamT: Copy,
+    LexerT,
 > {
-    parser: &'a Parser<'a, 'b, 'input, LexemeT, StorageT, ActionT, ParamT>,
+    parser: &'a Parser<'a, 'b, 'input, LexemeT, StorageT, ActionT, ParamT, LexerT>,
 }
 
 pub(super) fn recoverer<
@@ -117,9 +118,10 @@ pub(super) fn recoverer<
     StorageT: 'static + Debug + Hash + PrimInt + Unsigned,
     ActionT: 'a,
     ParamT: Copy,
+    LexErrorT,
 >(
-    parser: &'a Parser<LexemeT, StorageT, ActionT, ParamT>,
-) -> Box<dyn Recoverer<LexemeT, StorageT, ActionT, ParamT> + 'a>
+    parser: &'a Parser<LexemeT, StorageT, ActionT, ParamT, LexErrorT>,
+) -> Box<dyn Recoverer<LexemeT, StorageT, ActionT, ParamT, LexErrorT> + 'a>
 where
     usize: AsPrimitive<StorageT>,
 {
@@ -134,15 +136,16 @@ impl<
         StorageT: 'static + Debug + Hash + PrimInt + Unsigned,
         ActionT: 'a,
         ParamT: Copy,
-    > Recoverer<LexemeT, StorageT, ActionT, ParamT>
-    for CPCTPlus<'a, 'b, 'input, LexemeT, StorageT, ActionT, ParamT>
+        LexErrorT,
+    > Recoverer<LexemeT, StorageT, ActionT, ParamT, LexErrorT>
+    for CPCTPlus<'a, 'b, 'input, LexemeT, StorageT, ActionT, ParamT, LexErrorT>
 where
     usize: AsPrimitive<StorageT>,
 {
     fn recover(
         &self,
         finish_by: Instant,
-        parser: &Parser<LexemeT, StorageT, ActionT, ParamT>,
+        parser: &Parser<LexemeT, StorageT, ActionT, ParamT, LexErrorT>,
         in_laidx: usize,
         in_pstack: &mut Vec<StIdx<StorageT>>,
         astack: &mut Vec<AStackType<LexemeT, ActionT>>,
@@ -269,7 +272,8 @@ impl<
         StorageT: 'static + Debug + Hash + PrimInt + Unsigned,
         ActionT: 'a,
         ParamT: Copy,
-    > CPCTPlus<'a, 'b, 'input, LexemeT, StorageT, ActionT, ParamT>
+        LexErrorT,
+    > CPCTPlus<'a, 'b, 'input, LexemeT, StorageT, ActionT, ParamT, LexErrorT>
 where
     usize: AsPrimitive<StorageT>,
 {
@@ -456,8 +460,9 @@ fn apply_repairs<
     StorageT: 'static + Debug + Hash + PrimInt + Unsigned,
     ActionT: 'a,
     ParamT: Copy,
+    LexErrorT,
 >(
-    parser: &Parser<LexemeT, StorageT, ActionT, ParamT>,
+    parser: &Parser<LexemeT, StorageT, ActionT, ParamT, LexErrorT>,
     mut laidx: usize,
     pstack: &mut Vec<StIdx<StorageT>>,
     astack: &mut Option<&mut Vec<AStackType<LexemeT, ActionT>>>,
@@ -495,8 +500,9 @@ fn simplify_repairs<
     StorageT: 'static + Hash + PrimInt + Unsigned,
     ActionT,
     ParamT: Copy,
+    LexErrorT,
 >(
-    parser: &Parser<LexemeT, StorageT, ActionT, ParamT>,
+    parser: &Parser<LexemeT, StorageT, ActionT, ParamT, LexErrorT>,
     all_rprs: &mut Vec<Vec<ParseRepair<LexemeT, StorageT>>>,
 ) where
     usize: AsPrimitive<StorageT>,
@@ -555,8 +561,9 @@ fn rank_cnds<
     StorageT: 'static + Debug + Hash + PrimInt + Unsigned,
     ActionT: 'a,
     ParamT: Copy,
+    LexErrorT,
 >(
-    parser: &Parser<LexemeT, StorageT, ActionT, ParamT>,
+    parser: &Parser<LexemeT, StorageT, ActionT, ParamT, LexErrorT>,
     finish_by: Instant,
     in_laidx: usize,
     in_pstack: &[StIdx<StorageT>],
@@ -659,10 +666,11 @@ mod test {
     fn check_all_repairs<
         LexemeT: Lexeme<StorageT>,
         StorageT: 'static + Debug + Hash + PrimInt + Unsigned,
+        LexErrorT,
     >(
         grm: &YaccGrammar<StorageT>,
         lex: &SmallLexer<'_>,
-        err: &LexParseError<LexemeT, StorageT>,
+        err: &LexParseError<LexemeT, StorageT, LexErrorT>,
         expected: &[&str],
     ) where
         usize: AsPrimitive<StorageT>,

--- a/lrpar/src/lib/lex_api.rs
+++ b/lrpar/src/lib/lex_api.rs
@@ -19,7 +19,7 @@ impl TryFrom<usize> for StartStateId {
 }
 
 /// A Lexing error.
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct LexError {
     span: Span,
     lexing_state: Option<StartStateId>,

--- a/lrpar/src/lib/lex_api.rs
+++ b/lrpar/src/lib/lex_api.rs
@@ -33,6 +33,10 @@ impl LexError {
     pub fn span(&self) -> Span {
         self.span
     }
+
+    pub fn lexing_state(&self) -> Option<StartStateId> {
+        self.lexing_state
+    }
 }
 
 impl Error for LexError {}

--- a/lrpar/src/lib/lex_api.rs
+++ b/lrpar/src/lib/lex_api.rs
@@ -5,65 +5,24 @@ use std::{cmp, error::Error, fmt, hash::Hash, marker};
 use cfgrammar::Span;
 use num_traits::{PrimInt, Unsigned};
 
-#[derive(Copy, Clone, Debug)]
-pub struct StartStateId {
-    id: usize,
-}
-
-impl TryFrom<usize> for StartStateId {
-    type Error = std::convert::Infallible;
-
-    fn try_from(id: usize) -> Result<Self, Self::Error> {
-        Ok(Self { id })
-    }
-}
-
-/// A Lexing error.
-#[derive(Clone, Debug)]
-pub struct LexError {
-    span: Span,
-    lexing_state: Option<StartStateId>,
-}
-
-impl LexError {
-    pub fn new(span: Span, lexing_state: Option<StartStateId>) -> Self {
-        LexError { span, lexing_state }
-    }
-
-    pub fn span(&self) -> Span {
-        self.span
-    }
-
-    pub fn lexing_state(&self) -> Option<StartStateId> {
-        self.lexing_state
-    }
-}
-
-impl Error for LexError {}
-
-impl fmt::Display for LexError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "Couldn't lex input starting at byte {}",
-            self.span.start()
-        )
-    }
-}
-
 /// The base trait which all lexers which want to interact with `lrpar` must implement.
-pub trait Lexer<LexemeT: Lexeme<StorageT>, StorageT: Hash + PrimInt + Unsigned> {
+pub trait Lexer<LexemeT: Lexeme<StorageT>, StorageT: Hash + PrimInt + Unsigned, LexErrorT: LexError>
+{
     /// Iterate over all the lexemes in this lexer. Note that:
     ///   * The lexer may or may not stop after the first [LexError] is encountered.
     ///   * There are no guarantees about what happens if this function is called more than once.
     ///     For example, a streaming lexer may only produce [Lexeme]s on the first call.
-    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = Result<LexemeT, LexError>> + 'a>;
+    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = Result<LexemeT, LexErrorT>> + 'a>;
 }
 
 /// A `NonStreamingLexer` is one that takes input in one go, and is then able to hand out
 /// substrings to that input and calculate line and column numbers from a [Span].
-pub trait NonStreamingLexer<'input, LexemeT: Lexeme<StorageT>, StorageT: Hash + PrimInt + Unsigned>:
-    Lexer<LexemeT, StorageT>
+pub trait NonStreamingLexer<
+    'input,
+    LexemeT: Lexeme<StorageT>,
+    StorageT: Hash + PrimInt + Unsigned,
+    LexErrorT: LexError,
+>: Lexer<LexemeT, StorageT, LexErrorT>
 {
     /// Return the user input associated with a [Span].
     ///
@@ -132,4 +91,10 @@ pub trait Lexeme<StorageT>: fmt::Debug + fmt::Display + cmp::Eq + Hash + marker:
     /// If `true`, note that the lexeme's span may be greater or less than you may expect from the
     /// lexeme's definition.
     fn faulty(&self) -> bool;
+}
+
+/// A lexing error.
+pub trait LexError: Error {
+    /// Return the span associated with this error.
+    fn span(&self) -> Span;
 }

--- a/lrpar/src/lib/test_utils.rs
+++ b/lrpar/src/lib/test_utils.rs
@@ -1,9 +1,10 @@
 #![allow(clippy::len_without_is_empty)]
 
-use cfgrammar::Span;
 use std::{error::Error, fmt, hash::Hash};
 
-use crate::Lexeme;
+use cfgrammar::Span;
+
+use crate::{LexError, Lexeme};
 
 type StorageT = u16;
 
@@ -59,3 +60,20 @@ impl fmt::Display for TestLexeme {
 }
 
 impl Error for TestLexeme {}
+
+#[derive(Debug)]
+pub struct TestLexError {}
+
+impl LexError for TestLexError {
+    fn span(&self) -> Span {
+        unreachable!()
+    }
+}
+
+impl Error for TestLexError {}
+
+impl fmt::Display for TestLexError {
+    fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result {
+        unreachable!();
+    }
+}


### PR DESCRIPTION
This PR tries to make `LexError` a generic trait, so that we can (re)separate lrlex and lrpar. @ratmice I *think* this PR succeeds in its aims, but I'd be grateful if you could check it carefully, including whether it breaks "normal" use cases (e.g. `build.rs` files based on the quick start guide). I don't think we should blindly merge this PR until we're convinced that it doesn't impose an extra burden on users.

After two simple warmup commits, the main commit in this trio is https://github.com/softdevteam/grmtools/commit/9e38e9a2433adcb5a468212684431fce8eb5be14, whose commit message hopefully outlines what's been done and why.