### PR TITLE
Document lex differences for verbatim code entries in the rules section

### DIFF
--- a/doc/src/lexcompatibility.md
+++ b/doc/src/lexcompatibility.md
@@ -57,3 +57,6 @@ There are several major differences between Lex and grmtools:
 
    But the characters to which this behavior applies is impacted by the escape sequence
    differences listed above.
+
+* Lex treats lines in the rules section beginning with whitespace as code to be copied verbatim
+  into the generated lexer source.  Grmtools lex does not support these and produces an error. 


### PR DESCRIPTION
I didn't think about it until the previous commit had landed, but figured it would be good to add a short blurb to the `lex compatibility` section about verbatim code in the rules section.