### PR TITLE
Add ctfails tests for warnings_are_errors.

### DIFF
--- a/lrpar/cttests/src/ctfails/warnings.test
+++ b/lrpar/cttests/src/ctfails/warnings.test
@@ -1,0 +1,12 @@
+name: Test warnings are treated as errors by default.
+yacckind: Original(YaccOriginalActionKind::GenericParseTree)
+grammar: |
+    %start A
+    %token b
+    %%
+    A : 'a';
+    B : 'b';
+lexer: |
+    %%
+    a 'a'
+    b 'b'

--- a/lrpar/cttests/src/ctfails/warnings_flags.test
+++ b/lrpar/cttests/src/ctfails/warnings_flags.test
@@ -1,0 +1,13 @@
+name: Test enabling warnings are errors.
+yacckind: Original(YaccOriginalActionKind::GenericParseTree)
+yacc_flags: [ warnings_are_errors ]
+grammar: |
+    %start A
+    %token b
+    %%
+    A : 'a';
+    B : 'b';
+lexer: |
+    %%
+    a 'a'
+    b 'b'


### PR DESCRIPTION
When we added warnings in #354 there wasn't a way to test the failure cases automatically, which we can do now in ctfails.

