### PR TITLE
Fix unwrap in Quickstart chapter

### DIFF
--- a/doc/src/quickstart.md
+++ b/doc/src/quickstart.md
@@ -58,7 +58,8 @@ fn main() {
                 .grammar_in_src_dir("calc.y")
                 .unwrap()
         })
-        .lexer_in_src_dir("calc.l")?
+        .lexer_in_src_dir("calc.l")
+        .unwrap()
         .build()
         .unwrap();
 }


### PR DESCRIPTION
Fixed unwrap usage in the quickstart doc. Use of `?` for unwrapping was giving an error when used in a function that didn't give have an option return type.