### PR TITLE
Error reporting

### DIFF
--- a/cfgrammar/src/lib/yacc/mod.rs
+++ b/cfgrammar/src/lib/yacc/mod.rs
@@ -5,10 +5,12 @@ pub mod firsts;
 pub mod follows;
 pub mod grammar;
 pub mod parser;
+pub mod reporting;
 
 pub use self::{
     grammar::{AssocKind, Precedence, SentenceGenerator, YaccGrammar},
     parser::{YaccGrammarError, YaccGrammarErrorKind, YaccGrammarWarning, YaccGrammarWarningKind},
+    reporting::ErrorReport,
 };
 
 #[cfg(feature = "serde")]

--- a/cfgrammar/src/lib/yacc/reporting.rs
+++ b/cfgrammar/src/lib/yacc/reporting.rs
@@ -1,4 +1,8 @@
 use super::{YaccGrammarError, YaccGrammarWarning};
+use crate::{
+    yacc::{parser::SpansKind, YaccGrammarErrorKind},
+    Span, Spanned,
+};
 use std::fmt;
 
 /// Caller gives ownership of errors and warnings to the impl.
@@ -7,6 +11,38 @@ pub trait ErrorReport {
     fn grammar_error(&mut self, err: YaccGrammarError);
     /// Gives ownership of a warning to self.
     fn grammar_warning(&mut self, err: YaccGrammarWarning);
+
+    /// Default implementation does nothing. If you override this
+    /// and have a child report you must call finish on the child.
+    ///
+    /// Some `ErrorReport` implementations may wrap others,
+    /// and buffer the errors passed in. This function allows
+    /// them to drain that buffer.
+    ///
+    /// Another use case is when an `ErrorReport` containing
+    /// an `mpsc::Sender`, this would be called to drop the
+    /// `Sender`, so an `mpsc::Receiver` won't block forever
+    /// after the last error has been sent.
+    ///
+    /// This function is called at the end of `ASTBuilder::build`.
+    ///
+    /// Thoughts:
+    /// Waiting until we are finished is overzealous, we *know*
+    /// we only find certain errors in sections, and won't find
+    /// duplicates in later sections. Thus we could generalize this.
+    /// to something like:
+    /// ```
+    /// enum Stage {
+    ///   Header,
+    ///   Rules,
+    ///   Program,
+    ///   Finished,
+    /// }
+    /// fn stage(stage: Stage) {}
+    ///
+    /// ```
+    /// fn stage()
+    fn finish(&mut self) {}
 }
 
 /// A basic Report that stores errors and warnings in a `Vec`.
@@ -38,6 +74,70 @@ impl SimpleReport {
         &self.errors
     }
 }
