### PR TITLE
Add allow_wholeline_comments LexFlag.

### DIFF
--- a/lrlex/src/lib/ctbuilder.rs
+++ b/lrlex/src/lib/ctbuilder.rs
@@ -482,6 +482,7 @@ pub fn lexerdef() -> {lexerdef_type} {{
         .ok();
 
         let LexFlags {
+            allow_wholeline_comments,
             dot_matches_new_line,
             multi_line,
             octal,
@@ -494,6 +495,7 @@ pub fn lexerdef() -> {lexerdef_type} {{
             dfa_size_limit,
             nest_limit,
         } = lex_flags;
+        let allow_wholeline_comments = QuoteOption(allow_wholeline_comments);
         let dot_matches_new_line = QuoteOption(dot_matches_new_line);
         let multi_line = QuoteOption(multi_line);
         let octal = QuoteOption(octal);
@@ -508,6 +510,7 @@ pub fn lexerdef() -> {lexerdef_type} {{
 
         outs.push_str(&format!(
             "let mut lex_flags = ::lrlex::DEFAULT_LEX_FLAGS;
+            lex_flags.allow_wholeline_comments = {allow_wholeline_comments};
             lex_flags.dot_matches_new_line = {dot_matches_new_line};
             lex_flags.multi_line = {multi_line};
             lex_flags.octal = {octal};
@@ -521,6 +524,7 @@ pub fn lexerdef() -> {lexerdef_type} {{
             lex_flags.nest_limit = {nest_limit};
             let lex_flags = lex_flags;
 ",
+            allow_wholeline_comments = quote!(#allow_wholeline_comments),
             dot_matches_new_line = quote!(#dot_matches_new_line),
             multi_line = quote!(#multi_line),
             octal = quote!(#octal),

--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -28,6 +28,7 @@ pub struct LexFlags {
     pub multi_line: Option<bool>,
     pub octal: Option<bool>,
     pub posix_escapes: Option<bool>,
+    pub allow_wholeline_comments: Option<bool>,
 
     // All the following values when `None` default to the `regex` crate's default value.
     pub case_insensitive: Option<bool>,
@@ -43,6 +44,9 @@ impl LexFlags {
     /// Merges flags from `other` into `self`
     /// Flags which are `Some` in `other` overriding flags in self.
     pub fn merge_from(&mut self, other: &Self) {
+        if other.allow_wholeline_comments.is_some() {
+            self.allow_wholeline_comments = other.allow_wholeline_comments;
+        }
         if other.dot_matches_new_line.is_some() {
             self.dot_matches_new_line = other.dot_matches_new_line;
         }
@@ -81,6 +85,7 @@ impl LexFlags {
 
 /// LexFlags with flags set to default values.
 pub const DEFAULT_LEX_FLAGS: LexFlags = LexFlags {
+    allow_wholeline_comments: Some(false),
     dot_matches_new_line: Some(true),
     multi_line: Some(true),
     octal: Some(true),
@@ -96,6 +101,7 @@ pub const DEFAULT_LEX_FLAGS: LexFlags = LexFlags {
 
 /// LexFlags with all of the values `None`.
 pub const UNSPECIFIED_LEX_FLAGS: LexFlags = LexFlags {
+    allow_wholeline_comments: None,
     dot_matches_new_line: None,
     multi_line: None,
     octal: None,


### PR DESCRIPTION
Fixes #403

This doesn't actually attempt to implement comments at the end of rules or directives,
such as `. 'dot' // comment at the end of a rule` just comment at the beginning of a line behavior.
