### PR TITLE
Consistently prefer `unwrap()` in build.rs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,17 @@ the root of our project with the following content:
 use cfgrammar::yacc::YaccKind;
 use lrlex::CTLexerBuilder;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() {
     CTLexerBuilder::new()
         .lrpar_config(|ctp| {
             ctp.yacckind(YaccKind::Grmtools)
                 .grammar_in_src_dir("calc.y")
                 .unwrap()
         })
-        .lexer_in_src_dir("calc.l")?
-        .build()?;
+        .lexer_in_src_dir("calc.l")
+        .unwrap()
+        .build()
+        .unwrap();
     Ok(())
 }
 ```

--- a/doc/src/manuallexer.md
+++ b/doc/src/manuallexer.md
@@ -42,12 +42,14 @@ use cfgrammar::yacc::YaccKind;
 use lrlex::{ct_token_map, DefaultLexerTypes};
 use lrpar::CTParserBuilder;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() {
     let ctp = CTParserBuilder::<DefaultLexerTypes<u8>>::new()
         .yacckind(YaccKind::Grmtools)
-        .grammar_in_src_dir("grammar.y")?
-        .build()?;
-    ct_token_map::<u8>("token_map", ctp.token_map(), None)
+        .grammar_in_src_dir("grammar.y")
+        .unwrap()
+        .build()
+        .unwrap();
+    ct_token_map::<u8>("token_map", ctp.token_map(), None).unwrap()
 }
 ```
 

--- a/doc/src/quickstart.md
+++ b/doc/src/quickstart.md
@@ -51,7 +51,7 @@ Our `build.rs` file thus looks as follows:
 use cfgrammar::yacc::YaccKind;
 use lrlex::CTLexerBuilder;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() {
     CTLexerBuilder::new()
         .lrpar_config(|ctp| {
             ctp.yacckind(YaccKind::Grmtools)
@@ -59,8 +59,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .unwrap()
         })
         .lexer_in_src_dir("calc.l")?
-        .build()?;
-    Ok(())
+        .build()
+        .unwrap();
 }
 ```
 

--- a/lrlex/examples/calc_manual_lex/build.rs
+++ b/lrlex/examples/calc_manual_lex/build.rs
@@ -11,14 +11,17 @@ const TOKENS_MAP: &[(&str, &str)] = &[
     (")", "RBRACK"),
 ];
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() {
     let ctp = CTParserBuilder::<DefaultLexerTypes<u8>>::new()
         .yacckind(YaccKind::Grmtools)
-        .grammar_in_src_dir("calc.y")?
-        .build()?;
+        .grammar_in_src_dir("calc.y")
+        .unwrap()
+        .build()
+        .unwrap();
     ct_token_map::<u8>(
         "token_map",
         ctp.token_map(),
         Some(&TOKENS_MAP.iter().cloned().collect()),
     )
+    .unwrap();
 }

--- a/lrlex/examples/calclex/build.rs
+++ b/lrlex/examples/calclex/build.rs
@@ -1,6 +1,9 @@
 use lrlex::CTLexerBuilder;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    CTLexerBuilder::new().lexer_in_src_dir("calc.l")?.build()?;
-    Ok(())
+fn main() {
+    CTLexerBuilder::new()
+        .lexer_in_src_dir("calc.l")
+        .unwrap()
+        .build()
+        .unwrap();
 }

--- a/lrpar/README.md
+++ b/lrpar/README.md
@@ -31,16 +31,17 @@ as follows:
 use cfgrammar::yacc::YaccKind;
 use lrlex::CTLexerBuilder;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() {
     CTLexerBuilder::new()
         .lrpar_config(|ctp| {
             ctp.yacckind(YaccKind::Grmtools)
                 .grammar_in_src_dir("calc.y")
                 .unwrap()
         })
-        .lexer_in_src_dir("calc.l")?
-        .build()?;
-    Ok(())
+        .lexer_in_src_dir("calc.l")
+        .unwrap()
+        .build()
+        .unwrap();
 }
 ```
 

