### PR TITLE
Replace tuple field access with pattern matching

### DIFF
--- a/cfgrammar/src/lib/idxnewtype.rs
+++ b/cfgrammar/src/lib/idxnewtype.rs
@@ -15,22 +15,23 @@ macro_rules! IdxNewtype {
         pub struct $n<T>(pub T);
 
         impl<T: PrimInt + Unsigned> From<$n<T>> for usize {
-            fn from(st: $n<T>) -> Self {
+            fn from($n(st): $n<T>) -> Self {
                 debug_assert!(size_of::<usize>() >= size_of::<T>());
-                num_traits::cast(st.0).unwrap()
+                num_traits::cast(st).unwrap()
             }
         }
 
         impl<T: PrimInt + Unsigned> From<$n<T>> for u32 {
-            fn from(st: $n<T>) -> Self {
+            fn from($n(st): $n<T>) -> Self {
                 debug_assert!(size_of::<u32>() >= size_of::<T>());
-                num_traits::cast(st.0).unwrap()
+                num_traits::cast(st).unwrap()
             }
         }
 
         impl<T: PrimInt + Unsigned> $n<T> {
             pub fn as_storaget(&self) -> T {
-                self.0
+                let $n(st) = self;
+                *st
             }
         }
     }

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -118,8 +118,8 @@ impl SymbolIdx {
     pub(crate) fn symbol(self, ast: &GrammarAST) -> Symbol {
         match self {
             SymbolIdx::Rule(idx) => {
-                let rule = &ast.rules[idx];
-                Symbol::Rule(rule.name.0.clone(), rule.name.1)
+                let (rule_name, rule_span) = &ast.rules[idx].name;
+                Symbol::Rule(rule_name.clone(), *rule_span)
             }
             SymbolIdx::Token(idx) => {
                 let tok = &ast.tokens[idx];

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -405,12 +405,15 @@ impl YaccParser {
                 let (j, v) = self.parse_string(i)?;
                 let vspan = Span::new(i, j);
                 match self.ast.epp.entry(n) {
-                    Entry::Occupied(orig) => add_duplicate_occurrence(
-                        errs,
-                        YaccGrammarErrorKind::DuplicateEPP,
-                        orig.get().0,
-                        span,
-                    ),
+                    Entry::Occupied(orig) => {
+                        let (orig_span, _) = orig.get();
+                        add_duplicate_occurrence(
+                            errs,
+                            YaccGrammarErrorKind::DuplicateEPP,
+                            *orig_span,
+                            span,
+                        )
+                    }
                     Entry::Vacant(epp) => {
                         epp.insert((span, (v, vspan)));
                     }

--- a/lrlex/src/lib/parser.rs
+++ b/lrlex/src/lib/parser.rs
@@ -1473,12 +1473,12 @@ a\[\]a 'aboxa'
             "brace",
             rule.target_state
                 .as_ref()
-                .map(|s| states.get(&s.0).unwrap())
+                .map(|(s, _)| states.get(s).unwrap())
                 .unwrap()
         );
         assert_eq!(
             StartStateOperation::Push,
-            *rule.target_state.as_ref().map(|s| &s.1).unwrap()
+            *rule.target_state.as_ref().map(|(_, s)| s).unwrap()
         );
         rule = ast.get_rule_by_name("CLOSE_BRACE").unwrap();
         assert_eq!("CLOSE_BRACE", rule.name.as_ref().unwrap());
@@ -1497,12 +1497,12 @@ a\[\]a 'aboxa'
             "brace",
             rule.target_state
                 .as_ref()
-                .map(|s| states.get(&s.0).unwrap())
+                .map(|(s, _)| states.get(s).unwrap())
                 .unwrap()
         );
         assert_eq!(
             StartStateOperation::Pop,
-            *rule.target_state.as_ref().map(|s| &s.1).unwrap()
+            *rule.target_state.as_ref().map(|(_, s)| s).unwrap()
         );
         rule = ast.get_rule_by_name("OPEN_BRACKET").unwrap();
         assert_eq!("OPEN_BRACKET", rule.name.as_ref().unwrap());
@@ -1521,12 +1521,12 @@ a\[\]a 'aboxa'
             "bracket",
             rule.target_state
                 .as_ref()
-                .map(|s| states.get(&s.0).unwrap())
+                .map(|(s, _)| states.get(s).unwrap())
                 .unwrap()
         );
         assert_eq!(
             StartStateOperation::Push,
-            *rule.target_state.as_ref().map(|s| &s.1).unwrap()
+            *rule.target_state.as_ref().map(|(_, s)| s).unwrap()
         );
         rule = ast.get_rule_by_name("CLOSE_BRACKET").unwrap();
         assert_eq!("CLOSE_BRACKET", rule.name.as_ref().unwrap());
@@ -1545,12 +1545,12 @@ a\[\]a 'aboxa'
             "bracket",
             rule.target_state
                 .as_ref()
-                .map(|s| states.get(&s.0).unwrap())
+                .map(|(s, _)| states.get(s).unwrap())
                 .unwrap()
         );
         assert_eq!(
             StartStateOperation::Pop,
-            *rule.target_state.as_ref().map(|s| &s.1).unwrap()
+            *rule.target_state.as_ref().map(|(_, s)| s).unwrap()
         );
         rule = ast.get_rule_by_name("OPEN_FIRST_BRACE").unwrap();
         assert_eq!("OPEN_FIRST_BRACE", rule.name.as_ref().unwrap());
@@ -1561,12 +1561,12 @@ a\[\]a 'aboxa'
             "brace",
             rule.target_state
                 .as_ref()
-                .map(|s| states.get(&s.0).unwrap())
+                .map(|(s, _)| states.get(s).unwrap())
                 .unwrap()
         );
         assert_eq!(
             StartStateOperation::ReplaceStack,
-            *rule.target_state.as_ref().map(|s| &s.1).unwrap()
+            *rule.target_state.as_ref().map(|(_, s)| s).unwrap()
         );
         rule = ast.get_rule_by_name("OPEN_FIRST_BRACKET").unwrap();
         assert_eq!("OPEN_FIRST_BRACKET", rule.name.as_ref().unwrap());
@@ -1577,12 +1577,12 @@ a\[\]a 'aboxa'
             "bracket",
             rule.target_state
                 .as_ref()
-                .map(|s| states.get(&s.0).unwrap())
+                .map(|(s, _)| states.get(s).unwrap())
                 .unwrap()
         );
         assert_eq!(
             StartStateOperation::ReplaceStack,
-            *rule.target_state.as_ref().map(|s| &s.1).unwrap()
+            *rule.target_state.as_ref().map(|(_, s)| s).unwrap()
         );
     }
 

--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -600,10 +600,10 @@ where
     // Remove any elements except those which parsed as far as possible.
     cnds = cnds
         .into_iter()
-        .filter(|x| x.1 == furthest)
+        .filter(|(_, x, _)| *x == furthest)
         .collect::<Vec<_>>();
 
-    cnds.into_iter().flat_map(|x| x.2).collect::<Vec<_>>()
+    cnds.into_iter().flat_map(|(_, _, x)| x).collect::<Vec<_>>()
 }
 
 /// Do `repairs` end with enough Shift repairs to be considered a success node?

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -94,12 +94,14 @@ where
 struct ErrorString(String);
 impl fmt::Display for ErrorString {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
+        let ErrorString(s) = self;
+        write!(f, "{}", s)
     }
 }
 impl fmt::Debug for ErrorString {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self)
