### PR TITLE
Issue 473 assertion

### DIFF
--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -104,6 +104,7 @@ pub struct Production {
 pub enum Symbol {
     Rule(String, Span),
     Token(String, Span),
+    Empty(Span),
 }
 
 /// Specifies an index into a `GrammarAst.tokens` or a `GrammarAST.rules`.
@@ -133,6 +134,7 @@ impl fmt::Display for Symbol {
         match *self {
             Symbol::Rule(ref s, _) => write!(f, "{}", s),
             Symbol::Token(ref s, _) => write!(f, "{}", s),
+            Symbol::Empty(_) => write!(f, "%empty"),
         }
     }
 }
@@ -262,6 +264,7 @@ impl GrammarAST {
                                 });
                             }
                         }
+                        Symbol::Empty(_) => {}
                     }
                 }
             }
@@ -300,6 +303,7 @@ impl GrammarAST {
                         });
                     }
                 }
+                Symbol::Empty(_) => {}
             }
         }
         Ok(())
@@ -311,6 +315,9 @@ impl GrammarAST {
                 let (kind, span) = match symidx.symbol(self) {
                     Symbol::Rule(_, span) => (YaccGrammarWarningKind::UnusedRule, span),
                     Symbol::Token(_, span) => (YaccGrammarWarningKind::UnusedToken, span),
+                    Symbol::Empty(_) => {
+                        unreachable!()
+                    }
                 };
                 YaccGrammarWarning {
                     kind,
@@ -340,6 +347,9 @@ impl GrammarAST {
                 Symbol::Token(sym_name, _) => {
                     expected_unused_tokens.insert(sym_name);
                 }
+                Symbol::Empty(_) => {
+                    unreachable!();
+                }
             }
         }
         if let Some(implicit_tokens) = self.implicit_tokens.as_ref() {
@@ -363,6 +373,8 @@ impl GrammarAST {
                         }
                         Symbol::Token(name, _) => {
                             seen_tokens.insert(name);
+                        }
+                        Symbol::Empty(_) => {
                         }
                     };
                 }

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -295,6 +295,7 @@ where
                                 prod.push(Symbol::Rule(rule_map[implicit_rule]));
                             }
                         }
+                        ast::Symbol::Empty(_) => {}
                     };
                 }
                 let mut prec = None;

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -1041,6 +1041,7 @@ S: S | ;";
                 match sym {
                     ast::Symbol::Rule(_, span) => assert_eq!(span, &Span::new(6, 7)),
                     ast::Symbol::Token(_, _) => panic!("Incorrect symbol"),
+                    ast::Symbol::Empty(_) => panic!("Empty symbol"),
                 }
             }
             Err(e) => panic!("Incorrect error returned {:?}", e),
@@ -1072,6 +1073,7 @@ T: S | ;";
                 match sym {
                     ast::Symbol::Rule(_, span) => assert_eq!(span, &Span::new(15, 16)),
                     ast::Symbol::Token(_, _) => panic!("Incorrect symbol"),
+                    ast::Symbol::Empty(_) => panic!("Empty symbol"),
                 }
             }
             Err(e) => panic!("Incorrect error returned {:?}", e),

--- a/nimbleparse/src/diagnostics.rs
+++ b/nimbleparse/src/diagnostics.rs
@@ -24,18 +24,16 @@ where
     usize: num_traits::AsPrimitive<StorageT>,
     StorageT: 'static + num_traits::PrimInt + num_traits::Unsigned,
 {
-    if usize::from(pidx) < ast.prods.len() {
-        let prod = &ast.prods[usize::from(pidx)];
-        prod.symbols
-            .iter()
-            .map(|sym| match sym {
-                Symbol::Rule(name, span) => (format!("'{}'", name), span),
-                Symbol::Token(name, span) => (format!("'{}'", name), span),
-            })
-            .unzip()
-    } else {
-        (vec![], vec![])
-    }
+    let pidx = usize::from(pidx);
+    assert!(pidx < ast.prods.len());
+    let prod = &ast.prods[pidx];
+    prod.symbols
+        .iter()
+        .map(|sym| match sym {
+            Symbol::Rule(name, span) => (format!("'{}'", name), span),
+            Symbol::Token(name, span) => (format!("'{}'", name), span),
+        })
+        .unzip()
 }
 
 impl<'a> SpannedDiagnosticFormatter<'a> {

--- a/nimbleparse/src/diagnostics.rs
+++ b/nimbleparse/src/diagnostics.rs
@@ -32,6 +32,7 @@ where
         .map(|sym| match sym {
             Symbol::Rule(name, span) => (format!("'{}'", name), span),
             Symbol::Token(name, span) => (format!("'{}'", name), span),
+            Symbol::Empty(span) => (format!("%empty"), span),
         })
         .unzip()
 }


### PR DESCRIPTION
This seems to fix the assert in issue 473, however i'm marking this as draft because
for some reason the spans seem off by one when parsing the examples posted in that issue.
Strangely the spans are fine for the fuzzer minimized reproducer.  Should probably also add test cases etc.

I wonder if this could be due to comments?

The other thing is that after fixing the assertion, nimbleparse seems to return to taking forever to parse the file.
I believe that it might be caused by running error recovery, as I did see some error recovery output.

For some reason It isn't clear whether a mention of @mingodad will work, but he may want to try this patch.