+
+pub struct DedupReport<R: ErrorReport> {
+    errors: Vec<YaccGrammarError>,
+    child_report: R,
+}
+
+impl<R: ErrorReport> DedupReport<R> {
+    pub fn new(r: R) -> Self {
+        Self {
+            errors: Vec::new(),
+            child_report: r,
+        }
+    }
+    pub fn child(&self) -> &R {
+        &self.child_report
+    }
+}
+
+impl<R: ErrorReport> ErrorReport for DedupReport<R> {
+    fn grammar_error(&mut self, err: YaccGrammarError) {
+        // We would need to make a few things pub (kind) to implement this outside of the crate.
+        fn add_duplicate_occurrence(
+            errs: &mut Vec<YaccGrammarError>,
+            kind: YaccGrammarErrorKind,
+            orig_span: Span,
+            dup_span: Span,
+        ) {
+            // .rev() might be better when we hit.
+            if !errs.iter_mut().any(|e| {
+                if e.kind == kind && e.spans[0] == orig_span {
+                    e.spans.push(dup_span);
+                    true
+                } else {
+                    false
+                }
+            }) {
+                errs.push(YaccGrammarError {
+                    kind,
+                    spans: vec![orig_span, dup_span],
+                });
+            }
+        }
+        let spans = err.spans();
+        if let SpansKind::DuplicationError = err.spanskind() {
+            add_duplicate_occurrence(&mut self.errors, err.kind.clone(), spans[0], spans[1])
+        } else {
+            // Rather than send directly to the child report
+            // We store them to maintain their order.
+            self.errors.push(err);
+        }
+    }
+    fn grammar_warning(&mut self, w: YaccGrammarWarning) {
+        // Currently there is no such thing as a duplicate warning.
+        self.child_report.grammar_warning(w);
+    }
+
+    fn finish(&mut self) {
+        for e in self.errors.drain(..) {
+            self.child_report.grammar_error(e);
+        }
+        self.child_report.finish();
+    }
+}
+
 #[derive(Debug)]
 pub enum ASTBuilderError {
     /// This error is just an indication that a failure occurred.

--- a/cfgrammar/src/lib/yacc/reporting.rs
+++ b/cfgrammar/src/lib/yacc/reporting.rs
@@ -7,3 +7,33 @@ pub trait ErrorReport {
     /// Gives ownership of a warning to self.
     fn grammar_warning(&mut self, err: YaccGrammarWarning);
 }
+
+/// A basic Report that stores errors and warnings in a `Vec`.
+pub struct SimpleReport {
+    errors: Vec<YaccGrammarError>,
+    warnings: Vec<YaccGrammarWarning>,
+}
+
+impl ErrorReport for SimpleReport {
+    fn grammar_error(&mut self, err: YaccGrammarError) {
+        self.errors.push(err);
+    }
+    fn grammar_warning(&mut self, err: YaccGrammarWarning) {
+        self.warnings.push(err);
+    }
+}
+
+impl SimpleReport {
+    pub fn new() -> Self {
+        SimpleReport {
+            errors: vec![],
+            warnings: vec![],
+        }
+    }
+    pub(crate) fn warnings(&self) -> &[YaccGrammarWarning] {
+        &self.warnings
+    }
+    pub(crate) fn errors(&self) -> &[YaccGrammarError] {
+        &self.errors
+    }
+}

--- a/cfgrammar/src/lib/yacc/reporting.rs
+++ b/cfgrammar/src/lib/yacc/reporting.rs
@@ -82,6 +82,21 @@ impl ErrorReport for SimpleReport {
     }
 }
 
+impl ErrorMap for SimpleReport {
+    fn format_errors<'a, F: ErrorFormatter + ?Sized>(
+        &'a self,
+        f: &'a F,
+    ) -> impl Iterator<Item = Box<dyn Error>> + '_ {
+        self.errors.iter().map(move |e| f.format_error(e))
+    }
+    fn format_warnings<'a, F: ErrorFormatter + ?Sized>(
+        &'a self,
+        f: &'a F,
+    ) -> impl Iterator<Item = String> + '_ {
+        self.warnings.iter().map(move |w| f.format_warning(w))
+    }
+}
+
 impl SimpleReport {
     pub fn new() -> Self {
         SimpleReport {
@@ -156,6 +171,22 @@ impl<R: ErrorReport> ErrorReport for DedupReport<R> {
             self.child_report.grammar_error(e);
         }
         self.child_report.finish();
+    }
+}
+
+impl<R: ErrorReport + ErrorMap> ErrorMap for DedupReport<R> {
+    fn format_errors<'a, F: ErrorFormatter + ?Sized>(
+        &'a self,
+        f: &'a F,
+    ) -> impl Iterator<Item = Box<dyn Error>> + '_ {
+        self.child_report.format_errors(f)
+    }
+
+    fn format_warnings<'a, F: ErrorFormatter + ?Sized>(
+        &'a self,
+        f: &'a F,
+    ) -> impl Iterator<Item = String> + '_ {
+        self.child_report.format_warnings(f)
     }
 }
 

--- a/cfgrammar/src/lib/yacc/reporting.rs
+++ b/cfgrammar/src/lib/yacc/reporting.rs
@@ -1,0 +1,9 @@
+use super::{YaccGrammarError, YaccGrammarWarning};
+
+/// Caller gives ownership of errors and warnings to the impl.
+pub trait ErrorReport {
+    /// Gives ownership of an error to self.
+    fn grammar_error(&mut self, err: YaccGrammarError);
+    /// Gives ownership of a warning to self.
+    fn grammar_warning(&mut self, err: YaccGrammarWarning);
+}

