### PR TITLE
Error handler trait

### DIFF
--- a/lrlex/src/lib/ctbuilder.rs
+++ b/lrlex/src/lib/ctbuilder.rs
@@ -89,7 +89,7 @@ where
     fn lexer_path(&mut self, filename: &Path);
     /// Called with the lexers source contents.
     fn lexer_src(&mut self, src: &str);
-    fn on_lex_build_error(&mut self, errors: Box<[LexBuildError]>);
+    fn on_lex_build_error(&mut self, errors: &[LexBuildError]);
     fn missing_in_lexer(&mut self, missing: &HashSet<String>);
     fn missing_in_parser(&mut self, missing: &HashSet<String>);
     /// This function must return an `Err` variant if any of the following are true:
@@ -371,7 +371,7 @@ where
 
                 Box::new(if let Some(error_handler) = self.error_handler.as_mut() {
                     lexerdef.map_err(|errs| {
-                        error_handler.on_lex_build_error(errs.into_boxed_slice());
+                        error_handler.on_lex_build_error(errs.as_slice());
                         error_handler
                             .results()
                             .expect_err("Expected an error from error_handler.")

--- a/lrlex/src/lib/ctbuilder.rs
+++ b/lrlex/src/lib/ctbuilder.rs
@@ -85,12 +85,19 @@ where
     LexerTypesT: LexerTypes,
     usize: num_traits::AsPrimitive<LexerTypesT::StorageT>,
 {
-    /// Called with the lexers filename
+    /// Will be called with the path to the `.l` file
+    /// before `fn on_*` or `fn missing_*`.
     fn lexer_path(&mut self, filename: &Path);
-    /// Called with the lexers source contents.
+    /// Will be called with the `.y` file sources as `src`
+    /// before any call to `fn on_*`.
     fn lexer_src(&mut self, src: &str);
+    /// Lends `self` a slice containing `LexBuildError`s
     fn on_lex_build_error(&mut self, errors: &[LexBuildError]);
+    /// Lends `self` a set of `String`s denoting tokens
+    /// present in the parser, but missing from the lexer.
     fn missing_in_lexer(&mut self, missing: &HashSet<String>);
+    /// Lends `self` a set of `String`s denoting tokens
+    /// present in the lexer, but missing from the parser.
     fn missing_in_parser(&mut self, missing: &HashSet<String>);
     /// This function must return an `Err` variant if any of the following are true:
     ///

--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -21,7 +21,9 @@ mod lexer;
 mod parser;
 
 pub use crate::{
-    ctbuilder::{ct_token_map, CTLexer, CTLexerBuilder, LexerKind, RustEdition, Visibility},
+    ctbuilder::{
+        ct_token_map, CTLexer, CTLexerBuilder, LexErrorHandler, LexerKind, RustEdition, Visibility,
+    },
     defaults::{DefaultLexeme, DefaultLexerTypes},
     lexer::{
         LRNonStreamingLexer, LRNonStreamingLexerDef, LexerDef, RegexOptions, Rule,

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -156,11 +156,20 @@ where
     LexerTypesT: LexerTypes,
     usize: num_traits::AsPrimitive<LexerTypesT::StorageT>,
 {
+    /// Will be called with the `.y` file sources
+    /// as `src`, before any any call to `fn on_*`.
     fn grammar_src(&mut self, src: &str);
+    /// Will be called with the path to the `.y`
+    /// file, before any any call to `fn on_*`.
     fn grammar_path(&mut self, path: &Path);
+    /// Will be called with a flag denoting whether warnings
+    /// should be treated as errors before any call to `fn on_*`.
     fn warnings_are_errors(&mut self, flag: bool);
+    /// Lends `Self` a slice containing warnings.
     fn on_grammar_warning(&mut self, ws: &[YaccGrammarWarning]);
+    /// Lends `Self` a slice containing errors.
     fn on_grammar_error(&mut self, errs: &[YaccGrammarError]);
+    /// Lends `Self` conflicts, and values necessary to obtain spans.
     fn on_unexpected_conflicts(
         &mut self,
         ast: &GrammarAST,

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -159,8 +159,8 @@ where
     fn grammar_src(&mut self, src: &str);
     fn grammar_path(&mut self, path: &Path);
     fn warnings_are_errors(&mut self, flag: bool);
-    fn on_grammar_warning(&mut self, ws: Box<[YaccGrammarWarning]>);
-    fn on_grammar_error(&mut self, errs: Box<[YaccGrammarError]>);
+    fn on_grammar_warning(&mut self, ws: &[YaccGrammarWarning]);
+    fn on_grammar_error(&mut self, errs: &[YaccGrammarError]);
     fn on_unexpected_conflicts(
         &mut self,
         ast: &GrammarAST,
@@ -480,7 +480,7 @@ where
             Ok(_) if self.warnings_are_errors && !warnings.is_empty() => {
                 if let Some(error_handler) = self.error_handler {
                     let mut error_handler = error_handler.borrow_mut();
-                    error_handler.on_grammar_warning(warnings.into_boxed_slice());
+                    error_handler.on_grammar_warning(warnings.as_slice());
                     return Err(error_handler
                         .results()
                         .expect_err("Expected error from error handler"));
@@ -506,7 +506,7 @@ where
                 if !warnings.is_empty() {
                     if let Some(error_handler) = self.error_handler.as_ref() {
                         let mut error_handler = error_handler.borrow_mut();
-                        error_handler.on_grammar_warning(warnings.into_boxed_slice());
+                        error_handler.on_grammar_warning(warnings.as_slice());
                     } else {
                         let mut line_cache = NewlineCache::new();
                         line_cache.feed(&inc);
@@ -526,9 +526,9 @@ where
                 if let Some(error_handler) = self.error_handler.as_ref() {
                     let mut error_handler = error_handler.borrow_mut();
                     if !warnings.is_empty() {
-                        error_handler.on_grammar_warning(warnings.into_boxed_slice())
+                        error_handler.on_grammar_warning(warnings.as_slice())
                     }
-                    error_handler.on_grammar_error(errs.into_boxed_slice());
+                    error_handler.on_grammar_error(errs.as_slice());
                     return Err(error_handler
                         .results()
                         .expect_err("Expected an error from error_handler."));

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -204,7 +204,7 @@ pub mod parser;
 mod test_utils;
 
 pub use crate::{
-    ctbuilder::{CTParser, CTParserBuilder, RustEdition, Visibility},
+    ctbuilder::{CTParser, CTParserBuilder, GrammarErrorHandler, RustEdition, Visibility},
     lex_api::{LexError, Lexeme, Lexer, LexerTypes, NonStreamingLexer},
     parser::{LexParseError, Node, ParseError, ParseRepair, RTParserBuilder, RecoveryKind},
 };


### PR DESCRIPTION
Here is the best attempt I think I can muster for implementing the patch in #426 as a trait instead of plain callback functions,
I figured it might be better to push it to a separate branch since @DavidHVernon has been doing some test on that, and this switches the API quite a bit.

This allows for the `ErrorHandler` to be owned by the outer thing, so values in it's `Self` type can escape. So that is the benefit over the plain callbacks approach which can only return via the `Box<dyn Error>`.

I've pushed a branch of `error_callbacks_test` repo which implement this trait
First a very quick/dirty implementation using `String` as a backing store.
https://github.com/ratmice/error_callbacks_test/blob/implement_as_trait/build.rs#L273-L287
The second one is much nicer using the `ariadne` crate to produce nice messages.
https://github.com/ratmice/error_callbacks_test/tree/ariadne_trait_impl

In the second (the work in progress ariadne errors) these errors look something like:
```
     ╭─[src/erroneous.y:4:1]
     │
   1 │ %token a b
     │        ┬
     │        ╰── Shifted
     │
   4 │ B -> (): a | a a {};
     │ ┬        ┬
     │ ╰─────────── Reduced rule
     │          │
     │          ╰── Reduced production
  ───╯
```

It is outside the repo because it's a failing build.rs, and ctfails tests can't quite handle it.
I was hoping that this would make calling it easier than having a bunch of individual functions for each callback.
It sort of succeeds from the `CT*Builder` perspective, but the lifetimes semantics require a few differences from the normal build.rs e.g. a `move |...|` closure to `lrpar_config`. This is why `LexErrorHandler` can be a `&mut`, while `GrammarErrorHandler` has to be the `Rc<RefCell<_>>`.

I believe that I am happy with this approach in general, I think it can both be used by tools like `nimbleparse` to cut down some code duplication internally (But I don't try to do that here), and useful for outside projects (Like custom error printing, and my future project of producing SARIF output).  As a trait these things should be easier to put into a crates and used.

With the holidays coming up, I'm not certain how quickly I will be able to respond to any requested changes.
If you don't happen to get to it before then either, I wish you happy holidays.