### PR TITLE
Bespoke nimbleparse errors

### DIFF
--- a/nimbleparse/Cargo.toml
+++ b/nimbleparse/Cargo.toml
@@ -20,3 +20,4 @@ lrlex = { path="../lrlex", version="0.13" }
 lrpar = { path="../lrpar", version="0.13" }
 lrtable = { path="../lrtable", version="0.13" }
 num-traits = "0.2"
+unicode-width = "0.1.11"

--- a/nimbleparse/src/diagnostics.rs
+++ b/nimbleparse/src/diagnostics.rs
@@ -1,0 +1,359 @@
+use std::{error::Error, fmt::Display, path::Path, str::FromStr};
+
+use cfgrammar::{newlinecache::NewlineCache, yacc::parser::SpansKind, Span, Spanned};
+use unicode_width::UnicodeWidthStr;
+
+pub struct SpannedDiagnosticFormatter<'a> {
+    src: &'a str,
+    path: &'a Path,
+    nlc: NewlineCache,
+}
+
+impl<'a> SpannedDiagnosticFormatter<'a> {
+    #[allow(clippy::result_unit_err)]
+    pub fn new(src: &'a str, path: &'a Path) -> Result<Self, ()> {
+        Ok(Self {
+            src,
+            path,
+            nlc: NewlineCache::from_str(src)?,
+        })
+    }
+
+    pub fn ordinal(v: usize) -> String {
+        // I didn't feel like thinking about these special cases,
+        // so I just borrowed this from rusts diagnostics code.
+        let suffix = match ((11..=13).contains(&(v % 100)), v % 10) {
+            (false, 1) => "st",
+            (false, 2) => "nd",
+            (false, 3) => "rd",
+            _ => "th",
+        };
+        format!("{v}{suffix}")
+    }
+
+    // If a span is given returns "msg at path/file.foo:5:6" otherwise returns "msg in path/file.foo"
+    pub fn file_location_msg(&self, msg: &str, span: Option<Span>) -> String {
+        if let Some(span) = span {
+            let (line, col) = self
+                .nlc
+                .byte_to_line_num_and_col_num(self.src, span.start())
+                .unwrap_or((0, 0));
+            format!("{} at {}:{line}:{col}", msg, self.path.display())
+        } else {
+            format!("{} in {}", msg, self.path.display())
+        }
+    }
+
+    /// Print the line/column information and source text for all lines intersecting the span.
+    /// Underline the portion covered by the span with the `underline_c` character.
+    #[allow(unused)]
+    pub fn underline_span_with_text(&self, span: Span, s: String, underline_c: char) -> String {
+        self.prefixed_underline_span_with_text("", span, s, underline_c)
+    }
+
+    // This prints a span with an optional prefix under the line numbers, which
+    // is intended to be used for denoting when lines are non-contiguous.
+    pub fn prefixed_underline_span_with_text(
+        &self,
+        prefix: &str,
+        mut span: Span,
+        s: String,
+        underline_c: char,
+    ) -> String {
+        let mut out = String::new();
+        let (start_byte, end_byte) = self.nlc.span_line_bytes(span);
+        // Produce an underline underneath a span which may cover multiple lines, and a message on the last line.
+        let mut source_lines = self.src[start_byte..end_byte].lines().peekable();
+        while let Some(source_line) = source_lines.next() {
+            let (line_start_byte, _) = self.nlc.span_line_bytes(span);
+            let span_offset_from_start = span.start() - line_start_byte;
+
+            // An underline bounded by the current line.
+            let underline_span = Span::new(
+                span.start(),
+                span.end()
+                    .min(span.start() + (source_line.len() - span_offset_from_start)),
+            );
+            let (line_num, _) = self
+                .nlc
+                .byte_to_line_num_and_col_num(self.src, span.start())
+                .expect("Span must correlate to a line in source");
+            // Print the line_num/source text for the line.
+            out.push_str(&format!("{}| {}\n", line_num, source_line));
+            let line_num_digits = line_num.to_string().len();
+            assert!(prefix.len() <= "0| ".len());
+            // Add indentation from the start of the underlined span
+            out.push_str(&format!(
+                "{prefix}{}",
+                &" ".repeat(
+                    UnicodeWidthStr::width(&self.src[line_start_byte..underline_span.start()])
+                        + (line_num_digits + "| ".len() - prefix.len())
+                )
+            ));
+            // Add underline upto the end of line.
+            out.push_str(&(underline_c.to_string()).repeat(UnicodeWidthStr::width(
+                &self.src[underline_span.start()..underline_span.end()],
+            )));
+
+            if source_lines.peek().is_none() {
+                // If we're at the end print the message.
+                out.push_str(&format!(" {}", &s));
+            } else {
+                // Otherwise set next span to start at the beginning of the next line.
+                out.push('\n');
+                span = Span::new(line_start_byte + source_line.len() + 1, span.end())
+            }
+        }
+
+        out
+    }
+
+    fn format_spanned(&self, e: &impl Spanned) -> String {
+        let mut out = String::new();
+        let mut spans = e.spans().iter().enumerate().peekable();
+        while let Some((span_num, span)) = spans.next() {
+            let (line, _) = self
+                .nlc
+                .byte_to_line_num_and_col_num(self.src, span.start())
+                .unwrap_or((0, 0));
+            let next_line = spans
+                .peek()
+                .map(|(_, span)| span)
+                .map(|s| self.nlc.byte_to_line_num(s.start()).unwrap_or(line))
+                .unwrap_or(line);
+            // Is this line contiguous with the next, if not prefix it with dots.
+            let dots = if next_line - line > 1 { "..." } else { "" };
+            if span_num == 0 {
+                let s = e.to_string();
+                out.push_str(&self.prefixed_underline_span_with_text(dots, *span, s, '^'));
+            } else {
+                let s = match e.spanskind() {
+                    SpansKind::DuplicationError => {
+                        format!("{} occurrence", Self::ordinal(span_num + 1))
+                    }
+                    SpansKind::Error => {
+                        unreachable!("Should contain a single span at the site of the error")
+                    }
+                };
+                out.push_str(&self.prefixed_underline_span_with_text(dots, *span, s, '-'));
+            }
+        }
+        out
+    }
+}
+
+pub trait DiagnosticFormatter {
+    fn format_error<E>(&self, e: E) -> Box<dyn Error>
+    where
+        E: Spanned + Error;
+    fn format_warning<W>(&self, e: W) -> String
+    where
+        W: Spanned + Display;
+}
+
+impl DiagnosticFormatter for SpannedDiagnosticFormatter<'_> {
+    fn format_error<E>(&self, e: E) -> Box<dyn Error>
+    where
+        E: Spanned + Error,
+    {
+        self.format_spanned(&e).into()
+    }
+
+    fn format_warning<W>(&self, w: W) -> String
+    where
+        W: Spanned + Display,
+    {
+        self.format_spanned(&w)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn underline_multiline_span_test() {
+        let s = "\naaaaaabbb\nbbb\nbbbb\n";
+        let test_path = PathBuf::from("test");
+        let formatter = SpannedDiagnosticFormatter::new(s, &test_path).unwrap();
+
+        let span = Span::new(7, 7 + 12);
+        let out = format!(
+            "\n{}",
+            formatter.underline_span_with_text(span, "Test message".into(), '-')
+        );
+        assert_eq!(
+            out,
+            r"
+2| aaaaaabbb
+         ---
+3| bbb
+   ---
+4| bbbb
+   ---- Test message"
+        );
+
+        let out = format!(
+            "\n{}",
+            formatter.underline_span_with_text(span, "Test message".into(), '^')
+        );
+        assert_eq!(
+            out,
+            r"
+2| aaaaaabbb
+         ^^^
+3| bbb
+   ^^^
+4| bbbb
+   ^^^^ Test message"
+        );
+    }
+
+    #[test]
+    fn underline_single_line_span_test() {
+        let s = "\naaaaaabbb bbb bbbb\n";
+        let test_path = PathBuf::from("test");
+        let formatter = SpannedDiagnosticFormatter::new(s, &test_path).unwrap();
+
+        let span = Span::new(7, 7 + 12);
+        let out = format!(
+            "\n{}",
+            formatter.underline_span_with_text(span, "Test message".into(), '-')
+        );
+        assert_eq!(
+            out,
+            r"
+2| aaaaaabbb bbb bbbb
+         ------------ Test message"
+        );
+        let out = format!(
+            "\n{}",
+            formatter.underline_span_with_text(span, "Test message".into(), '^')
+        );
+        assert_eq!(
+            out,
+            r"
+2| aaaaaabbb bbb bbbb
+         ^^^^^^^^^^^^ Test message"
+        );
+    }
+
+    #[test]
+    fn span_prefix() {
+        let s = "\naaaaaabbb\nbbb\nbbbb\n";
+        let test_path = PathBuf::from("test");
+        let formatter = SpannedDiagnosticFormatter::new(s, &test_path).unwrap();
+        // For raw string alignment.
+        let mut out = String::from("\n");
+        // On occasion we want dots to signal that the lines are not contiguous.
+        out.push_str(&formatter.prefixed_underline_span_with_text(
+            "...",
+            Span::new(7, 10),
+            "Test message".to_string(),
+            '^',
+        ));
+        out.push('\n');
+        // Skip over the middle set of b's.
+        out.push_str(&formatter.underline_span_with_text(
+            Span::new(15, 19),
+            "Other message".to_string(),
+            '-',
+        ));
+        assert_eq!(
+            out,
+            r"
+2| aaaaaabbb
+...      ^^^ Test message
+4| bbbb
+   ---- Other message"
+        );
+    }
+
+    #[test]
+    fn span_prefix_2() {
+        let s = "\n\n\n\n\n\n\n\n\n\n\naaaaaabbb\nbbb\nbbbb\n";
+        let test_path = PathBuf::from("test");
+        let formatter = SpannedDiagnosticFormatter::new(s, &test_path).unwrap();
+        let mut out = String::from("\n");
+        // On occasion we want dots to signal that the lines are not contiguous.
+        out.push_str(&formatter.prefixed_underline_span_with_text(
+            "...",
+            Span::new(17, 20),
+            "Test message".to_string(),
+            '^',
+        ));
+        out.push('\n');
+        // Skip over the middle set of b's.
+        out.push_str(&formatter.underline_span_with_text(
+            Span::new(25, 29),
+            "Other message".to_string(),
+            '-',
+        ));
+        assert_eq!(
+            out,
+            r"
+12| aaaaaabbb
+...       ^^^ Test message
+14| bbbb
+    ---- Other message"
+        );
+    }
+
+    #[test]
+    fn span_multiline_unicode() {
+        let crabs = " 🦀🦀🦀 ";
+        let crustaceans = format!("\"{crabs}\n{crabs}\"");
+        let test_path = PathBuf::from("test");
+        let formatter = SpannedDiagnosticFormatter::new(&crustaceans, &test_path).unwrap();
+        // For raw string alignment.
+        let mut out = String::from("\n");
+        out.push_str(&formatter.underline_span_with_text(
+            Span::new(0, crabs.len() * 2 + "\n\"\"".len()),
+            "Test".to_string(),
+            '^',
+        ));
+        assert_eq!(
+            out,
+            r#"
+1| " 🦀🦀🦀 
+   ^^^^^^^^^
+2|  🦀🦀🦀 "
+   ^^^^^^^^^ Test"#
+        );
+    }
+
+    #[test]
+    fn span_unicode() {
+        let crab = "\n🦀";
+        let lobster = "🦞";
+        let crustaceans = format!("{crab}{lobster}{crab}{crab}{lobster}");
+        let test_path = PathBuf::from("test");
+        let formatter = SpannedDiagnosticFormatter::new(&crustaceans, &test_path).unwrap();
+        // For raw string alignment.
+        let mut out = String::from("\n");
+        out.push_str(&formatter.prefixed_underline_span_with_text(
+            "...",
+            Span::new(crab.len(), crab.len() + lobster.len()),
+            "Not a crab".to_string(),
+            '^',
+        ));
+        out.push('\n');
+        out.push_str(&formatter.underline_span_with_text(
+            Span::new(
+                crab.len() * 3 + lobster.len(),
+                crab.len() * 3 + lobster.len() * 2,
+            ),
+            "Not a crab either".to_string(),
+            '-',
+        ));
+        assert_eq!(
+            out,
+            r"
+2| 🦀🦞
+...  ^^ Not a crab
+4| 🦀🦞
+     -- Not a crab either"
+        );
+    }
+}

