### PR TITLE
Keep cargodoc happy.

### DIFF
--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -382,7 +382,7 @@ where
     ///      the return type of the `%start` rule;
     ///    * or, if the `yacckind` was set to
     ///      `YaccKind::Original(YaccOriginalActionKind::GenericParseTree)`, it
-    ///      is [crate::Node<StorageT>].
+    ///      is [`crate::Node<StorageT>`].
     ///
     /// # Panics
     ///


### PR DESCRIPTION
Without backticks, [`crate::Node<StorageT>`] is now interpreted as HTML (this wasn't previously the case).