--- a/cfgrammar/src/lib/yacc/reporting.rs
+++ b/cfgrammar/src/lib/yacc/reporting.rs
@@ -50,6 +50,23 @@ pub trait ErrorFormatter {
     fn format_warning(&self, e: &YaccGrammarWarning) -> String;
 }
 
+/// Applies a `map` operation with the function `f` over
+/// the error values owned by self.
+pub trait ErrorMap {
+    /// Applies `f` to all errors owned by self where `f` is a function
+    /// returning a type that implements `Error`.
+    fn format_errors<'a, F: ErrorFormatter + ?Sized>(
+        &'a self,
+        f: &'a F,
+    ) -> impl Iterator<Item = Box<dyn Error>> + '_;
+    /// Applies `f` to all warnings owned by self where `f` is a function
+    /// returning a type that implements `Display`.
+    fn format_warnings<'a, F: ErrorFormatter + ?Sized>(
+        &'a self,
+        f: &'a F,
+    ) -> impl Iterator<Item = String> + '_;
+}
+
 /// A basic Report that stores errors and warnings in a `Vec`.
 pub struct SimpleReport {
     errors: Vec<YaccGrammarError>,

--- a/cfgrammar/src/lib/yacc/reporting.rs
+++ b/cfgrammar/src/lib/yacc/reporting.rs
@@ -1,4 +1,5 @@
 use super::{YaccGrammarError, YaccGrammarWarning};
+use std::fmt;
 
 /// Caller gives ownership of errors and warnings to the impl.
 pub trait ErrorReport {
@@ -35,5 +36,21 @@ impl SimpleReport {
     }
     pub(crate) fn errors(&self) -> &[YaccGrammarError] {
         &self.errors
+    }
+}
+#[derive(Debug)]
+pub enum ASTBuilderError {
+    /// This error is just an indication that a failure occurred.
+    /// But otherwise lacks information such as what and where.
+    /// For that you will need to look at a `YaccGrammarError`
+    /// in an `ErrorReport`.
+    ConstructionFailure,
+}
+
+impl fmt::Display for ASTBuilderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match self {
+            Self::ConstructionFailure => write!(f, "Grammar construction failure"),
+        }
     }
 }

--- a/cfgrammar/src/lib/yacc/reporting.rs
+++ b/cfgrammar/src/lib/yacc/reporting.rs
@@ -3,7 +3,8 @@ use crate::{
     yacc::{parser::SpansKind, YaccGrammarErrorKind},
     Span, Spanned,
 };
-use std::fmt;
+use std::{error::Error, fmt, path};
+
 /// Caller gives ownership of errors and warnings to the impl.
 pub trait ErrorReport {
     /// Gives ownership of an error to self.
@@ -44,6 +45,11 @@ pub trait ErrorReport {
     fn finish(&mut self) {}
 }
 
+pub trait ErrorFormatter {
+    fn format_error(&self, e: &YaccGrammarError) -> Box<dyn Error>;
+    fn format_warning(&self, e: &YaccGrammarWarning) -> String;
+}
+
 /// A basic Report that stores errors and warnings in a `Vec`.
 pub struct SimpleReport {
     errors: Vec<YaccGrammarError>,
@@ -73,7 +79,6 @@ impl SimpleReport {
         &self.errors
     }
 }
-
 pub struct DedupReport<R: ErrorReport> {
     errors: Vec<YaccGrammarError>,
     child_report: R,
@@ -136,6 +141,7 @@ impl<R: ErrorReport> ErrorReport for DedupReport<R> {
         self.child_report.finish();
     }
 }
+
 pub(crate) struct ReportHandler<'a, T> {
     any_errors_found: bool,
     report: &'a mut T,

--- a/cfgrammar/src/lib/yacc/reporting.rs
+++ b/cfgrammar/src/lib/yacc/reporting.rs
@@ -55,16 +55,13 @@ pub trait ErrorFormatter {
 pub trait ErrorMap {
     /// Applies `f` to all errors owned by self where `f` is a function
     /// returning a type that implements `Error`.
-    fn format_errors<'a, F: ErrorFormatter + ?Sized>(
-        &'a self,
-        f: &'a F,
-    ) -> impl Iterator<Item = Box<dyn Error>> + '_;
+    fn format_errors<F: ErrorFormatter + ?Sized>(
+        &self,
+        f: &F,
+    ) -> impl Iterator<Item = Box<dyn Error>>;
     /// Applies `f` to all warnings owned by self where `f` is a function
     /// returning a type that implements `Display`.
-    fn format_warnings<'a, F: ErrorFormatter + ?Sized>(
-        &'a self,
-        f: &'a F,
-    ) -> impl Iterator<Item = String> + '_;
+    fn format_warnings<F: ErrorFormatter + ?Sized>(&self, f: &F) -> impl Iterator<Item = String>;
 }
 
 /// A basic Report that stores errors and warnings in a `Vec`.
