### PR TITLE
Update to latest clippy/cargo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members=[
     "lrtable",
     "nimbleparse",
 ]
+resolver = "2"
 
 [profile.release]
 opt-level = 3

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -840,7 +840,7 @@ where
                 for i in 0..todo.len() {
                     cur.extend(&ms[i][todo[i]]);
                 }
-                sts.push(cur.drain(..).collect::<Vec<TIdx<StorageT>>>());
+                sts.push(std::mem::take(&mut cur));
 
                 let mut j = todo.len() - 1;
                 loop {

--- a/lrlex/src/lib/parser.rs
+++ b/lrlex/src/lib/parser.rs
@@ -26,7 +26,7 @@ lazy_static! {
     static ref RE_LINE_SEP: Regex = Regex::new(r"[\p{Pattern_White_Space}&&[\p{Zl}\p{Zp}\n\r\v]]").unwrap();
     static ref RE_LEADING_LINE_SEPS: Regex = Regex::new(r"^[\p{Pattern_White_Space}&&[\p{Zl}\p{Zp}\n\r\v]]*").unwrap();
     // Horizontal space separators
-    static ref RE_SPACE_SEP: Regex = Regex::new(r#"[\p{Pattern_White_Space}&&[\p{Zs}\t]]"#).unwrap();
+    static ref RE_SPACE_SEP: Regex = Regex::new(r"[\p{Pattern_White_Space}&&[\p{Zs}\t]]").unwrap();
     static ref RE_LEADING_WS: Regex = Regex::new(r"^[\p{Pattern_White_Space}]*").unwrap();
     static ref RE_WS: Regex = Regex::new(r"\p{Pattern_White_Space}").unwrap();
 }
@@ -1264,7 +1264,7 @@ mod test {
         // This is guaranteed not to change without a semver bump by regex_syntax.
         assert!(regex_syntax::is_meta_character('<').not());
         // Test escaping '<' and '>' start state operators, as the initial characters of a regex.
-        let src = r#"
+        let src = r"
 %%
 \> 'gt'
 \< 'lt'
@@ -1295,7 +1295,7 @@ a\[\]a 'aboxa'
 [\nabc\<defg\t] 'bookend3'
 [\tabcdefg\<] 'bookend4'
 [\<abcdefg\t] 'bookend5'
-"#
+"
         .to_string();
         let ast = LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).unwrap();
         let mut rule = ast.get_rule_by_name("gt").unwrap();
@@ -1655,14 +1655,14 @@ b "A"
 
 . "BlankLinesDontError"
 "#;
-        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).unwrap();
+        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(src).unwrap();
         let src = r#"
 %%
  // Historical practice is that in the rules section entries starting with whitespace are copied verbatim into generated code. This is not supported.
 . "InitialWhitespaceDoError"
 "#;
-        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(&src).expect_error_at_line_col(
-            &src,
+        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(src).expect_error_at_line_col(
+            src,
             LexErrorKind::VerbatimNotSupported,
             3,
             1,

--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -716,7 +716,7 @@ E : 'N'
         //    )
         // is also the result of a valid minimal-cost repair, but, since the repair involves a
         // Shift, rank_cnds will always put this too low down the list for us to ever see it.
-        if !vec![
+        if ![
             "E
  ( (
  E


### PR DESCRIPTION
In my previous patches I had neglected to run clippy with `--all-targets`, so there were some lints triggering in test code.
While fixing that I updated rustc/clippy, that triggered some new lints.  

As well as a cargo warning:
```
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```
Looking through
https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2

I had a vague recollection of the build dependencies overlap with selected features possibly affecting us, so it seemed like it might be worthwhile to bump that.