### PR TITLE
Upgrade dependencies

### DIFF
--- a/cfgrammar/Cargo.toml
+++ b/cfgrammar/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/lib/mod.rs"
 
 [dependencies]
 lazy_static = "1.0"
-indexmap = "1"
+indexmap = "2"
 num-traits = "0.2"
 regex = "1"
 serde = { version="1.0", features=["derive"], optional=true }

--- a/lrlex/Cargo.toml
+++ b/lrlex/Cargo.toml
@@ -26,7 +26,7 @@ getopts = "0.2" # only needed for src/main.rs
 lazy_static = "1.4"
 lrpar = { path = "../lrpar", version = "0.13" }
 regex = "1"
-regex-syntax = "0.6.27"
+regex-syntax = "0.7"
 num-traits = "0.2"
 quote = "1.0"
 serde = "1.0"

--- a/lrpar/Cargo.toml
+++ b/lrpar/Cargo.toml
@@ -26,7 +26,7 @@ bincode = "1.2"
 cactus = "1.0"
 cfgrammar = { path="../cfgrammar", version = "0.13", features=["serde"] }
 filetime = "0.2"
-indexmap = "1.3"
+indexmap = "2"
 lazy_static = "1.4"
 lrtable = { path="../lrtable", version = "0.13", features=["serde"] }
 num-traits = "0.2"


### PR DESCRIPTION
This pull request updates the version of two dependent crates. A project I'm working on now has duplicate crates in it because `lrlex` and `lrpar` are using older instances. It would reduce compile time and executable size if I only had to build one copy of these crates.

I ran `cargo test` and every test passed, so this pull request shouldn't introduce any regressions.