+        let ErrorString(s) = self;
+        write!(f, "{}", s)
     }
 }
 impl Error for ErrorString {}

--- a/lrpar/src/lib/dijkstra.rs
+++ b/lrpar/src/lib/dijkstra.rs
@@ -39,7 +39,7 @@ where
             continue;
         }
 
-        let n = todo[usize::from(c)].pop().unwrap().1;
+        let (_, n) = todo[usize::from(c)].pop().unwrap();
         if success(&n) {
             scs_nodes.push(n);
             break;

--- a/lrtable/src/lib/mod.rs
+++ b/lrtable/src/lib/mod.rs
@@ -29,22 +29,23 @@ macro_rules! IdxNewtype {
         pub struct $n<T>(pub T);
 
         impl<T: PrimInt + Unsigned> From<$n<T>> for usize {
-            fn from(st: $n<T>) -> Self {
+            fn from($n(st): $n<T>) -> Self {
                 debug_assert!(size_of::<usize>() >= size_of::<T>());
-                num_traits::cast(st.0).unwrap()
+                num_traits::cast(st).unwrap()
             }
         }
 
         impl<T: PrimInt + Unsigned> From<$n<T>> for u32 {
-            fn from(st: $n<T>) -> Self {
+            fn from($n(st): $n<T>) -> Self {
                 debug_assert!(size_of::<u32>() >= size_of::<T>());
-                num_traits::cast(st.0).unwrap()
+                num_traits::cast(st).unwrap()
             }
         }
 
         impl<T: PrimInt + Unsigned> $n<T> {
             pub fn as_storaget(&self) -> T {
-                self.0
+                let $n(st) = self;
+                *st
             }
         }
     }

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -46,24 +46,26 @@ where
 
     /// Return the itemset for closed state `stidx`. Panics if `stidx` doesn't exist.
     pub fn closed_state(&self, stidx: StIdx<StorageT>) -> &Itemset<StorageT> {
-        &self.states[usize::from(stidx)].1
+        let (_, closed_state) = &self.states[usize::from(stidx)];
+        closed_state
     }
 
     /// Return an iterator over all closed states in this `StateGraph`.
     pub fn iter_closed_states<'a>(
         &'a self,
     ) -> Box<dyn Iterator<Item = &'a Itemset<StorageT>> + 'a> {
-        Box::new(self.states.iter().map(|x| &x.1))
+        Box::new(self.states.iter().map(|(_, x)| x))
     }
 
     /// Return the itemset for core state `stidx` or `None` if it doesn't exist.
     pub fn core_state(&self, stidx: StIdx<StorageT>) -> &Itemset<StorageT> {
-        &self.states[usize::from(stidx)].0
+        let (core_states, _) = &self.states[usize::from(stidx)];
+        core_states
     }
 
     /// Return an iterator over all core states in this `StateGraph`.
     pub fn iter_core_states<'a>(&'a self) -> Box<dyn Iterator<Item = &'a Itemset<StorageT>> + 'a> {
-        Box::new(self.states.iter().map(|x| &x.0))
+        Box::new(self.states.iter().map(|(x, _)| x))
     }
 
     /// How many states does this `StateGraph` contain? NB: By definition the `StateGraph` contains
@@ -266,7 +268,7 @@ mod test {
         ).unwrap();
         let sg = pager_stategraph(&grm);
         assert_eq!(sg.all_states_len(), StIdx(7));
-        assert_eq!(sg.states.iter().fold(0, |a, x| a + x.0.items.len()), 7);
+        assert_eq!(sg.states.iter().fold(0, |a, (x, _)| a + x.items.len()), 7);
         assert_eq!(sg.all_edges_len(), 9);
 
         // This follows the (not particularly logical) ordering of state numbers in the paper.


### PR DESCRIPTION
Uncertain how I feel about most of these changes, I am pretty indifferent to the majority of them.

Where I think it improved things is perhaps hoisting the `start_name` variable out of the loop possible because `ast` is a shared reference.  The other one I thought was nice was the `ast::Rule` *until* `cargo fmt` split it up into 4 very short lines but after that happened... :man_shrugging:

Edit: It may in fact be easiest to just note those which you feel like keeping?
