### PR TITLE
(lrtable) Make the final_state field conditional on `cfg(test)`

### DIFF
--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -141,6 +141,7 @@ pub struct StateTable<StorageT> {
     prods_len: PIdx<StorageT>,
     tokens_len: TIdx<StorageT>,
     conflicts: Option<Conflicts<StorageT>>,
+    #[cfg(test)]
     final_state: StIdx<StorageT>,
 }
 
@@ -370,6 +371,7 @@ where
             prods_len: grm.prods_len(),
             tokens_len: grm.tokens_len(),
             conflicts,
+            #[cfg(test)]
             final_state: final_state.unwrap(),
         })
     }


### PR DESCRIPTION
This conditionally includes a field into `struct StateTable`. Previously `clippy with --no-default-features -p lrtable` would produce a warning about `final_state` never being read.  This was presumably being suppressed by serde derive macros.  Since this field was only used in the test cfg.

It seemed better to make it conditional rather than `#[allow(dead_code)]`.