### PR TITLE
Fix an issue where `default_lex_flags` could go unused.

### DIFF
--- a/lrlex/src/lib/parser.rs
+++ b/lrlex/src/lib/parser.rs
@@ -324,7 +324,7 @@ where
     ) -> LexInternalBuildResult<usize> {
         i = self.parse_ws(i)?;
         let mut grmtools_section_span_map = HashMap::new();
-        let mut grmtools_section_lex_flags = DEFAULT_LEX_FLAGS;
+        let mut grmtools_section_lex_flags = UNSPECIFIED_LEX_FLAGS;
         if let Some(j) = self.lookahead_is("%grmtools", i) {
             i = self.parse_ws(j)?;
             if let Some(j) = self.lookahead_is("{", i) {


### PR DESCRIPTION
When I went to go implement comments, my cursor was staring at a small bug in my last commits *sigh*.

Because of this `let` usage `const DEFAULT_LEX_FLAGS` would override `default_lex_flags` from `CTLexerBuilder` rather than the other way around, because it appeared twice in the (middle of the) merge chain, instead of just at the end of the chain via `self.lex_flags`.