### PR TITLE
Less serde

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -17,6 +17,9 @@ rustup default stable
 cargo test
 cargo test --release
 
+cargo test --lib cfgrammar --features serde
+cargo test --lib lrpar --features serde
+
 root=`pwd`
 cd $root/lrlex/examples/calc_manual_lex
 echo "2 + 3 * 4" | cargo run | grep "Result: 14"

--- a/lrpar/Cargo.toml
+++ b/lrpar/Cargo.toml
@@ -15,6 +15,9 @@ keywords = ["parser", "LR", "yacc", "grammar"]
 name = "lrpar"
 path = "src/lib/mod.rs"
 
+[features]
+serde = []
+
 [build-dependencies]
 vergen = { version = "7", default-features = false, features = ["build"] }
 

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -53,7 +53,7 @@ struct CTConflictsError<StorageT: Eq + Hash> {
 
 impl<StorageT> fmt::Display for CTConflictsError<StorageT>
 where
-    StorageT: 'static + Debug + Hash + PrimInt + Serialize + Unsigned,
+    StorageT: 'static + Debug + Hash + PrimInt + Unsigned,
     usize: AsPrimitive<StorageT>,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -69,7 +69,7 @@ where
 
 impl<StorageT> fmt::Debug for CTConflictsError<StorageT>
 where
-    StorageT: 'static + Debug + Hash + PrimInt + Serialize + Unsigned,
+    StorageT: 'static + Debug + Hash + PrimInt + Unsigned,
     usize: AsPrimitive<StorageT>,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -85,7 +85,7 @@ where
 
 impl<StorageT> Error for CTConflictsError<StorageT>
 where
-    StorageT: 'static + Debug + Hash + PrimInt + Serialize + Unsigned,
+    StorageT: 'static + Debug + Hash + PrimInt + Unsigned,
     usize: AsPrimitive<StorageT>,
 {
 }
@@ -1312,7 +1312,7 @@ where
 
 impl<StorageT> CTParser<StorageT>
 where
-    StorageT: 'static + Debug + Hash + PrimInt + Serialize + Unsigned,
+    StorageT: 'static + Debug + Hash + PrimInt + Unsigned,
     usize: AsPrimitive<StorageT>,
 {
     /// Returns `true` if this compile-time parser was regenerated or `false` if it was not.

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -12,6 +12,7 @@ use cactus::Cactus;
 use cfgrammar::{yacc::YaccGrammar, RIdx, Span, TIdx};
 use lrtable::{Action, StIdx, StateTable};
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::{cpctplus, LexError, Lexeme, NonStreamingLexer};
@@ -603,7 +604,8 @@ pub(super) trait Recoverer<
 }
 
 /// What recovery algorithm should be used when a syntax error is encountered?
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum RecoveryKind {
     /// The CPCT+ algorithm from Diekmann/Tratt "Don't Panic! Better, Fewer, Syntax Errors for LR
     /// Parsers".


### PR DESCRIPTION
One of the things that sunk my attempts to make nice `trait` containers for type parameters was that `Serialize` crept in too often. Having looked at this afresh, it seems that some of lrpar's `Serialize` use is unnecessary. Even if this doesn't help me `trait`ify things, having fewer unnecessary trait bounds probably isn't a bad thing in its own right!