### PR TITLE
Add a `YaccKind::SelfDescribing` style.

### DIFF
--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -14,6 +14,7 @@ use crate::Span;
 /// Contains a `GrammarAST` structure produced from a grammar source file.
 /// As well as any errors which occurred during the construction of the AST.
 pub struct ASTWithValidityInfo {
+    yacc_kind: YaccKind,
     ast: GrammarAST,
     errs: Vec<YaccGrammarError>,
 }
@@ -25,14 +26,19 @@ impl ASTWithValidityInfo {
     /// `Ok(YaccGrammar)` or an `Err` which includes these errors.
     pub fn new(yacc_kind: YaccKind, s: &str) -> Self {
         let mut errs = Vec::new();
-        let ast = {
+        let (ast, yacc_kind) = {
             let mut yp = YaccParser::new(yacc_kind, s.to_string());
             yp.parse().map_err(|e| errs.extend(e)).ok();
+            let yacc_kind = yp.yacc_kind.clone();
             let mut ast = yp.ast();
             ast.complete_and_validate().map_err(|e| errs.push(e)).ok();
-            ast
+            (ast, yacc_kind)
         };
-        ASTWithValidityInfo { ast, errs }
+        ASTWithValidityInfo {
+            ast,
+            errs,
+            yacc_kind,
+        }
     }
 
     /// Returns a `GrammarAST` constructed as the result of parsing a source file.
@@ -52,6 +58,10 @@ impl ASTWithValidityInfo {
     /// Returns all errors which were encountered during AST construction.
     pub fn errors(&self) -> &[YaccGrammarError] {
         self.errs.as_slice()
+    }
+
+    pub fn yacc_kind(&self) -> &YaccKind {
+        &self.yacc_kind
     }
 }
 

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -29,8 +29,7 @@ impl ASTWithValidityInfo {
         let (ast, yacc_kind) = {
             let mut yp = YaccParser::new(yacc_kind, s.to_string());
             yp.parse().map_err(|e| errs.extend(e)).ok();
-            let yacc_kind = yp.yacc_kind.clone();
-            let mut ast = yp.ast();
+            let (yacc_kind, mut ast) = yp.finish();
             ast.complete_and_validate().map_err(|e| errs.push(e)).ok();
             (ast, yacc_kind)
         };

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -25,14 +25,12 @@ impl ASTWithValidityInfo {
     /// `Ok(YaccGrammar)` or an `Err` which includes these errors.
     pub fn new(yacc_kind: YaccKind, s: &str) -> Self {
         let mut errs = Vec::new();
-        let ast = match yacc_kind {
-            YaccKind::Original(_) | YaccKind::Grmtools | YaccKind::Eco => {
-                let mut yp = YaccParser::new(yacc_kind, s.to_string());
-                yp.parse().map_err(|e| errs.extend(e)).ok();
-                let mut ast = yp.ast();
-                ast.complete_and_validate().map_err(|e| errs.push(e)).ok();
-                ast
-            }
+        let ast = {
+            let mut yp = YaccParser::new(yacc_kind, s.to_string());
+            yp.parse().map_err(|e| errs.extend(e)).ok();
+            let mut ast = yp.ast();
+            ast.complete_and_validate().map_err(|e| errs.push(e)).ok();
+            ast
         };
         ASTWithValidityInfo { ast, errs }
     }

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -107,11 +107,10 @@ where
     /// user defined start rule.
     pub fn new_with_storaget(yacc_kind: YaccKind, s: &str) -> YaccGrammarResult<Self> {
         let ast_validation = ast::ASTWithValidityInfo::new(yacc_kind.clone(), s);
-        Self::new_from_ast_with_validity_info(yacc_kind, &ast_validation)
+        Self::new_from_ast_with_validity_info(&ast_validation)
     }
 
     pub fn new_from_ast_with_validity_info(
-        yacc_kind: YaccKind,
         ast_validation: &ast::ASTWithValidityInfo,
     ) -> YaccGrammarResult<Self> {
         if !ast_validation.is_valid() {
@@ -149,7 +148,7 @@ where
 
         let implicit_rule;
         let implicit_start_rule;
-        match yacc_kind {
+        match ast_validation.yacc_kind() {
             YaccKind::SelfDescribing(_) => {
                 unimplemented!("Concrete YaccKind must be known by this point")
             }

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -150,6 +150,9 @@ where
         let implicit_rule;
         let implicit_start_rule;
         match yacc_kind {
+            YaccKind::SelfDescribing => {
+                unimplemented!("Concrete YaccKind should be known by this point")
+            }
             YaccKind::Original(_) | YaccKind::Grmtools => {
                 implicit_rule = None;
                 implicit_start_rule = None;

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -151,7 +151,7 @@ where
         let implicit_start_rule;
         match yacc_kind {
             YaccKind::SelfDescribing(_) => {
-                unimplemented!("Concrete YaccKind should be known by this point")
+                unimplemented!("Concrete YaccKind must be known by this point")
             }
             YaccKind::Original(_) | YaccKind::Grmtools => {
                 implicit_rule = None;

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -106,7 +106,7 @@ where
     /// though the actual name is a fresh name that is guaranteed to be unique) that references the
     /// user defined start rule.
     pub fn new_with_storaget(yacc_kind: YaccKind, s: &str) -> YaccGrammarResult<Self> {
-        let ast_validation = ast::ASTWithValidityInfo::new(yacc_kind, s);
+        let ast_validation = ast::ASTWithValidityInfo::new(yacc_kind.clone(), s);
         Self::new_from_ast_with_validity_info(yacc_kind, &ast_validation)
     }
 
@@ -150,7 +150,7 @@ where
         let implicit_rule;
         let implicit_start_rule;
         match yacc_kind {
-            YaccKind::SelfDescribing => {
+            YaccKind::SelfDescribing(_) => {
                 unimplemented!("Concrete YaccKind should be known by this point")
             }
             YaccKind::Original(_) | YaccKind::Grmtools => {

--- a/cfgrammar/src/lib/yacc/mod.rs
+++ b/cfgrammar/src/lib/yacc/mod.rs
@@ -26,7 +26,8 @@ pub enum YaccKind {
     Grmtools,
     /// The variant used in the [Eco language composition editor](http://soft-dev.org/src/eco/)
     Eco,
-    /// A `SelfDescribing` grammar starts with an initial `%grmtools` directive specifying it's yacckind.
+    /// A `SelfDescribing` grammar starts with an initial `%grmtools` directive specifying it's
+    /// yacckind.
     ///
     /// For example:
     /// ``` yacc
@@ -35,6 +36,10 @@ pub enum YaccKind {
     /// }
     /// ...
     /// ```
+    ///
+    /// The `Option<Box<YaccKind>>` value if specified will be used as the default format.
+    /// If the default kind is `None` and the file does not specify a yacc kind produce a
+    /// `MissingYaccKind` error.
     SelfDescribing(Option<Box<YaccKind>>),
 }
 

--- a/cfgrammar/src/lib/yacc/mod.rs
+++ b/cfgrammar/src/lib/yacc/mod.rs
@@ -15,7 +15,7 @@ pub use self::{
 use serde::{Deserialize, Serialize};
 
 /// The particular Yacc variant this grammar makes use of.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum YaccKind {
     /// The original Yacc style as documented by
@@ -35,7 +35,7 @@ pub enum YaccKind {
     /// }
     /// ...
     /// ```
-    SelfDescribing,
+    SelfDescribing(Option<Box<YaccKind>>),
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/cfgrammar/src/lib/yacc/mod.rs
+++ b/cfgrammar/src/lib/yacc/mod.rs
@@ -26,6 +26,16 @@ pub enum YaccKind {
     Grmtools,
     /// The variant used in the [Eco language composition editor](http://soft-dev.org/src/eco/)
     Eco,
+    /// A `SelfDescribing` grammar starts with an initial `%grmtools` directive specifying it's yacckind.
+    ///
+    /// For example:
+    /// ``` yacc
+    /// %grmtools {
+    ///   yacckind Original(NoAction)
+    /// }
+    /// ...
+    /// ```
+    SelfDescribing,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -2815,7 +2815,11 @@ B";
         ];
         for yacc_src in srcs {
             parse(YaccKind::SelfDescribing(None), yacc_src).unwrap();
-            parse(YaccKind::SelfDescribing(Some(Box::new(YaccKind::SelfDescribing(None)))), yacc_src).unwrap();
+            parse(
+                YaccKind::SelfDescribing(Some(Box::new(YaccKind::SelfDescribing(None)))),
+                yacc_src,
+            )
+            .unwrap();
         }
 
         let fallback_srcs = [
@@ -2913,11 +2917,10 @@ B";
             1,
             1,
         );
-        parse(YaccKind::SelfDescribing(Some(Box::new(YaccKind::SelfDescribing(None)))), src).expect_error_at_line_col(
+        parse(
+            YaccKind::SelfDescribing(Some(Box::new(YaccKind::SelfDescribing(None)))),
             src,
-            YaccGrammarErrorKind::InvalidYaccKind,
-            1,
-            1,
-        );
+        )
+        .expect_error_at_line_col(src, YaccGrammarErrorKind::InvalidYaccKind, 1, 1);
     }
 }

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -2779,38 +2779,38 @@ B";
     fn test_self_describing_yacckind() {
         let srcs = [
             r#"%grmtools {
-  yacckind Original(NoAction)
-}
-%%
-S: "()";"#,
+                    yacckind Original(NoAction)
+               }
+               %%
+               S: "()";"#,
             r#"%grmtools { yacckind Original(NoAction) }
-%%
-S: "()";"#,
+               %%
+               S: "()";"#,
             r#"%grmtools {yacckind Original(NoAction)}
-%%
-S: "()";"#,
+               %%
+               S: "()";"#,
             r#"%grmtools
                {yacckind Original(NoAction)}
-%%
-S: "()";"#,
+               %%
+               S: "()";"#,
             r#"
-%grmtools {
-  yacckind Original(UserAction)
-}
-%%
-S: "()";"#,
+                %grmtools {
+                    yacckind Original(UserAction)
+                }
+                %%
+                S: "()";"#,
             r#"%grmtools {
-  yacckind Grmtools
-}
-%start S
-%%
-S -> (): "()" { () };"#,
+                    yacckind Grmtools
+               }
+               %start S
+               %%
+               S -> (): "()" { () };"#,
             r#"%grmtools {
-  yacckind grmtools
-}
-%start S
-%%
-S -> (): "()" { () };"#,
+                    yacckind grmtools
+               }
+               %start S
+               %%
+               S -> (): "()" { () };"#,
         ];
         for yacc_src in srcs {
             parse(YaccKind::SelfDescribing(None), yacc_src).unwrap();
@@ -2840,46 +2840,46 @@ S -> (): "()" { () };"#,
     #[test]
     fn test_self_describing_yacckind_errs() {
         let src = r#"%grmtools {
-invalid value
-}
-%%
-S: "()";"#;
+                                invalid value
+                           }
+                           %%
+                           S: "()";"#;
         parse(YaccKind::SelfDescribing(None), src).expect_error_at_line_col(
             src,
             YaccGrammarErrorKind::InvalidGrmtoolsHeaderKey,
             2,
-            1,
+            33,
         );
 
         let src = r#"%grmtools {
-yacckind Grmtools
-yacckind Grmtools
-}
-%%
-S: "()";"#;
+                                yacckind Grmtools
+                                yacckind Grmtools
+                           }
+                           %%
+                           S: "()";"#;
         parse(YaccKind::SelfDescribing(None), src).expect_error_at_lines_cols(
             src,
             YaccGrammarErrorKind::DuplicateGrmtoolsHeaderKey,
-            &mut [(2, 1), (3, 1)].into_iter(),
+            &mut [(2, 33), (3, 33)].into_iter(),
         );
 
         let src = r#"%grmtools {
-yacckind invalid_yacc_kind
-}
-%%
-S: "()";"#;
+                                yacckind invalid_yacc_kind
+                           }
+                           %%
+                           S: "()";"#;
         parse(YaccKind::SelfDescribing(None), src).expect_error_at_line_col(
             src,
             YaccGrammarErrorKind::InvalidYaccKind,
             2,
-            10,
+            42,
         );
         // Invalid brace after %grmtools [
         let src = r#"%grmtools [
-yacckind Grmtools
-}
-%%
-S: "()";"#;
+                                yacckind Grmtools
+                           }
+                           %%
+                           S: "()";"#;
         parse(YaccKind::SelfDescribing(None), src).expect_error_at_line_col(
             src,
             YaccGrammarErrorKind::MissingGrmtoolsHeader,
@@ -2889,8 +2889,8 @@ S: "()";"#;
 
         // Missing the %grmtools header entirely.
         let src = r#"%start S
-                     %%
-                     S: "()";"#;
+                           %%
+                           S: "()";"#;
 
         parse(YaccKind::SelfDescribing(None), src).expect_error_at_line_col(
             src,
@@ -2900,10 +2900,10 @@ S: "()";"#;
         );
         // Empty %grmtools header with no yacckind.
         let src = r#"%grmtools {
-                     }
-                     %start S
-                     %%
-                     S: "()";"#;
+                           }
+                           %start S
+                           %%
+                           S: "()";"#;
 
         parse(YaccKind::SelfDescribing(None), src).expect_error_at_line_col(
             src,

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -2783,6 +2783,12 @@ B";
 }
 %%
 S: "()";"#,
+            r#"%grmtools { yacckind Original(NoAction) }
+%%
+S: "()";"#,
+            r#"%grmtools {yacckind Original(NoAction)}
+%%
+S: "()";"#,
             r#"
 %grmtools {
   yacckind Original(UserAction)

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -374,14 +374,18 @@ impl YaccParser {
         }
     }
 
-    fn parse_yacckind(&mut self, i: usize, update_yacc_kind: bool) -> Result<usize, YaccGrammarError> {
+    fn parse_yacckind(
+        &mut self,
+        i: usize,
+        update_yacc_kind: bool,
+    ) -> Result<usize, YaccGrammarError> {
         // Compares haystack converted to lowercase to needle (assumed to be lowercase).
         fn starts_with_lower(needle: &'static str, haystack: &'_ str) -> bool {
-         if let Some((prefix, _)) = haystack.split_at_checked(needle.len()) {
-             prefix.to_lowercase() == needle
-         } else {
-            false
-         }
+            if let Some((prefix, _)) = haystack.split_at_checked(needle.len()) {
+                prefix.to_lowercase() == needle
+            } else {
+                false
+            }
         }
 
         const YACC_KINDS: [(&str, YaccKind); 5] = [
@@ -418,13 +422,14 @@ impl YaccParser {
 
     fn parse_grmtools_header(&mut self, mut i: usize) -> Result<usize, YaccGrammarError> {
         let mut yacc_kind_key_span = None;
-        let (update_yacc_kind, require_yacc_kind) = if let YaccKind::SelfDescribing(default) = &self.yacc_kind {
-            // 1. Override the self.yacc_kind with one in the header.
-            // 2. Throw an `MissingYaccKind` errors only if default.is_none().
-            (true, default.is_none())
-        } else {
-            (false, false)
-        };
+        let (update_yacc_kind, require_yacc_kind) =
+            if let YaccKind::SelfDescribing(default) = &self.yacc_kind {
+                // 1. Override the self.yacc_kind with one in the header.
+                // 2. Throw an `MissingYaccKind` errors only if default.is_none().
+                (true, default.is_none())
+            } else {
+                (false, false)
+            };
 
         i = self.parse_ws(i, true)?;
         if let Some(j) = self.lookahead_is("%grmtools", i) {
@@ -2801,20 +2806,25 @@ S -> (): "()" { () };"#,
             parse(YaccKind::SelfDescribing(None), yacc_src).unwrap();
         }
 
-      let fallback_srcs = [
-        r#"%start S
+        let fallback_srcs = [
+            r#"%start S
            %%
            S: "()";"#,
-        r#"%grmtools {
+            r#"%grmtools {
            }
            %start S
            %%
-           S: "()";"#
-      ];
-      for yacc_src in fallback_srcs {
-            parse(YaccKind::SelfDescribing(Some(Box::new(YaccKind::Original(YaccOriginalActionKind::NoAction)))), yacc_src).unwrap();
-      }
-
+           S: "()";"#,
+        ];
+        for yacc_src in fallback_srcs {
+            parse(
+                YaccKind::SelfDescribing(Some(Box::new(YaccKind::Original(
+                    YaccOriginalActionKind::NoAction,
+                )))),
+                yacc_src,
+            )
+            .unwrap();
+        }
     }
 
     #[test]

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -406,9 +406,9 @@ impl YaccParser {
         // invalid yacc kind value, but do not know the end, we could `self.parse_to_eol()`.
         Err(self.mk_error(YaccGrammarErrorKind::InvalidYaccKind, i))
     }
+
     fn parse_grmtools_header(&mut self, mut i: usize) -> Result<usize, YaccGrammarError> {
         let mut yacc_kind_key_span = None;
-        let mut _yacc_kind_val_span = None;
         let (update_yacc_kind, require_yacc_kind) = if let YaccKind::SelfDescribing(default) = &self.yacc_kind {
             // 1. Override the self.yacc_kind with one in the header.
             // 2. Throw an `MissingYaccKind` errors only if default.is_none().
@@ -427,9 +427,7 @@ impl YaccParser {
                     let (key_end_pos, key) = self.parse_name(i)?;
                     i = self.parse_ws(key_end_pos, false)?;
                     if key == "yacckind" {
-                        let val_start_pos = i;
                         let val_end_pos = self.parse_yacckind(i, update_yacc_kind)?;
-                        _yacc_kind_val_span = Some(Span::new(val_start_pos, val_end_pos));
                         if let Some(orig) = yacc_kind_key_span {
                             let dupe = Span::new(key_start_pos, key_end_pos);
                             return Err(YaccGrammarError {
@@ -748,7 +746,7 @@ impl YaccParser {
         }
         match self.yacc_kind {
             YaccKind::SelfDescribing(_) => {
-                unimplemented!("Concrete YaccKind should be known at this point")
+                unimplemented!("Concrete YaccKind must be known at this point")
             }
             YaccKind::Original(_) | YaccKind::Eco => {
                 if self.ast.get_rule(&rn).is_none() {
@@ -1135,7 +1133,6 @@ mod test {
     };
     use std::collections::HashSet;
 
-    #[track_caller]
     fn parse(yacc_kind: YaccKind, s: &str) -> Result<GrammarAST, Vec<YaccGrammarError>> {
         let mut yp = YaccParser::new(yacc_kind, s.to_string());
         yp.parse()?;
@@ -2804,6 +2801,7 @@ S -> (): "()" { () };"#,
       }
 
     }
+
     #[test]
     fn test_self_describing_yacckind_errs() {
         let src = r#"%grmtools {

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -375,18 +375,27 @@ impl YaccParser {
     }
 
     fn parse_yacckind(&mut self, i: usize, update_yacc_kind: bool) -> Result<usize, YaccGrammarError> {
+        // Compares haystack converted to lowercase to needle (assumed to be lowercase).
+        fn starts_with_lower(needle: &'static str, haystack: &'_ str) -> bool {
+         if let Some((prefix, _)) = haystack.split_at_checked(needle.len()) {
+             prefix.to_lowercase() == needle
+         } else {
+            false
+         }
+        }
+
         const YACC_KINDS: [(&str, YaccKind); 5] = [
-            ("Grmtools", YaccKind::Grmtools),
+            ("grmtools", YaccKind::Grmtools),
             (
-                "Original(NoAction)",
+                "original(noaction)",
                 YaccKind::Original(YaccOriginalActionKind::NoAction),
             ),
             (
-                "Original(UserAction)",
+                "original(useraction)",
                 YaccKind::Original(YaccOriginalActionKind::UserAction),
             ),
             (
-                "Original(GenericParseTree)",
+                "original(genericparsetree)",
                 YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
             ),
             ("Eco", YaccKind::Eco),
@@ -394,7 +403,7 @@ impl YaccParser {
         let j = self.parse_ws(i, false)?;
         let s = &self.src[i..];
         for (kind_name, kind) in YACC_KINDS {
-            if s.starts_with(kind_name) {
+            if starts_with_lower(kind_name, s) {
                 if update_yacc_kind {
                     self.yacc_kind = kind;
                 }
@@ -2777,6 +2786,12 @@ S: "()";"#,
 S: "()";"#,
             r#"%grmtools {
   yacckind Grmtools
+}
+%start S
+%%
+S -> (): "()" { () };"#,
+            r#"%grmtools {
+  yacckind grmtools
 }
 %start S
 %%

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -273,7 +273,7 @@ impl Spanned for YaccGrammarError {
 }
 
 pub(crate) struct YaccParser {
-    pub(crate) yacc_kind: YaccKind,
+    yacc_kind: YaccKind,
     src: String,
     num_newlines: usize,
     ast: GrammarAST,
@@ -472,8 +472,8 @@ impl YaccParser {
         Ok(i)
     }
 
-    pub(crate) fn ast(self) -> GrammarAST {
-        self.ast
+    pub(crate) fn finish(self) -> (YaccKind, GrammarAST) {
+        (self.yacc_kind, self.ast)
     }
 
     fn parse_declarations(
@@ -1147,7 +1147,7 @@ mod test {
     fn parse(yacc_kind: YaccKind, s: &str) -> Result<GrammarAST, Vec<YaccGrammarError>> {
         let mut yp = YaccParser::new(yacc_kind, s.to_string());
         yp.parse()?;
-        Ok(yp.ast())
+        Ok(yp.finish().1)
     }
 
     fn rule(n: &str) -> Symbol {

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -409,14 +409,9 @@ impl YaccParser {
     fn parse_grmtools_header(&mut self, mut i: usize) -> Result<usize, YaccGrammarError> {
         let mut yacc_kind_key_span = None;
         let mut _yacc_kind_val_span = None;
-        // Benign changes the behavior such that when false
-        // 1. The `%grmtools` section is required.
-        // 2. The `yacckind` key in the `%grmtools` section will override `self.yacc_kind`.
-        //
-        // The gist is that for all `YaccKind` other than `SelfDescribing` `%grmtools`
-        // optional and yacckinds within it are overridden by the value passed
-        // to the constructor. But it is still a valid directive for all `YaccKind` variants.
         let (update_yacc_kind, require_yacc_kind) = if let YaccKind::SelfDescribing(default) = &self.yacc_kind {
+            // 1. Override the self.yacc_kind with one in the header.
+            // 2. Throw an `MissingYaccKind` errors only if default.is_none().
             (true, default.is_none())
         } else {
             (false, false)

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -273,7 +273,7 @@ impl Spanned for YaccGrammarError {
 }
 
 pub(crate) struct YaccParser {
-    yacc_kind: YaccKind,
+    pub(crate) yacc_kind: YaccKind,
     src: String,
     num_newlines: usize,
     ast: GrammarAST,
@@ -463,17 +463,13 @@ impl YaccParser {
                 if let Some(i) = self.lookahead_is("}", i) {
                     return Ok(i);
                 }
-            } else {
-                if require_yacc_kind {
-                    return Err(self.mk_error(YaccGrammarErrorKind::MissingGrmtoolsHeader, i));
-                }
-            }
-        } else {
-            if require_yacc_kind {
+            } else if require_yacc_kind {
                 return Err(self.mk_error(YaccGrammarErrorKind::MissingGrmtoolsHeader, i));
             }
+        } else if require_yacc_kind {
+            return Err(self.mk_error(YaccGrammarErrorKind::MissingGrmtoolsHeader, i));
         }
-        return Ok(i);
+        Ok(i)
     }
 
     pub(crate) fn ast(self) -> GrammarAST {

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -433,7 +433,7 @@ impl YaccParser {
 
         i = self.parse_ws(i, true)?;
         if let Some(j) = self.lookahead_is("%grmtools", i) {
-            i = self.parse_ws(j, false)?;
+            i = self.parse_ws(j, true)?;
             if let Some(j) = self.lookahead_is("{", i) {
                 i = self.parse_ws(j, true)?;
                 while self.lookahead_is("}", i).is_none() {
@@ -2787,6 +2787,10 @@ S: "()";"#,
 %%
 S: "()";"#,
             r#"%grmtools {yacckind Original(NoAction)}
+%%
+S: "()";"#,
+            r#"%grmtools
+               {yacckind Original(NoAction)}
 %%
 S: "()";"#,
             r#"

--- a/lrpar/examples/calc_actions/src/calc.y
+++ b/lrpar/examples/calc_actions/src/calc.y
@@ -1,3 +1,7 @@
+%grmtools {
+  yacckind Grmtools
+}
+
 %start Expr
 %avoid_insert "INT"
 %%

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -400,8 +400,8 @@ where
             .output_path
             .as_ref()
             .expect("output_path must be specified before processing.");
-        let yk = match self.yacckind {
-            Some(YaccKind::SelfDescribing) | None => {
+        let yk = match self.yacckind.clone() {
+            Some(YaccKind::SelfDescribing(_)) | None => {
                 panic!("yacckind must be specified before processing.")
             }
             Some(YaccKind::Original(x)) => YaccKind::Original(x),
@@ -419,7 +419,7 @@ where
 
         let inc =
             read_to_string(grmp).map_err(|e| format!("When reading '{}': {e}", grmp.display()))?;
-        let ast_validation = ASTWithValidityInfo::new(yk, &inc);
+        let ast_validation = ASTWithValidityInfo::new(yk.clone(), &inc);
         let warnings = ast_validation.ast().warnings();
         let spanned_fmt = |x: &dyn Spanned, inc: &str, line_cache: &NewlineCache| {
             if let Some((line, column)) =
@@ -658,7 +658,7 @@ where
             output_path: self.output_path.clone(),
             mod_name: self.mod_name,
             recoverer: self.recoverer,
-            yacckind: self.yacckind,
+            yacckind: self.yacckind.clone(),
             error_on_conflicts: self.error_on_conflicts,
             warnings_are_errors: self.warnings_are_errors,
             show_warnings: self.show_warnings,
@@ -698,7 +698,7 @@ where
         outs.push_str(&self.gen_parse_function(grm, stable)?);
         outs.push_str(&self.gen_rule_consts(grm));
         outs.push_str(&self.gen_token_epp(grm));
-        match self.yacckind.unwrap() {
+        match self.yacckind.clone().unwrap() {
             YaccKind::Original(YaccOriginalActionKind::UserAction) | YaccKind::Grmtools => {
                 outs.push_str(&self.gen_wrappers(grm));
             }
@@ -773,8 +773,8 @@ where
         serialize_bin_output(grm, GRM_CONST_NAME, &mut outs)?;
         serialize_bin_output(stable, STABLE_CONST_NAME, &mut outs)?;
 
-        match self.yacckind.unwrap() {
-            YaccKind::SelfDescribing => {
+        match self.yacckind.clone().unwrap() {
+            YaccKind::SelfDescribing(_) => {
                 unimplemented!("Concrete YaccKind should be known at this point")
             }
             YaccKind::Original(YaccOriginalActionKind::UserAction) | YaccKind::Grmtools => {
@@ -837,8 +837,8 @@ where
             RecoveryKind::CPCTPlus => "CPCTPlus",
             RecoveryKind::None => "None",
         };
-        match self.yacckind.unwrap() {
-            YaccKind::SelfDescribing => {
+        match self.yacckind.clone().unwrap() {
+            YaccKind::SelfDescribing(_) => {
                 unimplemented!("Concrete YaccKind should be known at this point")
             }
             YaccKind::Original(YaccOriginalActionKind::UserAction) | YaccKind::Grmtools => {

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -401,9 +401,8 @@ where
             .as_ref()
             .expect("output_path must be specified before processing.");
         let yk = match self.yacckind.clone() {
-            Some(YaccKind::SelfDescribing(_)) | None => {
-                panic!("yacckind must be specified before processing.")
-            }
+            None => YaccKind::SelfDescribing(None),
+            Some(YaccKind::SelfDescribing(default)) => YaccKind::SelfDescribing(default),
             Some(YaccKind::Original(x)) => YaccKind::Original(x),
             Some(YaccKind::Grmtools) => YaccKind::Grmtools,
             Some(YaccKind::Eco) => panic!("Eco compile-time grammar generation not supported."),

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -402,10 +402,8 @@ where
             .expect("output_path must be specified before processing.");
         let yk = match self.yacckind.clone() {
             None => YaccKind::SelfDescribing(None),
-            Some(YaccKind::SelfDescribing(default)) => YaccKind::SelfDescribing(default),
-            Some(YaccKind::Original(x)) => YaccKind::Original(x),
-            Some(YaccKind::Grmtools) => YaccKind::Grmtools,
             Some(YaccKind::Eco) => panic!("Eco compile-time grammar generation not supported."),
+            Some(x) => x,
         };
 
         {

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -775,7 +775,7 @@ where
 
         match self.yacckind.clone().unwrap() {
             YaccKind::SelfDescribing(_) => {
-                unimplemented!("Concrete YaccKind should be known at this point")
+                unimplemented!("Concrete YaccKind must be known at this point")
             }
             YaccKind::Original(YaccOriginalActionKind::UserAction) | YaccKind::Grmtools => {
                 let parse_param = match grm.parse_param() {
@@ -839,7 +839,7 @@ where
         };
         match self.yacckind.clone().unwrap() {
             YaccKind::SelfDescribing(_) => {
-                unimplemented!("Concrete YaccKind should be known at this point")
+                unimplemented!("Concrete YaccKind must be known at this point")
             }
             YaccKind::Original(YaccOriginalActionKind::UserAction) | YaccKind::Grmtools => {
                 // action function references

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -391,7 +391,7 @@ where
     /// # Panics
     ///
     /// If `StorageT` is not big enough to index the grammar's tokens, rules, or productions.
-    pub fn build(self) -> Result<CTParser<StorageT>, Box<dyn Error>> {
+    pub fn build(mut self) -> Result<CTParser<StorageT>, Box<dyn Error>> {
         let grmp = self
             .grammar_path
             .as_ref()
@@ -417,6 +417,7 @@ where
         let inc =
             read_to_string(grmp).map_err(|e| format!("When reading '{}': {e}", grmp.display()))?;
         let ast_validation = ASTWithValidityInfo::new(yk.clone(), &inc);
+        self.yacckind = Some(ast_validation.yacc_kind().clone());
         let warnings = ast_validation.ast().warnings();
         let spanned_fmt = |x: &dyn Spanned, inc: &str, line_cache: &NewlineCache| {
             if let Some((line, column)) =

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -428,7 +428,7 @@ where
             }
         };
 
-        let res = YaccGrammar::<StorageT>::new_from_ast_with_validity_info(yk, &ast_validation);
+        let res = YaccGrammar::<StorageT>::new_from_ast_with_validity_info(&ast_validation);
         let grm = match res {
             Ok(_) if self.warnings_are_errors && !warnings.is_empty() => {
                 let mut line_cache = NewlineCache::new();

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -401,7 +401,9 @@ where
             .as_ref()
             .expect("output_path must be specified before processing.");
         let yk = match self.yacckind {
-            None => panic!("yacckind must be specified before processing."),
+            Some(YaccKind::SelfDescribing) | None => {
+                panic!("yacckind must be specified before processing.")
+            }
             Some(YaccKind::Original(x)) => YaccKind::Original(x),
             Some(YaccKind::Grmtools) => YaccKind::Grmtools,
             Some(YaccKind::Eco) => panic!("Eco compile-time grammar generation not supported."),
@@ -772,6 +774,9 @@ where
         serialize_bin_output(stable, STABLE_CONST_NAME, &mut outs)?;
 
         match self.yacckind.unwrap() {
+            YaccKind::SelfDescribing => {
+                unimplemented!("Concrete YaccKind should be known at this point")
+            }
             YaccKind::Original(YaccOriginalActionKind::UserAction) | YaccKind::Grmtools => {
                 let parse_param = match grm.parse_param() {
                     Some((name, tyname)) => format!(", {}: {}", name, tyname),
@@ -833,6 +838,9 @@ where
             RecoveryKind::None => "None",
         };
         match self.yacckind.unwrap() {
+            YaccKind::SelfDescribing => {
+                unimplemented!("Concrete YaccKind should be known at this point")
+            }
             YaccKind::Original(YaccOriginalActionKind::UserAction) | YaccKind::Grmtools => {
                 // action function references
                 let wrappers = grm

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -1002,7 +1002,7 @@ D : D;
 S: S | ;";
         let yk = YaccKind::Original(YaccOriginalActionKind::NoAction);
         let ast_validity = ASTWithValidityInfo::new(yk.clone(), src);
-        let grm = YaccGrammar::<u32>::new_from_ast_with_validity_info(yk, &ast_validity).unwrap();
+        let grm = YaccGrammar::<u32>::new_from_ast_with_validity_info(&ast_validity).unwrap();
         let sg = pager_stategraph(&grm);
         match StateTable::new(&grm, &sg) {
             Ok(_) => panic!("Expected accept reduce conflict"),
@@ -1054,7 +1054,7 @@ S: T | ;
 T: S | ;";
         let yk = YaccKind::Original(YaccOriginalActionKind::NoAction);
         let ast_validity = ASTWithValidityInfo::new(yk.clone(), src);
-        let grm = YaccGrammar::<u32>::new_from_ast_with_validity_info(yk, &ast_validity).unwrap();
+        let grm = YaccGrammar::<u32>::new_from_ast_with_validity_info(&ast_validity).unwrap();
         let sg = pager_stategraph(&grm);
         match StateTable::new(&grm, &sg) {
             Ok(_) => panic!("Expected accept reduce conflict"),

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -1001,7 +1001,7 @@ D : D;
         let src = "%%
 S: S | ;";
         let yk = YaccKind::Original(YaccOriginalActionKind::NoAction);
-        let ast_validity = ASTWithValidityInfo::new(yk, src);
+        let ast_validity = ASTWithValidityInfo::new(yk.clone(), src);
         let grm = YaccGrammar::<u32>::new_from_ast_with_validity_info(yk, &ast_validity).unwrap();
         let sg = pager_stategraph(&grm);
         match StateTable::new(&grm, &sg) {
@@ -1053,7 +1053,7 @@ S: S | ;";
 S: T | ;
 T: S | ;";
         let yk = YaccKind::Original(YaccOriginalActionKind::NoAction);
-        let ast_validity = ASTWithValidityInfo::new(yk, src);
+        let ast_validity = ASTWithValidityInfo::new(yk.clone(), src);
         let grm = YaccGrammar::<u32>::new_from_ast_with_validity_info(yk, &ast_validity).unwrap();
         let sg = pager_stategraph(&grm);
         match StateTable::new(&grm, &sg) {

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -123,7 +123,7 @@ fn main() {
     };
 
     let yacckind = match matches.opt_str("y") {
-        None => YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+        None => YaccKind::SelfDescribing(Some(Box::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)))),
         Some(s) => match &*s.to_lowercase() {
             "eco" => YaccKind::Eco,
             "grmtools" => YaccKind::Grmtools,
@@ -152,7 +152,7 @@ fn main() {
 
     let yacc_y_path = PathBuf::from(&matches.free[1]);
     let yacc_src = read_file(&yacc_y_path);
-    let ast_validation = ASTWithValidityInfo::new(yacckind, &yacc_src);
+    let ast_validation = ASTWithValidityInfo::new(yacckind.clone(), &yacc_src);
     let warnings = ast_validation.ast().warnings();
     let res = YaccGrammar::new_from_ast_with_validity_info(yacckind, &ast_validation);
     let mut yacc_diagnostic_formatter: Option<SpannedDiagnosticFormatter> = None;

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -123,7 +123,9 @@ fn main() {
     };
 
     let yacckind = match matches.opt_str("y") {
-        None => YaccKind::SelfDescribing(Some(Box::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)))),
+        None => YaccKind::SelfDescribing(Some(Box::new(YaccKind::Original(
+            YaccOriginalActionKind::GenericParseTree,
+        )))),
         Some(s) => match &*s.to_lowercase() {
             "eco" => YaccKind::Eco,
             "grmtools" => YaccKind::Grmtools,

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -156,7 +156,7 @@ fn main() {
     let yacc_src = read_file(&yacc_y_path);
     let ast_validation = ASTWithValidityInfo::new(yacckind.clone(), &yacc_src);
     let warnings = ast_validation.ast().warnings();
-    let res = YaccGrammar::new_from_ast_with_validity_info(yacckind, &ast_validation);
+    let res = YaccGrammar::new_from_ast_with_validity_info(&ast_validation);
     let mut yacc_diagnostic_formatter: Option<SpannedDiagnosticFormatter> = None;
     let grm = match res {
         Ok(x) => {


### PR DESCRIPTION
I belive this should implement what we discussed in #349 for lrpar (It doesn't try to tackle lrlex yet)
I'm still not certain I like the syntax but it seemed not worth worrying about until I got something working at least.

---

This allows the yacckind value to be specified within a grammar. When using the `YaccKind::SelfDescribing` style the grammar must start with an initial `%grmtools` section, as documented in the variant.

For other `YaccKind` variants the `%grmtools` section is allowed (not required) and the `YaccKind` value given to `YaccGrammar::new` overrides one given in the `%grmtools` section.

Fixes #349