### PR TITLE
Change YaccKind parameters to a new `YaccKindResolver` type

### DIFF
--- a/cfgrammar/src/lib/yacc/firsts.rs
+++ b/cfgrammar/src/lib/yacc/firsts.rs
@@ -9,7 +9,7 @@ use crate::{RIdx, Symbol, TIdx};
 /// `Firsts` stores all the first sets for a given grammar. For example, given this code and
 /// grammar:
 /// ```text
-///   let grm = YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), "
+///   let grm = YaccGrammar::new(YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)), "
 ///     S: A 'b';
 ///     A: 'a'
 ///      | ;").unwrap();
@@ -143,7 +143,7 @@ where
 #[cfg(test)]
 mod test {
     use super::{
-        super::{YaccGrammar, YaccKind, YaccOriginalActionKind},
+        super::{YaccGrammar, YaccKind, YaccKindResolver, YaccOriginalActionKind},
         YaccFirsts,
     };
     use num_traits::{AsPrimitive, PrimInt, Unsigned};
@@ -180,7 +180,7 @@ mod test {
     #[test]
     fn test_first() {
         let grm = YaccGrammar::new(
-            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
           %start C
           %token c d
@@ -202,7 +202,7 @@ mod test {
     #[test]
     fn test_first_no_subsequent_rules() {
         let grm = YaccGrammar::new(
-            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
           %start C
           %token c d
@@ -220,7 +220,7 @@ mod test {
     #[test]
     fn test_first_epsilon() {
         let grm = YaccGrammar::new(
-            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
           %start A
           %token a b c
@@ -241,7 +241,7 @@ mod test {
     #[test]
     fn test_last_epsilon() {
         let grm = YaccGrammar::new(
-            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
           %start A
           %token b c
@@ -261,7 +261,7 @@ mod test {
     #[test]
     fn test_first_no_multiples() {
         let grm = YaccGrammar::new(
-            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
           %start A
           %token b c
@@ -277,7 +277,7 @@ mod test {
 
     fn eco_grammar() -> YaccGrammar {
         YaccGrammar::new(
-            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
           %start S
           %token a b c d f
@@ -308,7 +308,7 @@ mod test {
     #[test]
     fn test_first_from_eco_bug() {
         let grm = YaccGrammar::new(
-            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
           %start E
           %token a b c d e f

--- a/cfgrammar/src/lib/yacc/follows.rs
+++ b/cfgrammar/src/lib/yacc/follows.rs
@@ -9,7 +9,7 @@ use crate::{RIdx, Symbol, TIdx};
 /// `Follows` stores all the Follow sets for a given grammar. For example, given this code and
 /// grammar:
 /// ```text
-///   let grm = YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), "
+///   let grm = YaccGrammar::new(YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)), "
 ///       S: A 'b';
 ///       A: 'a' | ;
 ///     ").unwrap();
@@ -115,7 +115,7 @@ where
 #[cfg(test)]
 mod test {
     use super::{
-        super::{YaccGrammar, YaccKind, YaccOriginalActionKind},
+        super::{YaccGrammar, YaccKind, YaccKindResolver, YaccOriginalActionKind},
         YaccFollows,
     };
     use num_traits::{AsPrimitive, PrimInt, Unsigned};
@@ -149,7 +149,7 @@ mod test {
     fn test_follow() {
         // Adapted from p2 of https://www.cs.uaf.edu/~cs331/notes/FirstFollow.pdf
         let grm = YaccGrammar::new(
-            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
                 %start E
                 %%
@@ -173,7 +173,7 @@ mod test {
     fn test_follow2() {
         // Adapted from https://www.l2f.inesc-id.pt/~david/w/pt/Top-Down_Parsing/Exercise_5:_Test_2010/07/01
         let grm = YaccGrammar::new(
-            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
                 %start A
                 %%
@@ -196,7 +196,7 @@ mod test {
     #[test]
     fn test_follow3() {
         let grm = YaccGrammar::new(
-            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
                 %start S
                 %%
@@ -213,7 +213,7 @@ mod test {
     #[test]
     fn test_follow_corchuelo() {
         let grm = YaccGrammar::new(
-            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
                 %start E
                 %%

--- a/cfgrammar/src/lib/yacc/mod.rs
+++ b/cfgrammar/src/lib/yacc/mod.rs
@@ -14,6 +14,17 @@ pub use self::{
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum YaccKindResolver {
+    /// The user can specify `%grmtools` in their grammar but unless it is compatible with this `YaccKind`, it's an error
+    Force(YaccKind),
+    /// Use `YaccKind` if the user doesn't specify `%grmtools` in their grammar
+    Default(YaccKind),
+    /// The user must specify `%grmtools` in their grammars or we throw an error
+    NoDefault,
+}
+
 /// The particular Yacc variant this grammar makes use of.
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/lrpar/cttests/src/calc_nodefault_yacckind.test
+++ b/lrpar/cttests/src/calc_nodefault_yacckind.test
@@ -1,0 +1,39 @@
+name: Test basic user actions using the calculator grammar
+grammar: |
+    %grmtools {yacckind Original(UserAction)}
+    %start Expr
+    %actiontype Result<u64, ()>
+    %avoid_insert 'INT'
+    %%
+    Expr: Expr '+' Term { Ok($1? + $3?) }
+        | Term { $1 }
+        ;
+
+    Term: Term '*' Factor { Ok($1? * $3?) }
+        | Factor { $1 }
+        ;
+
+    Factor: '(' Expr ')' { $2 }
+          | 'INT' {
+                let l = $1.map_err(|_| ())?;
+                match $lexer.span_str(l.span()).parse::<u64>() {
+                    Ok(v) => Ok(v),
+                    Err(_) => {
+                        let ((_, col), _) = $lexer.line_col(l.span());
+                        eprintln!("Error at column {}: '{}' cannot be represented as a u64",
+                                  col,
+                                  $lexer.span_str(l.span()));
+                        Err(())
+                    }
+                }
+            }
+          ;
+
+lexer: |
+    %%
+    [0-9]+ "INT"
+    \+ "+"
+    \* "*"
+    \( "("
+    \) ")"
+    [\t ]+ ;

--- a/lrpar/cttests/src/cgen_helper.rs
+++ b/lrpar/cttests/src/cgen_helper.rs
@@ -18,18 +18,19 @@ pub(crate) fn run_test_path<P: AsRef<Path>>(path: P) -> Result<(), Box<dyn std::
         let docs = YamlLoader::load_from_str(&s).unwrap();
         let grm = &docs[0]["grammar"].as_str().unwrap();
         let lex = &docs[0]["lexer"].as_str().unwrap();
-        let yacckind = match docs[0]["yacckind"].as_str().unwrap() {
-            "Original(YaccOriginalActionKind::NoAction)" => {
-                YaccKind::Original(YaccOriginalActionKind::NoAction)
+        let yacckind = match docs[0]["yacckind"].as_str() {
+            Some("Original(YaccOriginalActionKind::NoAction)") => {
+                Some(YaccKind::Original(YaccOriginalActionKind::NoAction))
             }
-            "Original(YaccOriginalActionKind::UserAction)" => {
-                YaccKind::Original(YaccOriginalActionKind::UserAction)
+            Some("Original(YaccOriginalActionKind::UserAction)") => {
+                Some(YaccKind::Original(YaccOriginalActionKind::UserAction))
             }
-            "Grmtools" => YaccKind::Grmtools,
-            "Original(YaccOriginalActionKind::GenericParseTree)" => {
-                YaccKind::Original(YaccOriginalActionKind::GenericParseTree)
+            Some("Grmtools") => Some(YaccKind::Grmtools),
+            Some("Original(YaccOriginalActionKind::GenericParseTree)") => {
+                Some(YaccKind::Original(YaccOriginalActionKind::GenericParseTree))
             }
-            s => panic!("YaccKind '{}' not supported", s),
+            Some(s) => panic!("YaccKind '{}' not supported", s),
+            None => None,
         };
         let (negative_yacc_flags, positive_yacc_flags) = &docs[0]["yacc_flags"]
             .as_vec()
@@ -88,8 +89,11 @@ pub(crate) fn run_test_path<P: AsRef<Path>>(path: P) -> Result<(), Box<dyn std::
         let mut outp = PathBuf::from(&out_dir);
         outp.push(format!("{}.y.rs", base));
         outp.set_extension("rs");
-        let mut cp_build = CTParserBuilder::<DefaultLexerTypes<u32>>::new()
-            .yacckind(yacckind)
+        let mut cp_build = CTParserBuilder::<DefaultLexerTypes<u32>>::new();
+        if let Some(yacckind) = yacckind {
+            cp_build = cp_build.yacckind(yacckind);
+        }
+        cp_build = cp_build
             .grammar_path(pg.to_str().unwrap())
             .output_path(&outp);
         if let Some(flag) = check_flag(yacc_flags, "error_on_conflicts") {

--- a/lrpar/cttests/src/lib.rs
+++ b/lrpar/cttests/src/lib.rs
@@ -19,6 +19,9 @@ lrpar_mod!("calc_actiontype.y");
 lrlex_mod!("calc_noactions.l");
 lrpar_mod!("calc_noactions.y");
 
+lrlex_mod!("calc_nodefault_yacckind.l");
+lrpar_mod!("calc_nodefault_yacckind.y");
+
 lrlex_mod!("calc_unsafeaction.l");
 lrpar_mod!("calc_unsafeaction.y");
 
@@ -75,6 +78,15 @@ fn test_basic_actions() {
     }
 }
 
+#[test]
+fn test_nodefault_yacckind() {
+    let lexerdef = calc_nodefault_yacckind_l::lexerdef();
+    let lexer = lexerdef.lexer("2+3");
+    match calc_nodefault_yacckind_y::parse(&lexer) {
+        (Some(Ok(5)), ref errs) if errs.is_empty() => (),
+        _ => unreachable!(),
+    }
+}
 #[test]
 fn test_unsafe_actions() {
     let lexerdef = calc_unsafeaction_l::lexerdef();

--- a/lrpar/examples/calc_actions/src/calc.y
+++ b/lrpar/examples/calc_actions/src/calc.y
@@ -1,3 +1,6 @@
+%grmtools {
+  yacckind Grmtools
+}
 %start Expr
 %avoid_insert "INT"
 %%

--- a/lrpar/examples/calc_parsetree/src/calc.y
+++ b/lrpar/examples/calc_parsetree/src/calc.y
@@ -1,3 +1,4 @@
+%grmtools{yacckind Original(GenericParseTree)}
 %start Expr
 %avoid_insert "INT"
 %%

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -954,7 +954,7 @@ pub(crate) mod test {
     use std::collections::HashMap;
 
     use cfgrammar::{
-        yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
+        yacc::{YaccGrammar, YaccKind, YaccKindResolver, YaccOriginalActionKind},
         Span,
     };
     use lrtable::{from_yacc, Minimiser};
@@ -1004,7 +1004,7 @@ pub(crate) mod test {
         >,
     ) {
         let grm = YaccGrammar::<u16>::new_with_storaget(
-            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             grms,
         )
         .unwrap();

--- a/lrtable/src/lib/itemset.rs
+++ b/lrtable/src/lib/itemset.rs
@@ -159,7 +159,7 @@ where
 #[cfg(test)]
 mod test {
     use cfgrammar::{
-        yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
+        yacc::{YaccGrammar, YaccKind, YaccKindResolver, YaccOriginalActionKind},
         SIdx, Symbol,
     };
     use vob::Vob;
@@ -172,7 +172,7 @@ mod test {
     fn test_dragon_grammar() {
         // From http://binarysculpting.com/2012/02/04/computing-lr1-closure/
         let grm = YaccGrammar::new(
-            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
           %start S
           %%
@@ -200,7 +200,7 @@ mod test {
 
     fn eco_grammar() -> YaccGrammar {
         YaccGrammar::new(
-            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
           %start S
           %token a b c d f
@@ -251,7 +251,7 @@ mod test {
     //     aSb
     fn grammar3() -> YaccGrammar {
         YaccGrammar::new(
-            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
           %start S
           %token a b c d

--- a/lrtable/src/lib/pager.rs
+++ b/lrtable/src/lib/pager.rs
@@ -400,7 +400,7 @@ mod test {
 
     use crate::{pager::pager_stategraph, stategraph::state_exists, StIdx};
     use cfgrammar::{
-        yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
+        yacc::{YaccGrammar, YaccKind, YaccKindResolver, YaccOriginalActionKind},
         SIdx, Symbol,
     };
 
@@ -440,7 +440,7 @@ mod test {
     //     aSb
     fn grammar3() -> YaccGrammar {
         YaccGrammar::new(
-            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
           %start S
           %token a b c d
@@ -519,7 +519,7 @@ mod test {
     // Pager grammar
     fn grammar_pager() -> YaccGrammar {
         YaccGrammar::new(
-            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
             %start X
             %%

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -250,7 +250,7 @@ pub(crate) fn state_exists<StorageT: 'static + Hash + PrimInt + Unsigned>(
 mod test {
     use crate::{pager::pager_stategraph, StIdx};
     use cfgrammar::{
-        yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
+        yacc::{YaccGrammar, YaccKind, YaccKindResolver, YaccOriginalActionKind},
         Symbol,
     };
 
@@ -259,7 +259,7 @@ mod test {
     fn test_statetable_core() {
         // Taken from p13 of https://link.springer.com/article/10.1007/s00236-010-0115-6
         let grm = YaccGrammar::new(
-            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
             %start A
             %%

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -600,7 +600,7 @@ mod test {
     use cfgrammar::{
         yacc::{
             ast::{self, ASTWithValidityInfo},
-            YaccGrammar, YaccKind, YaccOriginalActionKind,
+            YaccGrammar, YaccKind, YaccKindResolver, YaccOriginalActionKind,
         },
         PIdx, Span, Symbol, TIdx,
     };
@@ -611,7 +611,7 @@ mod test {
     fn test_statetable() {
         // Taken from p19 of www.cs.umd.edu/~mvz/cmsc430-s07/M10lr.pdf
         let grm = YaccGrammar::new(
-            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
             %start Expr
             %%
@@ -692,7 +692,7 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_default_reduce_reduce() {
-        let grm = YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), "
+        let grm = YaccGrammar::new(YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)), "
             %start A
             %%
             A : B 'x' | C 'x' 'x';
@@ -716,7 +716,7 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_default_shift_reduce() {
-        let grm = YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), "
+        let grm = YaccGrammar::new(YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)), "
             %start Expr
             %%
             Expr : Expr '+' Expr
@@ -746,7 +746,7 @@ mod test {
     #[rustfmt::skip]
     fn test_conflict_resolution() {
         // Example taken from p54 of Locally least-cost error repair in LR parsers, Carl Cerecke
-        let grm = YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), "
+        let grm = YaccGrammar::new(YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)), "
             %start S
             %%
             S: A 'c' 'd'
@@ -771,7 +771,7 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_left_associativity() {
-        let grm = YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), "
+        let grm = YaccGrammar::new(YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)), "
             %start Expr
             %left '+'
             %left '*'
@@ -810,7 +810,7 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_left_right_associativity() {
-        let grm = &YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), "
+        let grm = &YaccGrammar::new(YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)), "
             %start Expr
             %right '='
             %left '+'
@@ -866,7 +866,7 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_left_right_nonassoc_associativity() {
-        let grm = YaccGrammar::new(YaccKind::Original(YaccOriginalActionKind::GenericParseTree), "
+        let grm = YaccGrammar::new(YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)), "
             %start Expr
             %right '='
             %left '+'
@@ -941,7 +941,7 @@ mod test {
     #[test]
     fn conflicts() {
         let grm = YaccGrammar::new(
-            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
 %start A
 %%
@@ -977,7 +977,7 @@ C : 'a';
     #[test]
     fn accept_reduce_conflict() {
         let grm = YaccGrammar::new(
-            YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
 %start D
 %%
@@ -1000,9 +1000,9 @@ D : D;
     fn test_accept_reduce_conflict_spans1() {
         let src = "%%
 S: S | ;";
-        let yk = YaccKind::Original(YaccOriginalActionKind::NoAction);
+        let yk = YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::NoAction));
         let ast_validity = ASTWithValidityInfo::new(yk, src);
-        let grm = YaccGrammar::<u32>::new_from_ast_with_validity_info(yk, &ast_validity).unwrap();
+        let grm = YaccGrammar::<u32>::new_from_ast_with_validity_info(&ast_validity).unwrap();
         let sg = pager_stategraph(&grm);
         match StateTable::new(&grm, &sg) {
             Ok(_) => panic!("Expected accept reduce conflict"),
@@ -1052,9 +1052,9 @@ S: S | ;";
         let src = "%%
 S: T | ;
 T: S | ;";
-        let yk = YaccKind::Original(YaccOriginalActionKind::NoAction);
+        let yk = YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::NoAction));
         let ast_validity = ASTWithValidityInfo::new(yk, src);
-        let grm = YaccGrammar::<u32>::new_from_ast_with_validity_info(yk, &ast_validity).unwrap();
+        let grm = YaccGrammar::<u32>::new_from_ast_with_validity_info(&ast_validity).unwrap();
         let sg = pager_stategraph(&grm);
         match StateTable::new(&grm, &sg) {
             Ok(_) => panic!("Expected accept reduce conflict"),


### PR DESCRIPTION
Here is take two on my previous PR #491 

Had to slightly rush to get this out the door, as there is a possibility I may not be able to work on this or respond for a few days but hopefully nothing has been overlooked.

I did slightly relax the documentation string for `YaccKindResolver::Force` that you had given, changing it from being an error if they differ, to an error unless they are *compatible*.  This is primarily to allow for differing `YaccOriginalActionKind` behaviors when used with the `Original` kind.

I've added `%grmtools` sections to *some* of the files in the repo while testing, but certainly not *all* this should probably
done though.

--

This is a breaking change which adds a `YaccKindResolver` type. `YaccKindResolver` can allow a yacc grammar to be read from a `%grmtools` section of a yacc grammar source file.

CTParserBuilder which previously required a YaccKind, has been relaxed to allow the YaccKind to be unspecified in which case it will now attempt to find the `yacckind` in the `%grmtools` section.

nimbleparse previously would default to using `YaccKind::Original`, now attempts to read the yacc kind from the `%grmtools` section and otherwise throws an error. This should improve error messages and avoid defaulting to the wrong yacc kind.