### PR TITLE
Regex options take 2

### DIFF
--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -23,7 +23,10 @@ mod parser;
 pub use crate::{
     ctbuilder::{ct_token_map, CTLexer, CTLexerBuilder, LexerKind, RustEdition, Visibility},
     defaults::{DefaultLexeme, DefaultLexerTypes},
-    lexer::{LRNonStreamingLexer, LRNonStreamingLexerDef, LexerDef, Rule},
+    lexer::{
+        LRNonStreamingLexer, LRNonStreamingLexerDef, LexerDef, RegexOptions, Rule,
+        DEFAULT_REGEX_OPTIONS,
+    },
     parser::StartState,
     parser::StartStateOperation,
 };

--- a/lrpar/cttests/build.rs
+++ b/lrpar/cttests/build.rs
@@ -59,7 +59,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .map(|flags_vec| {
                     flags_vec
                         .iter()
-                        .partition(|flag| !flag.as_str().unwrap().starts_with('!'))
+                        .partition(|flag| flag.as_str().unwrap().starts_with('!'))
                 })
                 .unwrap_or_else(|| (Vec::new(), Vec::new()));
             let negative_lex_flags = negative_lex_flags
@@ -72,10 +72,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let positive_lex_flags = positive_lex_flags
                 .iter()
                 .map(|flag| flag.as_str().unwrap())
-                .collect::<Vec<_>>();
-            let negative_lex_flags = negative_lex_flags
-                .iter()
-                .map(|flag| flag.strip_prefix('!').unwrap())
                 .collect::<Vec<_>>();
             let lex_flags = (&positive_lex_flags, &negative_lex_flags);
 
@@ -95,46 +91,55 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let mut outp = PathBuf::from(&out_dir);
             outp.push(format!("{}.y.rs", base));
             outp.set_extension("rs");
-            let cp_build = CTParserBuilder::<DefaultLexerTypes<u32>>::new()
+            let mut cp_build = CTParserBuilder::<DefaultLexerTypes<u32>>::new()
                 .yacckind(yacckind)
                 .grammar_path(pg.to_str().unwrap())
                 .output_path(&outp);
-            let cp_build = if let Some(flag) = check_flag(yacc_flags, "error_on_conflicts") {
-                cp_build.error_on_conflicts(flag)
-            } else {
-                cp_build
-            };
-            let cp_build = if let Some(flag) = check_flag(yacc_flags, "warnings_are_errors") {
-                cp_build.warnings_are_errors(flag)
-            } else {
-                cp_build
-            };
-            let cp_build = if let Some(flag) = check_flag(yacc_flags, "show_warnings") {
-                cp_build.show_warnings(flag)
-            } else {
-                cp_build
+            if let Some(flag) = check_flag(yacc_flags, "error_on_conflicts") {
+                cp_build = cp_build.error_on_conflicts(flag)
+            }
+            if let Some(flag) = check_flag(yacc_flags, "warnings_are_errors") {
+                cp_build = cp_build.warnings_are_errors(flag)
+            }
+            if let Some(flag) = check_flag(yacc_flags, "show_warnings") {
+                cp_build = cp_build.show_warnings(flag)
             };
             let cp = cp_build.build()?;
 
             let mut outl = PathBuf::from(&out_dir);
             outl.push(format!("{}.l.rs", base));
             outl.set_extension("rs");
-            let cl_build = CTLexerBuilder::new()
+            let mut cl_build = CTLexerBuilder::new()
                 .rule_ids_map(cp.token_map())
                 .lexer_path(pl.to_str().unwrap())
                 .output_path(&outl);
-            let cl_build = if let Some(flag) = check_flag(lex_flags, "allow_missing_terms_in_lexer")
-            {
-                cl_build.allow_missing_terms_in_lexer(flag)
-            } else {
-                cl_build
-            };
-            let cl_build =
-                if let Some(flag) = check_flag(lex_flags, "allow_missing_tokens_in_parser") {
-                    cl_build.allow_missing_tokens_in_parser(flag)
-                } else {
-                    cl_build
-                };
+            if let Some(flag) = check_flag(lex_flags, "allow_missing_terms_in_lexer") {
+                cl_build = cl_build.allow_missing_terms_in_lexer(flag)
+            }
+            if let Some(flag) = check_flag(lex_flags, "allow_missing_tokens_in_parser") {
+                cl_build = cl_build.allow_missing_tokens_in_parser(flag)
+            }
+            if let Some(flag) = check_flag(lex_flags, "dot_matches_new_line") {
+                cl_build = cl_build.dot_matches_new_line(flag)
+            }
+            if let Some(flag) = check_flag(lex_flags, "case_insensitive") {
+                cl_build = cl_build.case_insensitive(flag)
+            }
+            if let Some(flag) = check_flag(lex_flags, "multi_line") {
+                cl_build = cl_build.multi_line(flag)
+            }
+            if let Some(flag) = check_flag(lex_flags, "swap_greed") {
+                cl_build = cl_build.swap_greed(flag)
+            }
+            if let Some(flag) = check_flag(lex_flags, "ignore_whitespace") {
+                cl_build = cl_build.ignore_whitespace(flag)
+            }
+            if let Some(flag) = check_flag(lex_flags, "unicode") {
+                cl_build = cl_build.unicode(flag)
+            }
+            if let Some(flag) = check_flag(lex_flags, "octal") {
+                cl_build = cl_build.octal(flag)
+            }
             cl_build.build()?;
         }
     }

--- a/lrpar/cttests/src/regex_opt.test
+++ b/lrpar/cttests/src/regex_opt.test
@@ -1,0 +1,13 @@
+name: Test NoAction using the calculator grammar
+yacckind: Original(YaccOriginalActionKind::NoAction)
+lex_flags: ['!dot_matches_new_line', 'octal']
+grammar: |
+    %start Start 
+    %%
+    Start: 'ANY' | 'a' | 'NL';
+
+lexer: |
+    %%
+    \141 'a'
+    . 'ANY'
+    [\n] 'NL'


### PR DESCRIPTION
I've been a bit slow in getting this finished, but this is basically the finished patch of the second attempt at regex options,
Overall exporting the constructor was simple, I didn't modify the trait `from_str` function at all, just added a new concrete function for  `LRNonStreamingLexerDef`.

I note that `from_str` does not take `self`, so there appear to be no issues involving things like `new_with_options(s,opts).from_str(s)` returning a lexer with default options.

While testing this, I noted some cleanups and bugs in `lrpar/cttests/build.rs`, when I added the lex_flags previously it was flipped,
there was a duplicate call `strip_prefix`, and some if statements could be simplified.  These are within the last patch adding tests.

Edit: By setting the `octal` flag to `'!octal'`, you can induce a regex/build error here.