### PR TITLE
Allow Stdin to be used as input file for lrlex/nimbleparse

### DIFF
--- a/lrlex/src/main.rs
+++ b/lrlex/src/main.rs
@@ -2,7 +2,7 @@ use getopts::Options;
 use std::{
     env,
     fs::File,
-    io::{stderr, Read, Write},
+    io::{stderr, stdin, Read, Write},
     path::Path,
     process,
     str::FromStr,
@@ -26,6 +26,11 @@ fn usage(prog: &str, msg: &str) {
 }
 
 fn read_file(path: &str) -> String {
+    let mut s = String::new();
+    if path == "-" {
+        stdin().read_to_string(&mut s).unwrap();
+        return s;
+    }
     let mut f = match File::open(path) {
         Ok(r) => r,
         Err(e) => {
@@ -33,7 +38,6 @@ fn read_file(path: &str) -> String {
             process::exit(1);
         }
     };
-    let mut s = String::new();
     f.read_to_string(&mut s).unwrap();
     s
 }

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -276,7 +276,13 @@ fn main() {
         }
     }
 
-    let input = read_file(&matches.free[2]);
+    let input = if &matches.free[2] == "-" {
+        let mut s = String::new();
+        std::io::stdin().read_to_string(&mut s).unwrap();
+        s
+    } else {
+        read_file(&matches.free[2])
+    };
     let lexer = lexerdef.lexer(&input);
     let pb = RTParserBuilder::new(&grm, &stable).recoverer(recoverykind);
     let (pt, errs) = pb.parse_generictree(&lexer);


### PR DESCRIPTION
Working a small project where I wanted to run lrlex over some compressed data, it seemed like it would be nice
to do so without having to decompress using a temporary file...  This implements it so you can do the the following
```
zcat compressed_stuff| lrlex foo.l -
``` 

Or a nimbleparse example that should work in the repository (echo -n to avoid newline)

```
echo -n "1 + 1" | target/release/nimbleparse lrpar/examples/calc_parsetree/src/calc.{l,y} -
```