### PR TITLE
Update to latest clippy

### DIFF
--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -340,8 +340,7 @@ where
                             &self
                                 .rules
                                 .iter()
-                                .filter(|x| x.name().is_some())
-                                .map(|x| x.name().unwrap())
+                                .filter_map(|x| x.name())
                                 .collect::<HashSet<&str>>(),
                         )
                         .cloned()

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -991,6 +991,7 @@ where
                         Symbol::Rule(ref_ridx) => {
                             write!(outs,
                             "
+        #[allow(clippy::let_unit_value)]
         let {prefix}arg_{i} = match {prefix}args.next().unwrap() {{
             ::lrpar::parser::AStackType::ActionType({actionskind}::{actionskindprefix}{ref_ridx}(x)) => x,
             _ => unreachable!()


### PR DESCRIPTION
With the ci failure in #485 I locally updated clippy/rustdoc, this was all I saw, but I'm uncertain if any of these changes correlate to the ci failures.

Perhaps I'm looking in the wrong place for failure output or doing something silly.