### PR TITLE
Clippy fallout & overzealous #[deny(unsafe_code)]

### DIFF
--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -833,8 +833,7 @@ where
             // needed). If the first column spills, then we're done. This is basically normal
             // arithmetic but with each digit having an arbitrary base.
 
-            let mut todo = Vec::new();
-            todo.resize(prod.len(), 0);
+            let mut todo = vec![0; prod.len()];
             let mut cur = Vec::new();
             'b: loop {
                 for i in 0..todo.len() {
@@ -893,10 +892,8 @@ where
     // means that we can iteratively improve our knowledge of a token's minimum cost:
     // eventually we will reach a point where we can determine it definitively.
 
-    let mut costs = vec![];
-    costs.resize(usize::from(grm.rules_len()), 0);
-    let mut done = vec![];
-    done.resize(usize::from(grm.rules_len()), false);
+    let mut costs = vec![0; usize::from(grm.rules_len())];
+    let mut done = vec![false; usize::from(grm.rules_len())];
     loop {
         let mut all_done = true;
         for i in 0..done.len() {
@@ -960,10 +957,8 @@ fn rule_max_costs<StorageT: 'static + PrimInt + Unsigned>(
 where
     usize: AsPrimitive<StorageT>,
 {
-    let mut done = vec![];
-    done.resize(usize::from(grm.rules_len()), false);
-    let mut costs = vec![];
-    costs.resize(usize::from(grm.rules_len()), 0);
+    let mut done = vec![false; usize::from(grm.rules_len())];
+    let mut costs = vec![0; usize::from(grm.rules_len())];
 
     // First mark all recursive rules.
     for ridx in grm.iter_rules() {

--- a/lrpar/cttests/src/calc_unsafeaction.test
+++ b/lrpar/cttests/src/calc_unsafeaction.test
@@ -5,11 +5,11 @@ grammar: |
     %actiontype Result<u64, ()>
     %avoid_insert 'INT'
     %%
-    Expr: Expr '+' Term { unsafe { Ok(Ok::<u64, ()>($1? + $3?).unwrap_unchecked()) } }
+    Expr: Expr '+' Term { unsafe { unsafe_ok($1? + $3?) } }
         | Term { $1 }
         ;
 
-    Term: Term '*' Factor { unsafe { Ok(Ok::<u64, ()>($1? * $3?).unwrap_unchecked()) } }
+    Term: Term '*' Factor { unsafe { unsafe_ok($1? * $3?) } }
         | Factor { $1 }
         ;
 
@@ -17,7 +17,7 @@ grammar: |
           | 'INT' {
                 let l = $1.map_err(|_| ())?;
                 match $lexer.span_str(l.span()).parse::<u64>() {
-                    Ok(v) => unsafe { Ok(Ok::<u64, ()>(v).unwrap_unchecked()) },
+                    Ok(v) => unsafe { unsafe_ok(v) },
                     Err(_) => {
                         let ((_, col), _) = $lexer.line_col(l.span());
                         eprintln!("Error at column {}: '{}' cannot be represented as a u64",
@@ -28,6 +28,11 @@ grammar: |
                 }
             }
           ;
+    %%
+    // Just check that unsafe blocks work in actions.
+    unsafe fn unsafe_ok<T, E>(x:T) -> Result<T, E> {
+      Ok(x)
+    }
 
 lexer: |
     %%

--- a/lrpar/cttests/src/lib.rs
+++ b/lrpar/cttests/src/lib.rs
@@ -242,7 +242,7 @@ fn test_parseparam() {
     let lexerdef = parseparam_l::lexerdef();
     let lexer = lexerdef.lexer("101");
     match parseparam_y::parse(&lexer, &3) {
-        (Some(i), _) if i == 104 => (),
+        (Some(104), _) => (),
         _ => unreachable!(),
     }
 }

--- a/lrpar/cttests_macro/src/lib.rs
+++ b/lrpar/cttests_macro/src/lib.rs
@@ -17,7 +17,7 @@ pub fn generate_codegen_fail_tests(item: TokenStream) -> TokenStream {
     let manifest_dir = std::path::Path::new(&manifest_dir)
         .strip_prefix(cwd)
         .unwrap();
-    let test_glob_path = manifest_dir.join(&test_glob_str.value());
+    let test_glob_path = manifest_dir.join(test_glob_str.value());
     let test_glob_str = test_glob_path.into_os_string().into_string().unwrap();
     let test_files = glob(&test_glob_str).unwrap();
     for file in test_files {

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -988,8 +988,8 @@ D : D;
             Ok(_) => panic!("Infinitely recursive rule let through"),
             Err(StateTableError {
                 kind: StateTableErrorKind::AcceptReduceConflict(_),
-                pidx,
-            }) if pidx == PIdx(1) => (),
+                pidx: PIdx(1),
+            }) => (),
             Err(e) => panic!("Incorrect error returned {:?}", e),
         }
     }


### PR DESCRIPTION
The first patch is just fixing normal clippy stuff.

In the second patch clippy was suggesting that we remove the unsafe code because it (being just a test) doesn't actually do anything. Rather than `#[allow(...)]` I tried defining an unsafe function in the program section and call that.

Turns out `#[deny(unsafe_code)]` is still enabled in the program section, since my patch at https://github.com/softdevteam/grmtools/pull/370

Subsequently the second patch writes the combined user actions + program section into a single module, and `#![allow(unsafe_code)]` within that module.  Previously the `program()` section could not specify inner attributes since those must be specified at the top of a module, so they couldn't easily opt in using `#![allow(unsafe_code)]`. With this reorganization it is now possible that the program section is at the top of the module, and can specify an inner attribute.


user actions + program code, need to be in the same module, because we currently don't require `pub` visibility modifiers between them.

Edit: The other option being we could just revert the `#[deny(unsafe_code)]` part from the generated sources, WDYT?