### PR TITLE
Unbreak empty productions and actions.

### DIFF
--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -691,9 +691,7 @@ impl YaccParser {
                 i = self.parse_ws(j, true)?;
                 action = Some(a);
 
-                if syms.is_empty()
-                    || !(self.lookahead_is("|", i).is_some() || self.lookahead_is(";", i).is_some())
-                {
+                if !(self.lookahead_is("|", i).is_some() || self.lookahead_is(";", i).is_some()) {
                     return Err(self.mk_error(YaccGrammarErrorKind::ProductionNotTerminated, i));
                 }
             } else if let Some(mut j) = self.lookahead_is("%empty", i) {
@@ -2629,5 +2627,12 @@ B";
             3,
             17,
         );
+
+        let src = "
+        %%
+        A: B B {};
+        B: {} ;
+        ";
+        parse(YaccKind::Original(YaccOriginalActionKind::NoAction), src).unwrap();
     }
 }


### PR DESCRIPTION
This is a classic copy and paste mistake on my part: I didn't think carefully enough about the `syms.is_empty()` clause.

Fixes https://github.com/softdevteam/grmtools/issues/463.