### PR TITLE
Cleanup test helpers

### DIFF
--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -1060,6 +1060,7 @@ mod test {
     }
 
     impl ErrorsHelper for Result<GrammarAST, Vec<YaccGrammarError>> {
+        #[track_caller]
         fn expect_error_at_line(self, src: &str, kind: YaccGrammarErrorKind, line: usize) {
             let errs = self
                 .as_ref()
@@ -1072,6 +1073,7 @@ mod test {
             assert_eq!(e.spans.len(), 1);
         }
 
+        #[track_caller]
         fn expect_error_at_line_col(
             self,
             src: &str,
@@ -1082,6 +1084,7 @@ mod test {
             self.expect_error_at_lines_cols(src, kind, &mut std::iter::once((line, col)))
         }
 
+        #[track_caller]
         fn expect_error_at_lines_cols(
             self,
             src: &str,
@@ -1108,6 +1111,7 @@ mod test {
             }
         }
 
+        #[track_caller]
         fn expect_multiple_errors(
             self,
             src: &str,

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -1096,7 +1096,7 @@ mod test {
             let e = &errs[0];
             assert_eq!(e.kind, kind);
             assert_eq!(
-                e.spans()[..]
+                e.spans()
                     .iter()
                     .map(|span| line_col!(src, span))
                     .collect::<Vec<(usize, usize)>>(),

--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -183,6 +183,7 @@ where
 
 /// This struct represents, in essence, a .l file in memory. From it one can produce an
 /// [LRNonStreamingLexer] which actually lexes inputs.
+#[derive(Debug)]
 pub struct LRNonStreamingLexerDef<LexerTypesT: LexerTypes>
 where
     usize: AsPrimitive<LexerTypesT::StorageT>,

--- a/lrlex/src/lib/parser.rs
+++ b/lrlex/src/lib/parser.rs
@@ -696,7 +696,7 @@ mod test {
             let e = &errs[0];
             assert_eq!(e.kind, kind);
             assert_eq!(
-                e.spans()[..]
+                e.spans()
                     .iter()
                     .map(|span| line_col!(src, span))
                     .collect::<Vec<(usize, usize)>>(),

--- a/lrlex/src/lib/parser.rs
+++ b/lrlex/src/lib/parser.rs
@@ -635,25 +635,6 @@ mod test {
     use std::collections::HashMap;
     use std::fmt::Write as _;
 
-    macro_rules! incorrect_errs {
-        ($src:ident, $errs:expr) => {{
-            for e in $errs {
-                let mut line_cache = ::cfgrammar::newlinecache::NewlineCache::new();
-                line_cache.feed(&$src);
-                if let Some((line, column)) = line_cache
-                    .byte_to_line_num_and_col_num(&$src, e.spans().first().unwrap().start())
-                {
-                    panic!(
-                        "Incorrect error returned {} at line {line} column {column}",
-                        e
-                    )
-                } else {
-                    panic!("{}", e)
-                }
-            }
-        }};
-    }
-
     macro_rules! line_col {
         ($src:ident, $span: expr) => {{
             let mut line_cache = ::cfgrammar::newlinecache::NewlineCache::new();
@@ -686,14 +667,15 @@ mod test {
 
     impl ErrorsHelper for Result<LRNonStreamingLexerDef<DefaultLexerTypes<u8>>, Vec<LexBuildError>> {
         fn expect_error_at_line(self, src: &str, kind: LexErrorKind, line: usize) {
-            match self.as_ref().map_err(Vec::as_slice) {
-                Ok(_) => panic!("Parsed ok while expecting error"),
-                Err([e])
-                    if e.kind == kind
-                        && line_of_offset(src, e.spans().first().unwrap().start()) == line
-                        && e.spans.len() == 1 => {}
-                Err(e) => incorrect_errs!(src, e),
-            }
+            let errs = self
+                .as_ref()
+                .map_err(Vec::as_slice)
+                .expect_err("Parsed ok while expecting error");
+            assert_eq!(errs.len(), 1);
+            let e = &errs[0];
+            assert_eq!(e.kind, kind);
+            assert_eq!(line_of_offset(src, e.spans()[0].start()), line);
+            assert_eq!(e.spans.len(), 1);
         }
 
         fn expect_error_at_line_col(self, src: &str, kind: LexErrorKind, line: usize, col: usize) {
@@ -706,27 +688,23 @@ mod test {
             kind: LexErrorKind,
             lines_cols: &mut dyn Iterator<Item = (usize, usize)>,
         ) {
-            match self.as_ref().map_err(Vec::as_slice) {
-                Ok(_) => panic!("Parsed ok while expecting error"),
-                Err([e])
-                    if e.kind == kind
-                        && line_col!(src, e.spans().first().unwrap())
-                            == lines_cols.next().unwrap() =>
-                {
-                    assert_eq!(
-                        e.spans()
-                            .iter()
-                            .skip(1)
-                            .map(|span| line_col!(src, span))
-                            .collect::<Vec<(usize, usize)>>(),
-                        lines_cols.collect::<Vec<(usize, usize)>>()
-                    );
-                    // Check that it is valid to slice the source with the spans.
-                    for span in e.spans() {
-                        let _ = &src[span.start()..span.end()];
-                    }
-                }
-                Err(e) => incorrect_errs!(src, e),
+            let errs = self
+                .as_ref()
+                .map_err(Vec::as_slice)
+                .expect_err("Parsed ok while expecting error");
+            assert_eq!(errs.len(), 1);
+            let e = &errs[0];
+            assert_eq!(e.kind, kind);
+            assert_eq!(
+                e.spans()[..]
+                    .iter()
+                    .map(|span| line_col!(src, span))
+                    .collect::<Vec<(usize, usize)>>(),
+                lines_cols.collect::<Vec<(usize, usize)>>()
+            );
+            // Check that it is valid to slice.
+            for span in e.spans() {
+                let _ = &src[span.start()..span.end()];
             }
         }
 
@@ -735,29 +713,28 @@ mod test {
             src: &str,
             expected: &mut dyn Iterator<Item = (LexErrorKind, Vec<(usize, usize)>)>,
         ) {
-            match self {
-                Ok(_) => panic!("Parsed ok while expecting error"),
-                Err(errs) => {
-                    let linecol_errs = errs
-                        .iter()
-                        .map(|e| {
-                            // Check that it is valid to slice the source with the spans.
-                            for span in e.spans() {
-                                let _ = &src[span.start()..span.end()];
-                            }
-                            (
-                                e.kind.clone(),
-                                e.spans()
-                                    .iter()
-                                    .map(|span| line_col!(src, span))
-                                    .collect::<Vec<_>>(),
-                            )
-                        })
-                        .collect::<Vec<_>>();
-
-                    assert_eq!(expected.collect::<Vec<_>>(), linecol_errs);
+            let errs = self.expect_err("Parsed ok while expecting error");
+            for e in &errs {
+                // Check that it is valid to slice the source with the spans.
+                for span in e.spans() {
+                    let _ = &src[span.start()..span.end()];
                 }
             }
+
+            assert_eq!(
+                errs.iter()
+                    .map(|e| {
+                        (
+                            e.kind.clone(),
+                            e.spans()
+                                .iter()
+                                .map(|span| line_col!(src, span))
+                                .collect::<Vec<_>>(),
+                        )
+                    })
+                    .collect::<Vec<_>>(),
+                expected.collect::<Vec<_>>()
+            );
         }
     }
 

--- a/lrlex/src/lib/parser.rs
+++ b/lrlex/src/lib/parser.rs
@@ -666,6 +666,7 @@ mod test {
     }
 
     impl ErrorsHelper for Result<LRNonStreamingLexerDef<DefaultLexerTypes<u8>>, Vec<LexBuildError>> {
+        #[track_caller]
         fn expect_error_at_line(self, src: &str, kind: LexErrorKind, line: usize) {
             let errs = self
                 .as_ref()
@@ -678,10 +679,12 @@ mod test {
             assert_eq!(e.spans.len(), 1);
         }
 
+        #[track_caller]
         fn expect_error_at_line_col(self, src: &str, kind: LexErrorKind, line: usize, col: usize) {
             self.expect_error_at_lines_cols(src, kind, &mut std::iter::once((line, col)))
         }
 
+        #[track_caller]
         fn expect_error_at_lines_cols(
             self,
             src: &str,
@@ -708,6 +711,7 @@ mod test {
             }
         }
 
+        #[track_caller]
         fn expect_multiple_errors(
             self,
             src: &str,


### PR DESCRIPTION
This is a cleanup for the `ErrorsHelper` test functions, it is primarily intended to improve the output.
I.e. it should now print both the error, and the expected, when they don't match now.
Previously this was difficult to do because the expected value was used in the if guard of an `Err(e) if ...` it could no longer be used in plain old the `Err(e)` branch of the match.  As such, I just reorganized the implementation to make that branch unneeded.

Doing the same thing in `lrlex` required we add a `Debug` derive for `LrNonStreamingLexerDef`.