### PR TITLE
Make pub(crate) fields of `ASTWithValidityInfo` private.

### DIFF
--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -14,8 +14,8 @@ use crate::Span;
 /// Contains a `GrammarAST` structure produced from a grammar source file.
 /// As well as any errors which occurred during the construction of the AST.
 pub struct ASTWithValidityInfo {
-    pub(crate) ast: GrammarAST,
-    pub(crate) errs: Vec<YaccGrammarError>,
+    ast: GrammarAST,
+    errs: Vec<YaccGrammarError>,
 }
 
 impl ASTWithValidityInfo {
@@ -48,7 +48,7 @@ impl ASTWithValidityInfo {
     /// Returns whether any errors where encountered during the
     /// parsing and validation of the AST during it's construction.
     pub fn is_valid(&self) -> bool {
-        self.errs.is_empty()
+        self.errors().is_empty()
     }
 
     /// Returns all errors which were encountered during AST construction.

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -115,9 +115,9 @@ where
         ast_validation: &ast::ASTWithValidityInfo,
     ) -> YaccGrammarResult<Self> {
         if !ast_validation.is_valid() {
-            return Err(ast_validation.errs.clone());
+            return Err(ast_validation.errors().to_owned());
         }
-        let ast = &ast_validation.ast;
+        let ast = ast_validation.ast();
         // Check that StorageT is big enough to hold RIdx/PIdx/SIdx/TIdx values; after these
         // checks we can guarantee that things like RIdx(ast.rules.len().as_()) are safe.
         if ast.rules.len() > num_traits::cast(StorageT::max_value()).unwrap() {


### PR DESCRIPTION
This makes some fields which were `pub (crate)` private, and replaces their usage outside the `ast` module with the existing `pub` functions.  Which makes it a tiny bit easier to refactor these fields.