### PR TITLE
Better %epp error

### DIFF
--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -265,6 +265,7 @@ impl GrammarAST {
                 }
             }
         }
+
         for k in self.epp.keys() {
             if self.tokens.contains(k) {
                 continue;

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -266,7 +266,7 @@ impl GrammarAST {
             }
         }
 
-        for k in self.epp.keys() {
+        for (k, (sp, _)) in self.epp.iter() {
             if self.tokens.contains(k) {
                 continue;
             }
@@ -277,7 +277,7 @@ impl GrammarAST {
             }
             return Err(YaccGrammarError {
                 kind: YaccGrammarErrorKind::UnknownEPP(k.clone()),
-                spans: vec![Span::new(0, 0)],
+                spans: vec![*sp],
             });
         }
 
@@ -532,7 +532,7 @@ mod test {
     #[test]
     fn test_invalid_epp() {
         let mut grm = GrammarAST::new();
-        let empty_span = Span::new(0, 0);
+        let empty_span = Span::new(2, 3);
         grm.start = Some(("A".to_string(), empty_span));
         grm.add_rule(("A".to_string(), empty_span), None);
         grm.add_prod("A".to_string(), vec![], None, None);
@@ -541,8 +541,8 @@ mod test {
         match grm.complete_and_validate() {
             Err(YaccGrammarError {
                 kind: YaccGrammarErrorKind::UnknownEPP(_),
-                ..
-            }) => (),
+                spans,
+            }) if spans.len() == 1 && spans[0] == Span::new(2, 3) => (),
             _ => panic!("Validation error"),
         }
     }

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -133,7 +133,11 @@ impl fmt::Display for YaccGrammarErrorKind {
                 )
             }
             YaccGrammarErrorKind::UnknownEPP(name) => {
-                return write!(f, "Unknown token '{}' in %epp declaration", name)
+                return write!(
+                    f,
+                    "Token '{}' in %epp declaration is not referenced in the grammar",
+                    name
+                )
             }
         };
         write!(f, "{}", s)


### PR DESCRIPTION
Changes:

```
t.y: [Error] Unknown token 'DIGIT' in %epp declaration at line 1 column 1
```

into:

```
t.y: [Error] Token 'DIGIT' in %epp declaration is not referenced in the grammar at line 4 column 6
```

Fixes https://github.com/softdevteam/grmtools/issues/418.