### PR TITLE
Add a doc section for third party tools

### DIFF
--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -18,4 +18,5 @@
   - [nimbleparse](nimbleparse.md)
   - [cfgrammar](cfgrammar.md)
   - [lrtable](lrtable.md)
+  - [third party](thirdparty.md)
 - [Other Rust parsing tools](othertools.md)

--- a/doc/src/thirdparty.md
+++ b/doc/src/thirdparty.md
@@ -1,0 +1,7 @@
+# Libraries and tools developed by third parties
+
+Besides using grmtools to develop parsers. The following items use grmtools
+to extend or augment the functionality which may be useful to people developing
+parsers with grmtools.
+
+- [nimbleparse_lsp](https://github.com/ratmice/nimbleparse_lsp)


### PR DESCRIPTION
It was recommended in #448 to add a link to the book about nimbleparse_lsp.
I'm not really certain it is a good idea to advertise it yet, as it has fallen behind by a few releases and overall is still fairly
prototype quality.  

Despite that, this adds "third party" section in chapter 6 of "individual libraries and tools".
I had hoped to just link directly to the repository, relying on the external readme.

Unfortunately trying to link to a `[lsp](https://)` within `SUMMARY.md` appends a `.html` extension breaking the URL.
Between adding a subsection, or just embedding a list within the `thirdparty.md` I went with a subsection,
since it more closely mirrored how the current list of tools and libraries is listed.