--- a/lrpar/examples/calc_actions/build.rs
+++ b/lrpar/examples/calc_actions/build.rs
@@ -2,7 +2,7 @@
 use cfgrammar::yacc::YaccKind;
 use lrlex::{self, CTLexerBuilder};
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() {
     // Since we're using both lrlex and lrpar, we use lrlex's `lrpar_config` convenience function
     // that makes it easy to a) create a lexer and parser and b) link them together.
     CTLexerBuilder::new()
@@ -13,7 +13,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .grammar_in_src_dir("calc.y")
                 .unwrap()
         })
-        .lexer_in_src_dir("calc.l")?
-        .build()?;
-    Ok(())
+        .lexer_in_src_dir("calc.l")
+        .unwrap()
+        .build()
+        .unwrap();
 }

--- a/lrpar/examples/calc_ast/build.rs
+++ b/lrpar/examples/calc_ast/build.rs
@@ -2,7 +2,7 @@
 use cfgrammar::yacc::YaccKind;
 use lrlex::CTLexerBuilder;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() {
     // Since we're using both lrlex and lrpar, we use lrlex's `lrpar_config` convenience function
     // that makes it easy to a) create a lexer and parser and b) link them together.
     CTLexerBuilder::new()
@@ -13,7 +13,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .grammar_in_src_dir("calc.y")
                 .unwrap()
         })
-        .lexer_in_src_dir("calc.l")?
-        .build()?;
-    Ok(())
+        .lexer_in_src_dir("calc.l")
+        .unwrap()
+        .build()
+        .unwrap();
 }

--- a/lrpar/examples/calc_parsetree/build.rs
+++ b/lrpar/examples/calc_parsetree/build.rs
@@ -1,7 +1,7 @@
 use cfgrammar::yacc::{YaccKind, YaccOriginalActionKind};
 use lrlex::CTLexerBuilder;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() {
     // Since we're using both lrlex and lrpar, we use lrlex's `lrpar_config` convenience function
     // that makes it easy to a) create a lexer and parser and b) link them together.
     CTLexerBuilder::new()
@@ -12,7 +12,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .grammar_in_src_dir("calc.y")
                 .unwrap()
         })
-        .lexer_in_src_dir("calc.l")?
-        .build()?;
-    Ok(())
+        .lexer_in_src_dir("calc.l")
+        .unwrap()
+        .build()
+        .unwrap();
 }

--- a/lrpar/examples/start_states/build.rs
+++ b/lrpar/examples/start_states/build.rs
@@ -1,7 +1,7 @@
 use cfgrammar::yacc::{YaccKind, YaccOriginalActionKind};
 use lrlex::CTLexerBuilder;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() {
     // Since we're using both lrlex and lrpar, we use lrlex's `lrpar_config` convenience function
     // that makes it easy to a) create a lexer and parser and b) link them together.
     CTLexerBuilder::new()
@@ -12,7 +12,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .grammar_in_src_dir("comment.y")
                 .unwrap()
         })
-        .lexer_in_src_dir("comment.l")?
-        .build()?;
-    Ok(())
+        .lexer_in_src_dir("comment.l")
+        .unwrap()
+        .build()
+        .unwrap();
 }

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -38,16 +38,17 @@
 //! use cfgrammar::yacc::YaccKind;
 //! use lrlex::CTLexerBuilder;
 //!
-//! fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! fn main() {
 //!     CTLexerBuilder::new()
 //!         .lrpar_config(|ctp| {
 //!             ctp.yacckind(YaccKind::Grmtools)
 //!                 .grammar_in_src_dir("calc.y")
 //!                 .unwrap()
 //!         })
-//!         .lexer_in_src_dir("calc.l")?
-//!         .build()?;
-//!     Ok(())
+//!         .lexer_in_src_dir("calc.l")
+//!         .unwrap()
+//!         .build()
+//!         .unwrap();
 //! }
 //! ```
 //!


### PR DESCRIPTION
Previously we had a mix of `?` (requiring a complex `main` return type) and `unwrap`. This extent plumps for the latter, partly because if something does go wrong, `unwrap` gives an error message which pinpoints which particular line caused the problem.

[Inadvertently spotted by @Pavel-Durov and @vext01]