@@ -83,16 +80,13 @@ impl ErrorReport for SimpleReport {
 }
 
 impl ErrorMap for SimpleReport {
-    fn format_errors<'a, F: ErrorFormatter + ?Sized>(
-        &'a self,
-        f: &'a F,
-    ) -> impl Iterator<Item = Box<dyn Error>> + '_ {
+    fn format_errors<F: ErrorFormatter + ?Sized>(
+        &self,
+        f: &F,
+    ) -> impl Iterator<Item = Box<dyn Error>> {
         self.errors.iter().map(move |e| f.format_error(e))
     }
-    fn format_warnings<'a, F: ErrorFormatter + ?Sized>(
-        &'a self,
-        f: &'a F,
-    ) -> impl Iterator<Item = String> + '_ {
+    fn format_warnings<F: ErrorFormatter + ?Sized>(&self, f: &F) -> impl Iterator<Item = String> {
         self.warnings.iter().map(move |w| f.format_warning(w))
     }
 }
@@ -175,17 +169,14 @@ impl<R: ErrorReport> ErrorReport for DedupReport<R> {
 }
 
 impl<R: ErrorReport + ErrorMap> ErrorMap for DedupReport<R> {
-    fn format_errors<'a, F: ErrorFormatter + ?Sized>(
-        &'a self,
-        f: &'a F,
-    ) -> impl Iterator<Item = Box<dyn Error>> + '_ {
+    fn format_errors<F: ErrorFormatter + ?Sized>(
+        &self,
+        f: &F,
+    ) -> impl Iterator<Item = Box<dyn Error>> {
         self.child_report.format_errors(f)
     }
 
-    fn format_warnings<'a, F: ErrorFormatter + ?Sized>(
-        &'a self,
-        f: &'a F,
-    ) -> impl Iterator<Item = String> + '_ {
+    fn format_warnings<F: ErrorFormatter + ?Sized>(&self, f: &F) -> impl Iterator<Item = String> {
         self.child_report.format_warnings(f)
     }
 }

