### PR TITLE
update clippy

### DIFF
--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -888,7 +888,7 @@ b 'B'
             StartState::new(1, "EXCLUSIVE", true, Span::new(0, 0)),
         ];
         let rule_states = vec![];
-        let current_state = all_states.get(0).unwrap();
+        let current_state = &all_states[0];
         let m = LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::state_matches(
             current_state,
             &rule_states,
@@ -903,7 +903,7 @@ b 'B'
             StartState::new(1, "EXCLUSIVE", true, Span::new(0, 0)),
         ];
         let rule_states = vec![];
-        let current_state = all_states.get(1).unwrap();
+        let current_state = &all_states[1];
         let m = LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::state_matches(
             current_state,
             &rule_states,
@@ -918,7 +918,7 @@ b 'B'
             StartState::new(1, "EXCLUSIVE", true, Span::new(0, 0)),
         ];
         let rule_states = vec![0];
-        let current_state = all_states.get(0).unwrap();
+        let current_state = &all_states[0];
         let m = LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::state_matches(
             current_state,
             &rule_states,
@@ -933,7 +933,7 @@ b 'B'
             StartState::new(1, "EXCLUSIVE", true, Span::new(0, 0)),
         ];
         let rule_states = vec![1];
-        let current_state = all_states.get(1).unwrap();
+        let current_state = &all_states[1];
         let m = LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::state_matches(
             current_state,
             &rule_states,
@@ -948,7 +948,7 @@ b 'B'
             StartState::new(1, "EXCLUSIVE", true, Span::new(0, 0)),
         ];
         let rule_states = vec![1];
-        let current_state = all_states.get(0).unwrap();
+        let current_state = &all_states[0];
         let m = LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::state_matches(
             current_state,
             &rule_states,
@@ -963,7 +963,7 @@ b 'B'
             StartState::new(1, "EXCLUSIVE", true, Span::new(0, 0)),
         ];
         let rule_states = vec![0];
-        let current_state = all_states.get(1).unwrap();
+        let current_state = &all_states[1];
         let m = LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::state_matches(
             current_state,
             &rule_states,


### PR DESCRIPTION
`clippy --all-targets --all-features` wanted to change `foo.get(0).unwrap()` to `foo.first().unwrap()`.
To make this more uniform across tests that call `get()` with non-zero indexes, I just switched them all to use `foo[i]` slice indexing.