### PR TITLE
Give better warnings if lexer/grammar can't be read at build time.

### DIFF
--- a/lrlex/src/lib/ctbuilder.rs
+++ b/lrlex/src/lib/ctbuilder.rs
@@ -325,7 +325,8 @@ where
             lk.insert(outp.clone());
         }
 
-        let lex_src = read_to_string(lexerp)?;
+        let lex_src = read_to_string(lexerp)
+            .map_err(|e| format!("When reading '{}': {e}", lexerp.display()))?;
         let line_cache = NewlineCache::from_str(&lex_src).unwrap();
         let mut lexerdef: Box<dyn LexerDef<LexerTypesT>> = match self.lexerkind {
             LexerKind::LRNonStreamingLexer => Box::new(

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -414,7 +414,8 @@ where
             lk.insert(outp.clone());
         }
 
-        let inc = read_to_string(grmp).unwrap();
+        let inc =
+            read_to_string(grmp).map_err(|e| format!("When reading '{}': {e}", grmp.display()))?;
         let ast_validation = ASTWithValidityInfo::new(yk, &inc);
         let warnings = ast_validation.ast().warnings();
         let spanned_fmt = |x: &dyn Spanned, inc: &str, line_cache: &NewlineCache| {


### PR DESCRIPTION
If the user gave an incorrect path, they got an internal `unwrap`, or similarly unhelpful message, from lrlex and lrpar. This commit tells them what file was attempting to be read, which makes working out what's actually gone wrong much easier.