### PR TITLE
Bundle the lex API types into a trait/struct.

### DIFF
--- a/doc/src/manuallexer.md
+++ b/doc/src/manuallexer.md
@@ -39,11 +39,11 @@ hand-written lexer will look roughly as follows:
 
 ```rust
 use cfgrammar::yacc::YaccKind;
-use lrlex::{ct_token_map, DefaultLexeme, LRLexError};
+use lrlex::{ct_token_map, DefaultLexerTypes};
 use lrpar::CTParserBuilder;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let ctp = CTParserBuilder::<DefaultLexeme<u8>, u8, LRLexError>::new()
+    let ctp = CTParserBuilder::<DefaultLexerTypes<u8>>::new()
         .yacckind(YaccKind::Grmtools)
         .grammar_in_src_dir("grammar.y")?
         .build()?;
@@ -84,13 +84,13 @@ and returns an `LRNonStreamingLexer` as follows:
 
 ```rust
 use cfgrammar::NewlineCache;
-use lrlex::{lrlex_mod, DefaultLexeme, LRNonStreamingLexer};
+use lrlex::{lrlex_mod, DefaultLexeme, DefaultLexerTypes, LRNonStreamingLexer};
 use lrpar::{lrpar_mod, Lexeme, NonStreamingLexer, Span};
 
 lrlex_mod!("token_map");
 use token_map::*;
 
