### PR TITLE
make generictree action fn public

### DIFF
--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -207,6 +207,7 @@ pub use crate::{
     parser::{LexParseError, Node, ParseError, ParseRepair, RTParserBuilder, RecoveryKind},
 };
 
+pub use crate::parser::action_generictree;
 /// A convenience macro for including statically compiled `.y` files. A file `src/a/b/c.y`
 /// processed by [CTParserBuilder::grammar_in_src_dir] can then be used in a crate with
 /// `lrpar_mod!("a/b/c.y")`.


### PR DESCRIPTION
This is an RFC about making generic_ptree pub, and renaming it actions_generictree.
In particular, I would like to make some parse action interruptable using panic_handler, and an AtomicBool
then call the normal GenericParseTree action, and for this I need the function underlies GenericParseTree action kind.

I had some difficulty trying to add this to the existing `lrpar::Parser::do_tests` testing based workflow,
So for the moment there are no specific tests that e.g. `parse_generictree(...) == parse_actions(&[action_generictree; ...]);`,
in part because the tests are shared between paths that have non-deterministic order to the output with recovery I believe.
