### PR TITLE
nimbleparse: add -d flag to dump state graph

### DIFF
--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -173,7 +173,9 @@ where
                 }
                 o.push_str("}]");
             }
-            for (esym, e_stidx) in self.edges(stidx).iter() {
+            let mut edges = self.edges(stidx).iter().collect::<Vec<_>>();
+            edges.sort_by(|(_, x), (_, y)| x.cmp(y));
+            for (esym, e_stidx) in edges {
                 write!(
                     o,
                     "\n{}{} -> {}",


### PR DESCRIPTION
This is a patch I used for testing https://github.com/softdevteam/sparsevec/pull/25
It adds a `-d` flag for dumping the state graph from nimbleparse, then exiting.
It also fixes an issue where the pretty printing function produces non-deterministic output.

I'm not certain it is quite up to par, because of the argument parsing an input file is required even though it is never used.
but making the input file 'required unless the -d flag is specified' is also weird.  Passing in an unused filename like /dev/null was sufficient for my testing purposes though.