-fn lex(s: &str) -> LRNonStreamingLexer<DefaultLexeme<u8>, u8> {
+fn lex(s: &str) -> LRNonStreamingLexer<DefaultLexerTypes<u8>> {
   let mut lexemes = Vec::new();
   let mut newlines = NewlineCache::new();
   let mut i = 0;

--- a/lrlex/examples/calc_manual_lex/build.rs
+++ b/lrlex/examples/calc_manual_lex/build.rs
@@ -1,5 +1,5 @@
 use cfgrammar::yacc::YaccKind;
-use lrlex::{ct_token_map, DefaultLexeme, LRLexError};
+use lrlex::{ct_token_map, DefaultLexerTypes};
 use lrpar::CTParserBuilder;
 
 // Some of the token names in the parser do not lead to valid Rust identifiers, so we map them to
@@ -12,7 +12,7 @@ const TOKENS_MAP: &[(&str, &str)] = &[
 ];
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let ctp = CTParserBuilder::<DefaultLexeme<u8>, u8, LRLexError>::new()
+    let ctp = CTParserBuilder::<DefaultLexerTypes<u8>>::new()
         .yacckind(YaccKind::Grmtools)
         .grammar_in_src_dir("calc.y")?
         .build()?;

--- a/lrlex/examples/calc_manual_lex/src/main.rs
+++ b/lrlex/examples/calc_manual_lex/src/main.rs
@@ -3,7 +3,7 @@
 use std::io::{self, BufRead, Write};
 
 use cfgrammar::{NewlineCache, Span};
-use lrlex::{lrlex_mod, DefaultLexeme, LRLexError, LRNonStreamingLexer};
+use lrlex::{lrlex_mod, DefaultLexeme, DefaultLexerTypes, LRNonStreamingLexer};
 use lrpar::{lrpar_mod, Lexeme, NonStreamingLexer};
 
 lrlex_mod!("token_map");
@@ -51,7 +51,7 @@ fn main() {
     }
 }
 
-fn lex(s: &str) -> LRNonStreamingLexer<DefaultLexeme<u8>, u8> {
+fn lex(s: &str) -> LRNonStreamingLexer<DefaultLexerTypes<u8>> {
     let mut lexemes = Vec::new();
     let mut i = 0;
     while i < s.len() {
@@ -102,7 +102,7 @@ fn lex(s: &str) -> LRNonStreamingLexer<DefaultLexeme<u8>, u8> {
 }
 
 fn eval(
-    lexer: &dyn NonStreamingLexer<DefaultLexeme<u8>, u8, LRLexError>,
+    lexer: &dyn NonStreamingLexer<DefaultLexerTypes<u8>>,
     e: Expr,
 ) -> Result<u64, (Span, &'static str)> {
     match e {

--- a/lrlex/src/lib/defaults.rs
+++ b/lrlex/src/lib/defaults.rs
@@ -1,11 +1,34 @@
 use std::{cmp, error::Error, fmt, hash::Hash, marker};
 
 use cfgrammar::Span;
-use lrpar::Lexeme;
+use lrpar::{Lexeme, LexerTypes};
+use num_traits::{AsPrimitive, PrimInt, Unsigned};
 
-/// lrlex's standard lexeme struct: all lexemes are instances of this struct.
+use crate::LRLexError;
+
+/// lrlex's standard [LexerTypes] `struct`, provided as a convenience.
+#[derive(Debug)]
+pub struct DefaultLexerTypes<T = u32>
+where
+    T: 'static + fmt::Debug + Hash + PrimInt + Unsigned,
+    usize: AsPrimitive<T>,
+{
+    phantom: std::marker::PhantomData<T>,
+}
+
+impl<T> LexerTypes for DefaultLexerTypes<T>
+where
+    usize: AsPrimitive<T>,
+    T: 'static + fmt::Debug + Hash + PrimInt + Unsigned,
+{
+    type LexemeT = DefaultLexeme<T>;
+    type StorageT = T;
+    type LexErrorT = LRLexError;
+}
+
+/// lrlex's standard lexeme struct, provided as a convenience.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub struct DefaultLexeme<StorageT = u32> {
+pub struct DefaultLexeme<StorageT: fmt::Debug = u32> {
     start: usize,
     len: usize,
     faulty: bool,

--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -21,7 +21,7 @@ mod parser;
 
 pub use crate::{
     ctbuilder::{ct_token_map, CTLexer, CTLexerBuilder, LexerKind, RustEdition, Visibility},
-    defaults::DefaultLexeme,
+    defaults::{DefaultLexeme, DefaultLexerTypes},
     lexer::{LRNonStreamingLexer, LRNonStreamingLexerDef, LexerDef, Rule},
     parser::StartState,
     parser::StartStateOperation,
@@ -162,7 +162,7 @@ impl fmt::Display for LRLexError {
     since = "0.8.0",
     note = "This struct has been renamed to LRNonStreamingLexerDef"
 )]
-pub type NonStreamingLexerDef<LexemeT, StorageT> = LRNonStreamingLexerDef<LexemeT, StorageT>;
+pub type NonStreamingLexerDef<StorageT> = LRNonStreamingLexerDef<StorageT>;
 
 /// A convenience macro for including statically compiled `.l` files. A file `src/a/b/c.l`
 /// processed by [CTLexerBuilder::lexer_in_src_dir] can then be used in a crate with

--- a/lrlex/src/lib/parser.rs
+++ b/lrlex/src/lib/parser.rs
@@ -557,7 +557,7 @@ mod test {
     use super::*;
     use crate::{
         lexer::{LRNonStreamingLexerDef, LexerDef},
-        DefaultLexeme,
+        DefaultLexerTypes,
     };
     use cfgrammar::Spanned as _;
     use std::collections::HashMap;
@@ -612,7 +612,7 @@ mod test {
         );
     }
 
-    impl ErrorsHelper for Result<LRNonStreamingLexerDef<DefaultLexeme<u8>, u8>, Vec<LexBuildError>> {
+    impl ErrorsHelper for Result<LRNonStreamingLexerDef<DefaultLexerTypes<u8>>, Vec<LexBuildError>> {
         fn expect_error_at_line(self, src: &str, kind: LexErrorKind, line: usize) {
             match self.as_ref().map_err(Vec::as_slice) {
                 Ok(_) => panic!("Parsed ok while expecting error"),
@@ -693,18 +693,18 @@ mod test {
 %option nounput
         "
         .to_string();
-        assert!(LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).is_err());
+        assert!(LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).is_err());
     }
 
     #[test]
     fn test_minimum() {
         let src = "%%".to_string();
-        assert!(LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).is_ok());
+        assert!(LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).is_ok());
     }
 
     #[test]
     fn test_empty() {
-        LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str("").expect_error_at_line_col(
+        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str("").expect_error_at_line_col(
             "",
             LexErrorKind::PrematureEnd,
             1,
@@ -716,7 +716,7 @@ mod test {
     fn test_premature_end_multibyte() {
         // Ends in LineSeparator multibyte whitespace.
         let src = "%S X ".to_string();
-        LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).expect_error_at_line_col(
+        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).expect_error_at_line_col(
             &src,
             LexErrorKind::PrematureEnd,
             1,
@@ -732,7 +732,7 @@ mod test {
 \\+ '+'
 "
         .to_string();
-        let ast = LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).unwrap();
+        let ast = LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).unwrap();
         let intrule = ast.get_rule_by_name("int").unwrap();
         assert_eq!("int", intrule.name.as_ref().unwrap());
         assert_eq!("[0-9]+", intrule.re_str);
@@ -750,7 +750,7 @@ mod test {
 [0-9]+ ;
 "
         .to_string();
-        let ast = LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).unwrap();
+        let ast = LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).unwrap();
         let intrule = ast.get_rule(0).unwrap();
         assert!(intrule.name.is_none());
         assert_eq!("[0-9]+", intrule.re_str);
@@ -762,8 +762,8 @@ mod test {
 [0-9]
 'int'"
             .to_string();
-        assert!(LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).is_err());
-        LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).expect_error_at_line_col(
+        assert!(LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).is_err());
+        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).expect_error_at_line_col(
             &src,
             LexErrorKind::MissingSpace,
             2,
@@ -776,8 +776,8 @@ mod test {
         let src = "%%
 [0-9] "
             .to_string();
-        assert!(LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).is_err());
-        LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).expect_error_at_line_col(
+        assert!(LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).is_err());
+        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).expect_error_at_line_col(
             &src,
             LexErrorKind::MissingSpace,
             2,
@@ -790,8 +790,8 @@ mod test {
         let src = "%%
 [0-9] int"
             .to_string();
-        assert!(LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).is_err());
-        LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).expect_error_at_line_col(
+        assert!(LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).is_err());
+        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).expect_error_at_line_col(
             &src,
             LexErrorKind::InvalidName,
             2,
@@ -804,8 +804,8 @@ mod test {
         let src = "%%
 [0-9] 'int"
             .to_string();
-        assert!(LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).is_err());
-        LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).expect_error_at_line_col(
+        assert!(LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).is_err());
+        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).expect_error_at_line_col(
             &src,
             LexErrorKind::InvalidName,
             2,
@@ -818,7 +818,7 @@ mod test {
         let srcs = [r#"a ""#, "a '", r#"a '""#, r#"a "'"#];
         for line_two in srcs {
             let src = format!("%%\n{line_two}");
-            LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src)
+            LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src)
                 .expect_error_at_line_col(&src, LexErrorKind::InvalidName, 2, 3);
         }
 
@@ -835,7 +835,7 @@ mod test {
 
         for line_two in srcs {
             let src = format!("%%\n{line_two}");
-            LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src)
+            LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src)
                 .expect_error_at_line_col(&src, LexErrorKind::InvalidName, 2, 5);
         }
     }
@@ -858,7 +858,7 @@ mod test {
         ];
         for line_two in srcs {
             let src = format!("%%\n{line_two}");
-            assert!(LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).is_ok());
+            assert!(LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).is_ok());
         }
     }
 
@@ -869,7 +869,7 @@ mod test {
 [0-9] 'int'
 [0-9] 'int'"
             .to_string();
-        LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).expect_error_at_lines_cols(
+        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).expect_error_at_lines_cols(
             &src,
             LexErrorKind::DuplicateName,
             &mut [(2, 8), (3, 8), (4, 8)].into_iter(),
@@ -886,7 +886,7 @@ mod test {
 [0-9] 'int'
 [A-Z] 'ALPHA'"
             .to_string();
-        LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).expect_multiple_errors(
+        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).expect_multiple_errors(
             &src,
             &mut [
                 (LexErrorKind::DuplicateName, vec![(2, 8), (4, 8), (6, 8)]),
@@ -902,7 +902,7 @@ mod test {
 %%
 <KNOWN>. 'known'"
             .to_string();
-        LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).expect_error_at_line_col(
+        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).expect_error_at_line_col(
             &src,
             LexErrorKind::UnknownDeclaration,
             1,
@@ -916,7 +916,7 @@ mod test {
 %%
 <KNOWN>. 'known'"
             .to_string();
-        LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).expect_error_at_line_col(
+        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).expect_error_at_line_col(
             &src,
             LexErrorKind::UnknownDeclaration,
             1,
@@ -930,7 +930,7 @@ mod test {
 %%
 <KNOWN>. 'known'"
             .to_string();
-        LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).expect_error_at_line_col(
+        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).expect_error_at_line_col(
             &src,
             LexErrorKind::UnknownDeclaration,
             1,
@@ -944,7 +944,7 @@ mod test {
 %%
 <KNOWN>. 'known'"
             .to_string();
-        LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).expect_error_at_line_col(
+        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).expect_error_at_line_col(
             &src,
             LexErrorKind::InvalidStartStateName,
             1,
@@ -958,7 +958,7 @@ mod test {
 %%
 <123>. 'known'"
             .to_string();
-        LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).expect_error_at_line_col(
+        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).expect_error_at_line_col(
             &src,
             LexErrorKind::InvalidStartStateName,
             1,
@@ -971,7 +971,7 @@ mod test {
         let src = "%%
 <1>. 'known'"
             .to_string();
-        LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).expect_error_at_line_col(
+        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).expect_error_at_line_col(
             &src,
             LexErrorKind::UnknownStartState,
             2,
@@ -984,7 +984,7 @@ mod test {
         let src = "%%
 . <1>'known'"
             .to_string();
-        LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).expect_error_at_line_col(
+        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).expect_error_at_line_col(
             &src,
             LexErrorKind::UnknownStartState,
             2,
@@ -998,7 +998,7 @@ mod test {
 %%
 <KNOWN>. 'known'"
             .to_string();
-        let ast = LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).unwrap();
+        let ast = LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).unwrap();
         let intrule = ast.get_rule(0).unwrap();
         assert_eq!("known", intrule.name.as_ref().unwrap());
         assert_eq!(".", intrule.re_str);
@@ -1012,7 +1012,7 @@ mod test {
         let src = "%%
 <UNKNOWN>. 'unknown'"
             .to_string();
-        LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).expect_error_at_line_col(
+        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).expect_error_at_line_col(
             &src,
             LexErrorKind::UnknownStartState,
             2,
@@ -1026,7 +1026,7 @@ mod test {
 %%
 . <KNOWN>'known'"
             .to_string();
-        let ast = LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).unwrap();
+        let ast = LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).unwrap();
         let intrule = ast.get_rule(0).unwrap();
         assert_eq!("known", intrule.name.as_ref().unwrap());
         assert_eq!(".", intrule.re_str);
@@ -1042,7 +1042,7 @@ mod test {
         let src = "%%
 . <UNKNOWN>'unknown'"
             .to_string();
-        LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).expect_error_at_line_col(
+        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).expect_error_at_line_col(
             &src,
             LexErrorKind::UnknownStartState,
             2,
@@ -1055,7 +1055,7 @@ mod test {
         let src = "%%
 <test. 'TEST'"
             .to_string();
-        LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).expect_error_at_line_col(
+        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).expect_error_at_line_col(
             &src,
             LexErrorKind::InvalidStartState,
             2,
@@ -1068,7 +1068,7 @@ mod test {
         let src = "%%
 . <test'TEST'"
             .to_string();
-        LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).expect_error_at_line_col(
+        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).expect_error_at_line_col(
             &src,
             LexErrorKind::InvalidStartState,
             2,
@@ -1082,7 +1082,7 @@ mod test {
 %%
 . 'TEST'"
             .to_string();
-        LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).expect_error_at_line_col(
+        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).expect_error_at_line_col(
             &src,
             LexErrorKind::InvalidStartStateName,
             1,
@@ -1096,7 +1096,7 @@ mod test {
 %%
 . 'TEST'"
             .to_string();
-        let ast = LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).unwrap();
+        let ast = LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).unwrap();
         // Expect two start states - INITIAL + test
         assert_eq!(2, ast.iter_start_states().count());
         assert!(ast
@@ -1113,7 +1113,7 @@ mod test {
 %%
 . 'TEST'"
             .to_string();
-        let ast = LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).unwrap();
+        let ast = LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).unwrap();
         // Expect two start states - INITIAL + test
         assert_eq!(2, ast.iter_start_states().count());
         assert!(ast
@@ -1130,7 +1130,7 @@ mod test {
 %%
 . 'TEST'"
             .to_string();
-        let ast = LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).unwrap();
+        let ast = LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).unwrap();
         // Expect two start states - INITIAL + test
         assert_eq!(2, ast.iter_start_states().count());
         assert!(ast
@@ -1148,7 +1148,7 @@ mod test {
 %%
 . 'TEST'"
             .to_string();
-        LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).expect_error_at_lines_cols(
+        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).expect_error_at_lines_cols(
             &src,
             LexErrorKind::DuplicateStartState,
             &mut [(1, 4), (2, 4)].into_iter(),
@@ -1161,7 +1161,7 @@ mod test {
         %%
         . 'TEST'"
             .to_string();
-        LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).expect_error_at_lines_cols(
+        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).expect_error_at_lines_cols(
             &src,
             LexErrorKind::DuplicateStartState,
             &mut [(1, 4), (1, 15)].into_iter(),
@@ -1175,7 +1175,7 @@ mod test {
 %%
 . 'TEST'"
             .to_string();
-        LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).expect_multiple_errors(
+        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).expect_multiple_errors(
             &src,
             &mut [
                 (LexErrorKind::DuplicateStartState, vec![(1, 4), (2, 4)]),
@@ -1224,7 +1224,7 @@ a\[\]a 'aboxa'
 [\<abcdefg\t] 'bookend5'
 "#
         .to_string();
-        let ast = LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).unwrap();
+        let ast = LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).unwrap();
         let mut rule = ast.get_rule_by_name("gt").unwrap();
         assert_eq!("gt", rule.name.as_ref().unwrap());
         assert_eq!(">", rule.re_str);
@@ -1318,7 +1318,7 @@ a\[\]a 'aboxa'
 %%
 . 'TEST'"
             .to_string();
-        LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).expect_error_at_lines_cols(
+        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).expect_error_at_lines_cols(
             &src,
             LexErrorKind::DuplicateStartState,
             &mut [(1, 4), (2, 4)].into_iter(),
@@ -1330,7 +1330,7 @@ a\[\]a 'aboxa'
         let src = "%%
 <1test>. 'TEST'"
             .to_string();
-        LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).expect_error_at_line_col(
+        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).expect_error_at_line_col(
             &src,
             LexErrorKind::UnknownStartState,
             2,
@@ -1343,7 +1343,7 @@ a\[\]a 'aboxa'
         let src = "%%
 . <1test>'TEST'"
             .to_string();
-        LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).expect_error_at_line_col(
+        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).expect_error_at_line_col(
             &src,
             LexErrorKind::UnknownStartState,
             2,
@@ -1370,7 +1370,7 @@ a\[\]a 'aboxa'
 \{ <brace>'OPEN_FIRST_BRACE'
 \[ <bracket>'OPEN_FIRST_BRACKET'"
             .to_string();
-        let ast = LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).unwrap();
+        let ast = LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).unwrap();
         for rule in ast.iter_rules() {
             println!("rule: {rule:?}");
         }
@@ -1522,7 +1522,7 @@ a\[\]a 'aboxa'
         for i in 0..257 {
             writeln!(src, "x 'x{}'\n", i).ok();
         }
-        LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src).ok();
+        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).ok();
     }
 
     /// Test that we accept various [Pattern_White_Space](https://unicode.org/reports/tr31/)
@@ -1535,11 +1535,11 @@ a\[\]a 'aboxa'
         %%
         A	;
         B 'b' C 'c' D	'A'";
-        assert!(LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(src).is_ok());
+        assert!(LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(src).is_ok());
         // En Space isn't part of Pattern_White_Space.
         let srcs = ["%S X Y", "%S X "];
         for src in srcs {
-            LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(src)
+            LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(src)
                 .expect_error_at_line_col(src, LexErrorKind::InvalidStartStateName, 1, 4);
         }
     }
@@ -1561,7 +1561,7 @@ a\[\]a 'aboxa'
             (LexErrorKind::DuplicateStartState, vec![(2, 12), (3, 12)]),
             (LexErrorKind::DuplicateName, vec![(5, 12), (6, 12)]),
         ];
-        LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src)
+        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src)
             .expect_multiple_errors(&src, &mut expected_errs.clone().into_iter());
 
         src.push_str(
@@ -1571,7 +1571,7 @@ a\[\]a 'aboxa'
         ",
         );
         expected_errs.push((LexErrorKind::RoutinesNotSupported, vec![(7, 9)]));
-        LRNonStreamingLexerDef::<DefaultLexeme<u8>, u8>::from_str(&src)
+        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src)
             .expect_multiple_errors(&src, &mut expected_errs.into_iter());
     }
 }

--- a/lrlex/src/main.rs
+++ b/lrlex/src/main.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use cfgrammar::{newlinecache::NewlineCache, Spanned};
-use lrlex::{DefaultLexeme, LRNonStreamingLexerDef, LexerDef};
+use lrlex::{DefaultLexerTypes, LRNonStreamingLexerDef, LexerDef};
 use lrpar::{Lexeme, Lexer};
 
 fn usage(prog: &str, msg: &str) {
@@ -55,8 +55,8 @@ fn main() {
 
     let lex_l_path = &matches.free[0];
     let lex_src = read_file(lex_l_path);
-    let lexerdef =
-        LRNonStreamingLexerDef::<DefaultLexeme, _>::from_str(&lex_src).unwrap_or_else(|errs| {
+    let lexerdef = LRNonStreamingLexerDef::<DefaultLexerTypes<u32>>::from_str(&lex_src)
+        .unwrap_or_else(|errs| {
             let nlcache = NewlineCache::from_str(&lex_src).unwrap();
             for e in errs {
                 if let Some((line, column)) = nlcache

--- a/lrpar/cttests/build.rs
+++ b/lrpar/cttests/build.rs
@@ -1,6 +1,6 @@
 use cfgrammar::yacc::{YaccKind, YaccOriginalActionKind};
 use glob::glob;
-use lrlex::{CTLexerBuilder, DefaultLexeme, LRLexError};
+use lrlex::{CTLexerBuilder, DefaultLexerTypes};
 use lrpar::CTParserBuilder;
 use std::{env, fs, path::PathBuf};
 use yaml_rust::YamlLoader;
@@ -95,7 +95,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let mut outp = PathBuf::from(&out_dir);
             outp.push(format!("{}.y.rs", base));
             outp.set_extension("rs");
-            let cp_build = CTParserBuilder::<DefaultLexeme<u32>, _, LRLexError>::new()
+            let cp_build = CTParserBuilder::<DefaultLexerTypes<u32>>::new()
                 .yacckind(yacckind)
                 .grammar_path(pg.to_str().unwrap())
                 .output_path(&outp);

--- a/lrpar/examples/calc_ast/src/main.rs
+++ b/lrpar/examples/calc_ast/src/main.rs
@@ -3,7 +3,7 @@
 use std::io::{self, BufRead, Write};
 
 use cfgrammar::Span;
-use lrlex::{lrlex_mod, DefaultLexeme, LRLexError};
+use lrlex::{lrlex_mod, DefaultLexerTypes};
 use lrpar::{lrpar_mod, NonStreamingLexer};
 
 // Using `lrlex_mod!` brings the lexer for `calc.l` into scope. By default the module name will be
@@ -56,7 +56,7 @@ fn main() {
 }
 
 fn eval(
-    lexer: &dyn NonStreamingLexer<DefaultLexeme<u32>, u32, LRLexError>,
+    lexer: &dyn NonStreamingLexer<DefaultLexerTypes<u32>>,
     e: Expr,
 ) -> Result<u64, (Span, &'static str)> {
     match e {

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -203,7 +203,7 @@ mod test_utils;
 
 pub use crate::{
     ctbuilder::{CTParser, CTParserBuilder, RustEdition, Visibility},
-    lex_api::{LexError, Lexeme, Lexer, NonStreamingLexer},
+    lex_api::{LexError, Lexeme, Lexer, LexerTypes, NonStreamingLexer},
     parser::{LexParseError, Node, ParseError, ParseRepair, RTParserBuilder, RecoveryKind},
 };
 

--- a/lrpar/src/lib/test_utils.rs
+++ b/lrpar/src/lib/test_utils.rs
@@ -4,9 +4,18 @@ use std::{error::Error, fmt, hash::Hash};
 
 use cfgrammar::Span;
 
-use crate::{LexError, Lexeme};
+use crate::{LexError, Lexeme, LexerTypes};
 
 type StorageT = u16;
+
+#[derive(Debug)]
+pub(crate) struct TestLexerTypes();
+
+impl LexerTypes for TestLexerTypes {
+    type LexemeT = TestLexeme;
+    type StorageT = u16;
+    type LexErrorT = TestLexError;
+}
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct TestLexeme {

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -13,7 +13,7 @@ use cfgrammar::{
     Spanned,
 };
 use getopts::Options;
-use lrlex::{DefaultLexeme, LRNonStreamingLexerDef, LexerDef};
+use lrlex::{DefaultLexerTypes, LRNonStreamingLexerDef, LexerDef};
 use lrpar::parser::{RTParserBuilder, RecoveryKind};
 use lrtable::{from_yacc, Minimiser};
 use num_traits::ToPrimitive;
@@ -122,7 +122,7 @@ fn main() {
             writeln!(stderr(), "{}: {}", &src_path, &spanned).ok();
         }
     };
-    let mut lexerdef = match LRNonStreamingLexerDef::<DefaultLexeme<u32>, u32>::from_str(&lex_src) {
+    let mut lexerdef = match LRNonStreamingLexerDef::<DefaultLexerTypes<u32>>::from_str(&lex_src) {
         Ok(ast) => ast,
         Err(errs) => {
             let nlcache = NewlineCache::from_str(&lex_src).unwrap();


### PR DESCRIPTION
The aim of this PR is to try and reduce the number of generic parameters that users have to deal with. This is a partial success: we still put more of a burden onto users than we perhaps should. That said, we do at least get rid of the `LexError` types.

I'm raising this for comments: I'm not yet convinced this is good enough to go in (but I might just need to sleep on it). I feel like we can probably do a better job at hiding more ickiness from users, but I'm curious what you think, @ratmice.