### PR TITLE
Fixed broken links for YACC and LEX manuals

### DIFF
--- a/doc/src/lexcompatibility.md
+++ b/doc/src/lexcompatibility.md
@@ -5,7 +5,7 @@ sequence of tokens. All Lex files require at least some porting to grmtools,
 though in many cases this is fairly trivial. Nevertheless, aspects such as
 the longest match rule are identical to Lex, and we assume familiarity with Lex
 syntax and its major features: the [Lex
-manual](http://dinosaur.compilertools.net/lex/index.html) is recommended
+manual](https://web.archive.org/web/20220402195947/dinosaur.compilertools.net/lex/index.html) is recommended
 reading.
 
 

--- a/doc/src/lrlex.md
+++ b/doc/src/lrlex.md
@@ -2,7 +2,7 @@
 
 `lrlex` ([crate](https://crates.io/crates/lrlex);
 [source](https://github.com/softdevteam/grmtools/tree/master/lrlex)) is a
-partial replacement for [`lex`](http://dinosaur.compilertools.net/lex/index.html) /
+partial replacement for [`lex`](https://web.archive.org/web/20220402195947/dinosaur.compilertools.net/lex/index.html) /
 [`flex`](https://westes.github.io/flex/manual/). It takes an input string and
 splits it into *lexemes* based on a `.l` file. Unfortunately, many real-world
 languages have corner cases which exceed the power that `lrlex` can provide.

--- a/doc/src/quickstart.md
+++ b/doc/src/quickstart.md
@@ -142,7 +142,7 @@ The first part specifies general settings for the grammar, at a minimum the
 start rule (`%start Expr`).
 
 The second part is the [Yacc
-grammar](http://dinosaur.compilertools.net/yacc/index.html). It consists of 3
+grammar](https://web.archive.org/web/20220830093827/dinosaur.compilertools.net/yacc/index.html). It consists of 3
 rules (`Expr`, `Term`, and `Factor`) and 6 productions (2 for each rule,
 separated by `|` characters). Because we are using the `Grmtools` Yacc variant,
 each rule has a Rust type associated with it (after `->`) which specifies the

--- a/doc/src/yacccompatibility.md
+++ b/doc/src/yacccompatibility.md
@@ -3,7 +3,7 @@
 grmtools supports most major Yacc features, to the extent that many Yacc
 grammars can be used unchanged with grmtools. In this book we assume
 familiarity with Yacc syntax and its major features: the
-[Yacc manual](http://dinosaur.compilertools.net/yacc/index.html) is recommended
+[Yacc manual](https://web.archive.org/web/20220830093827/dinosaur.compilertools.net/yacc/index.html) is recommended
 reading.
 
 


### PR DESCRIPTION
* Updated to use web.archive links

* Fixes #374 