### PR TITLE
Missed a newline in multi-span errors

### DIFF
--- a/nimbleparse/src/diagnostics.rs
+++ b/nimbleparse/src/diagnostics.rs
@@ -155,6 +155,7 @@ impl<'a> SpannedDiagnosticFormatter<'a> {
                 let s = e.to_string();
                 out.push_str(&self.prefixed_underline_span_with_text(dots, *span, s, '^'));
             } else {
+                out.push('\n');
                 let s = match e.spanskind() {
                     SpansKind::DuplicationError => {
                         format!("{} occurrence", Self::ordinal(span_num + 1))


### PR DESCRIPTION
It appears like I missed a newline in multi-span errors which would cause the next spans to be presented
on the same line as the previous spans error text sorry.