--- a/cfgrammar/src/lib/yacc/reporting.rs
+++ b/cfgrammar/src/lib/yacc/reporting.rs
@@ -198,6 +198,9 @@ pub struct SimpleErrorFormatter<'a> {
 
 impl<'a> SimpleErrorFormatter<'a> {
     #[allow(clippy::result_unit_err)]
+    // We could be more efficient by calling `feed(src[0..max_span_offset])`
+    // but we don't have the max span offset here, it may be worth considering
+    // now though because this is pub.
     pub fn new(src: &'a str, path: &'a path::Path) -> Result<Self, ()> {
         Ok(Self {
             src,
@@ -249,7 +252,11 @@ impl<'a> SimpleErrorFormatter<'a> {
                     .unwrap_or(line);
                 let dots = if next_line - line > 1 { "..." } else { "" };
                 out.push_str(dots);
-
+                // TODO:
+                // This may produce incorrect underlining for unicode characters.
+                // We could do better using the unicode_width crate. Should we
+                // feature gate fancy errors to make that an optional dependency?
+                //
                 // Because col is 1 indexed, subtract 1.
                 out.push_str(
                     &" ".repeat(col + (line.to_string().len() + "| ".len() - dots.len()) - 1),

--- a/cfgrammar/src/lib/yacc/reporting.rs
+++ b/cfgrammar/src/lib/yacc/reporting.rs
@@ -193,12 +193,18 @@ pub enum ASTBuilderError {
     /// For that you will need to look at a `YaccGrammarError`
     /// in an `ErrorReport`.
     ConstructionFailure,
+    MissingSource,
+    MissingErrorReport,
+    MissingYaccKind,
 }
 
 impl fmt::Display for ASTBuilderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match self {
             Self::ConstructionFailure => write!(f, "Grammar construction failure"),
+            Self::MissingSource => write!(f, "Sources for a grammar was not given"),
+            Self::MissingYaccKind => write!(f, "`YaccKind` for a grammar was not specified"),
+            Self::MissingErrorReport => write!(f, "`ErrorReport` for grammar was not given"),
         }
     }
 }


### PR DESCRIPTION
Sorry for sending another large PR.  I was hoping I could just send some smaller ones, but it seems fairly difficult to break up.
In theory I could break it up at patches [04ba0c1](https://github.com/softdevteam/grmtools/pull/436/commits/04ba0c15bb5aad1e1d76b446dbfb8252cff3e92d),  [c7bc81f](https://github.com/softdevteam/grmtools/pull/436/commits/c7bc81fac4a97b1c46cbce5fc439cb32f22b6e3c) and last [050d207](https://github.com/softdevteam/grmtools/pull/436/commits/050d2075f012abe334da79df1a46fe9410f25609).

But [6d41bbb](https://github.com/softdevteam/grmtools/pull/436/commits/6d41bbb8c0a09ef83649195b03cae10b883b4f45) modifies a trait. I wanted the addition of the trait method to be close to its usage, because the specific method was a key source of bugs during the development (when failing to call it) one way to avoid  it would be to call `finish` from the `ErrorMap` trait.  But we'd have to document that `finish` can be called multiple times, so using `drain` would be necessary. In a sense that would just swapping API awkwardness elsewhere.

Overall this branch has aspects of all three of the patches (callbacks, trait, and channel series minus the channels).
I'm not soo terribly certain how well actually trying to do `incremental` or prompt receiving of errors at the time they occurr.
In particular the combination of `warnings` and `errors` means that one of warnings or errors could block the other.
unless you spawn a thread for each, or use a channel which is sync on the grmtools side, and async on the outside (like my lsp does).

I'm not very smitten on some of the names, but have lacked any good alternatives like `ErrorReport` is kind of like `ErrorEscrow` or `ErrorCache` and using the `NewlineCache` style names for methods like `feed_error()`, `feed_warning()`.
But I tried not to get bogged down on naming and just get it working from end to end.

There isn't anything in the branch which calls it from build.rs, follows is an example, but FWIW, the parts hooking it up to `CTParserBuilder` could probably use some work, but at least as a proof of concept show it is possible here to get the source + the path to an error formatter without plumbing it all the way through the parser, or repeatedly building `NewlineCache`.

```
struct Formatter {}

impl Formatter {
    fn formatter(_src: &str, _path: &std::path::Path) -> Box<dyn ErrorFormatter> {
        Box::new(Self {}) as Box<dyn ErrorFormatter>
    }
}

impl ErrorFormatter for Formatter {
    fn format_error(&self, _: &YaccGrammarError) -> Box<dyn Error> {
        "fancy error".into()
    }

    fn format_warning(&self, _: &YaccGrammarWarning) -> String {
        "fancy warning".to_string()
    }
}
```
...
.lrpar_config(|ctp| {
                ctp.error_formatter(Box::new(Formatter::formatter)).grammar_in_src_dir(...).unwrap()
})
```