### PR TITLE
Enable the unreachable_pub lint in mod.rs.

### DIFF
--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -4,6 +4,7 @@
 #![allow(clippy::unnecessary_wraps)]
 #![allow(clippy::upper_case_acronyms)]
 #![forbid(unsafe_code)]
+#![deny(unreachable_pub)]
 
 //! A library for manipulating Context Free Grammars (CFG). It is impractical to fully homogenise
 //! all the types of grammars out there, so the aim is for different grammar types

--- a/cfgrammar/src/lib/yacc/mod.rs
+++ b/cfgrammar/src/lib/yacc/mod.rs
@@ -1,3 +1,5 @@
+#![deny(unreachable_pub)]
+
 pub mod ast;
 pub mod firsts;
 pub mod follows;

--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -10,6 +10,7 @@
 #![allow(clippy::unnecessary_wraps)]
 #![allow(clippy::upper_case_acronyms)]
 #![forbid(unsafe_code)]
+#![deny(unreachable_pub)]
 
 use std::{error::Error, fmt};
 

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::unnecessary_wraps)]
 #![allow(clippy::upper_case_acronyms)]
 #![forbid(unsafe_code)]
+#![deny(unreachable_pub)]
 
 //! `lrpar` provides a Yacc-compatible parser (where grammars can be generated at compile-time or
 //! run-time). It can take in traditional `.y` files and convert them into an idiomatic Rust

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -1046,7 +1046,7 @@ pub(crate) mod test {
     // lrlex as a dependency of lrpar). The format is the same as lrlex *except*:
     //   * The initial "%%" isn't needed, and only "'" is valid as a rule name delimiter.
     //   * "Unnamed" rules aren't allowed (e.g. you can't have a rule which discards whitespaces).
-    pub struct SmallLexer<'input> {
+    pub(crate) struct SmallLexer<'input> {
         lexemes: Vec<TestLexeme>,
         s: &'input str,
     }

--- a/lrpar/src/lib/test_utils.rs
+++ b/lrpar/src/lib/test_utils.rs
@@ -71,7 +71,7 @@ impl fmt::Display for TestLexeme {
 impl Error for TestLexeme {}
 
 #[derive(Debug)]
-pub struct TestLexError {}
+pub(crate) struct TestLexError {}
 
 impl LexError for TestLexError {
     fn span(&self) -> Span {

--- a/lrtable/src/lib/itemset.rs
+++ b/lrtable/src/lib/itemset.rs
@@ -14,7 +14,7 @@ use vob::Vob;
 use cfgrammar::yacc::firsts::YaccFirsts;
 
 /// The type of "context" (also known as "lookaheads")
-pub type Ctx = Vob;
+pub(crate) type Ctx = Vob;
 
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/lrtable/src/lib/mod.rs
+++ b/lrtable/src/lib/mod.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::type_complexity)]
 #![forbid(unsafe_code)]
+#![deny(unreachable_pub)]
 
 use std::{hash::Hash, mem::size_of};
 

--- a/lrtable/src/lib/pager.rs
+++ b/lrtable/src/lib/pager.rs
@@ -113,7 +113,7 @@ fn vob_intersect(v1: &Vob, v2: &Vob) -> bool {
 }
 
 /// Create a `StateGraph` from 'grm'.
-pub fn pager_stategraph<StorageT: 'static + Hash + PrimInt + Unsigned>(
+pub(crate) fn pager_stategraph<StorageT: 'static + Hash + PrimInt + Unsigned>(
     grm: &YaccGrammar<StorageT>,
 ) -> StateGraph<StorageT>
 where

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -200,7 +200,7 @@ where
 use cfgrammar::SIdx;
 
 #[cfg(test)]
-pub fn state_exists<StorageT: 'static + Hash + PrimInt + Unsigned>(
+pub(crate) fn state_exists<StorageT: 'static + Hash + PrimInt + Unsigned>(
     grm: &YaccGrammar<StorageT>,
     is: &Itemset<StorageT>,
     nt: &str,


### PR DESCRIPTION
This is a relatively minor and non-essential thing.  I've noticed on occasion that it can be difficult to know if things are pub but not exported from a module, due to usage within a test module for example or whether they are actually pub and part of the API.  This enables the `unreachable_pub` lint, so you should be able to tell from the visibility modifier whether it is a part of the API.

With this lint enabled items labeled `pub` must be reachable from the top-level module.  Items unreachable from top-level modules should be labeled `pub(crate)`.