### PR TITLE
Raise an error if rules start with whitespace.

### DIFF
--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -558,9 +558,8 @@ mod test {
 %%
 [0-9]+ 'int'
 [a-zA-Z]+ 'id'
-[ \t] ;
-        "
-        .to_string();
+[ \t] ;"
+            .to_string();
         let mut lexerdef = LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).unwrap();
         let mut map = HashMap::new();
         map.insert("int", 0);
@@ -587,9 +586,8 @@ mod test {
     fn test_basic_error() {
         let src = "
 %%
-[0-9]+ 'int'
-        "
-        .to_string();
+[0-9]+ 'int'"
+            .to_string();
         let lexerdef = LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).unwrap();
         match lexerdef.lexer("abc").iter().next().unwrap() {
             Ok(_) => panic!("Invalid input lexed"),

--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -59,6 +59,7 @@ pub enum LexErrorKind {
     InvalidStartStateName,
     DuplicateName,
     RegexError,
+    VerbatimNotSupported,
 }
 
 impl Spanned for LexBuildError {
@@ -76,6 +77,7 @@ impl Spanned for LexBuildError {
             | LexErrorKind::UnknownStartState
             | LexErrorKind::InvalidStartState
             | LexErrorKind::InvalidStartStateName
+            | LexErrorKind::VerbatimNotSupported
             | LexErrorKind::RegexError => SpansKind::Error,
             LexErrorKind::DuplicateName | LexErrorKind::DuplicateStartState => {
                 SpansKind::DuplicationError
@@ -87,6 +89,7 @@ impl Spanned for LexBuildError {
 impl fmt::Display for LexBuildError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let s = match self.kind {
+            LexErrorKind::VerbatimNotSupported => "Verbatim code not supported",
             LexErrorKind::PrematureEnd => "File ends prematurely",
             LexErrorKind::RoutinesNotSupported => "Routines not currently supported",
             LexErrorKind::UnknownDeclaration => "Unknown declaration",


### PR DESCRIPTION
Here is a patch which turns rules with leading whitespace into errors as discussed.

Posix lex treats these as verbatim copied into the generated code BSD/System V lex copy these into unreachable areas of code. Which are still used as the primary mechanism for adding comments to lex files.

Before this patch we trimmed leading spaces, and parsed them as normal rules. Afterwords we now throw a `VerbatimUnsupported` error.