--- a/nimbleparse/src/diagnostics.rs
+++ b/nimbleparse/src/diagnostics.rs
@@ -75,7 +75,6 @@ impl<'a> SpannedDiagnosticFormatter<'a> {
 
     /// Print the line/column information and source text for all lines intersecting the span.
     /// Underline the portion covered by the span with the `underline_c` character.
-    #[allow(unused)]
     pub fn underline_span_with_text(&self, span: Span, s: String, underline_c: char) -> String {
         self.prefixed_underline_span_with_text("", span, s, underline_c)
     }

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -1,11 +1,4 @@
-use std::{
-    env,
-    fs::File,
-    io::{stderr, Read, Write},
-    path::Path,
-    process,
-    str::FromStr,
-};
+use std::{env, fs::File, io::Read, path::Path, process, str::FromStr};
 
 use cfgrammar::{
     newlinecache::NewlineCache,
@@ -28,14 +21,9 @@ fn usage(prog: &str, msg: &str) -> ! {
         None => "lrpar",
     };
     if !msg.is_empty() {
-        writeln!(stderr(), "{}", msg).ok();
+        eprintln!("{}", msg);
     }
-    writeln!(
-        stderr(),
-        "Usage: {} [-r <cpctplus|none>] [-y <eco|grmtools|original>] [-q] <lexer.l> <parser.y> <input file>",
-        leaf
-    )
-    .ok();
+    eprintln!("Usage: {} [-r <cpctplus|none>] [-y <eco|grmtools|original>] [-q] <lexer.l> <parser.y> <input file>", leaf);
     process::exit(1);
 }
 
@@ -43,7 +31,7 @@ fn read_file(path: &str) -> String {
     let mut f = match File::open(path) {
         Ok(r) => r,
         Err(e) => {
-            writeln!(stderr(), "Can't open file {}: {}", path, e).ok();
+            eprintln!("Can't open file {}: {}", path, e);
             process::exit(1);
         }
     };
@@ -111,15 +99,12 @@ fn main() {
         if let Some((line, column)) =
             nlcache.byte_to_line_num_and_col_num(src, spanned.spans()[0].start())
         {
-            writeln!(
-                stderr(),
+            eprintln!(
                 "{}: {prefix} {} at line {line} column {column}",
-                src_path,
-                &spanned
-            )
-            .ok();
+                src_path, &spanned
+            );
         } else {
-            writeln!(stderr(), "{}: {}", &src_path, &spanned).ok();
+            eprintln!("{}: {}", &src_path, &spanned);
         }
     };
     let mut lexerdef = match LRNonStreamingLexerDef::<DefaultLexerTypes<u32>>::from_str(&lex_src) {
@@ -162,7 +147,7 @@ fn main() {
     let (sgraph, stable) = match from_yacc(&grm, Minimiser::Pager) {
         Ok(x) => x,
         Err(s) => {
-            writeln!(stderr(), "{}: {}", &yacc_y_path, &s).ok();
+            eprintln!("{}: {}", &yacc_y_path, &s);
             process::exit(1);
         }
     };
@@ -200,23 +185,21 @@ fn main() {
         let (missing_from_lexer, missing_from_parser) = lexerdef.set_rule_ids(&rule_ids);
         if !quiet {
             if let Some(tokens) = missing_from_parser {
-                writeln!(stderr(), "Warning: these tokens are defined in the lexer but not referenced in the\ngrammar:").ok();
+                eprintln!("Warning: these tokens are defined in the lexer but not referenced in the\ngrammar:");
                 let mut sorted = tokens.iter().cloned().collect::<Vec<&str>>();
                 sorted.sort_unstable();
                 for n in sorted {
-                    writeln!(stderr(), "  {}", n).ok();
+                    eprintln!("  {}", n);
                 }
             }
             if let Some(tokens) = missing_from_lexer {
-                writeln!(
-                    stderr(),
+                eprintln!(
                     "Error: these tokens are referenced in the grammar but not defined in the lexer:"
-                )
-                .ok();
+                );
                 let mut sorted = tokens.iter().cloned().collect::<Vec<&str>>();
                 sorted.sort_unstable();
                 for n in sorted {
-                    writeln!(stderr(), "  {}", n).ok();
+                    eprintln!("  {}", n);
                 }
                 process::exit(1);
             }

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -27,11 +27,11 @@ fn usage(prog: &str, msg: &str) -> ! {
     process::exit(1);
 }
 
-fn read_file(path: &str) -> String {
-    let mut f = match File::open(path) {
+fn read_file<P: AsRef<Path>>(path: P) -> String {
+    let mut f = match File::open(&path) {
         Ok(r) => r,
         Err(e) => {
-            eprintln!("Can't open file {}: {}", path, e);
+            eprintln!("Can't open file {}: {}", path.as_ref().display(), e);
             process::exit(1);
         }
     };


### PR DESCRIPTION
One thing I considered might be worth attempting (since it doesn't actually involve much in the way of new public API).
is just doing bespoke error handling for nimbleparse using some of the code i'd written for the various branches.

nimbleparse is a good choice since it uses the `RTParserBuilder` which doesn't run into abstraction boundaries,
so everything we need for error handling is in one place, and both lex/yacc are used.

So, this patch just does some initial error messages that use sort-of rust inspired messages with source underlining.
There is one API change that needed to happen for the `missing_from_lexer` in order to obtain the spans.

One thing it doesn't try to do, but could be done is try to apply this to the parser that gets built and it's input in the way of errors or error recovery.