### PR TITLE
Add grmtools section to `.y` files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members=[
     "lrpar/examples/calc_actions",
     "lrpar/examples/calc_ast",
     "lrpar/examples/calc_parsetree",
+    "lrpar/examples/calc_storaget",
     "lrpar/examples/start_states",
     "lrpar/examples/clone_param",
     "lrtable",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ members=[
     "lrpar/examples/calc_actions",
     "lrpar/examples/calc_ast",
     "lrpar/examples/calc_parsetree",
-    "lrpar/examples/calc_storaget",
     "lrpar/examples/start_states",
     "lrpar/examples/clone_param",
     "lrtable",

--- a/README.md
+++ b/README.md
@@ -14,14 +14,12 @@ grammar and lexing definitions). First we need to create a file `build.rs` in
 the root of our project with the following content:
 
 ```rust
-use cfgrammar::yacc::YaccKind;
 use lrlex::CTLexerBuilder;
 
 fn main() {
     CTLexerBuilder::new()
         .lrpar_config(|ctp| {
-            ctp.yacckind(YaccKind::Grmtools)
-                .grammar_in_src_dir("calc.y")
+            ctp.grammar_in_src_dir("calc.y")
                 .unwrap()
         })
         .lexer_in_src_dir("calc.l")
@@ -48,6 +46,7 @@ lexer can be found in `src/calc.l`:
 and where the definitions for the parser can be found in `src/calc.y`:
 
 ```rust
+%grmtools{yacckind Grmtools}
 %start Expr
 %avoid_insert "INT"
 %%

--- a/doc/src/errorrecovery.md
+++ b/doc/src/errorrecovery.md
@@ -49,6 +49,7 @@ make use of error recovery.
 A simple calculator grammar looks as follows:
 
 ```rust,noplaypen
+%grmtools{yacckind Grmtools}
 %start Expr
 %%
 Expr -> u64:
@@ -181,6 +182,7 @@ We thus change the grammar so that inserted integers prevent evaluation from
 occurring:
 
 ```rust,noplaypen
+%grmtools{yacckind Grmtools}
 %start Expr
 %%
 Expr -> Result<u64, ()>:
@@ -539,8 +541,7 @@ the first parsing error, with the `recoverer` method in `CTParserBuilder` or
 ```rust,noplaypen
 CTLexerBuilder::new()
     .lrpar_config(|ctp| {
-        ctp.yacckind(YaccKind::Grmtools)
-            .recoverer(lrpar::RecoveryKind::None)
+        ctp.recoverer(lrpar::RecoveryKind::None)
             .grammar_in_src_dir("calc.y")
             .unwrap()
     })

--- a/doc/src/manuallexer.md
+++ b/doc/src/manuallexer.md
@@ -38,13 +38,11 @@ Putting these together is then relatively easy. First a `build.rs` file for a
 hand-written lexer will look roughly as follows:
 
 ```rust
-use cfgrammar::yacc::YaccKind;
 use lrlex::{ct_token_map, DefaultLexerTypes};
 use lrpar::CTParserBuilder;
 
 fn main() {
     let ctp = CTParserBuilder::<DefaultLexerTypes<u8>>::new()
-        .yacckind(YaccKind::Grmtools)
         .grammar_in_src_dir("grammar.y")
         .unwrap()
         .build()

--- a/doc/src/quickstart.md
+++ b/doc/src/quickstart.md
@@ -48,14 +48,12 @@ file inside the root of our project which can process the lexer and grammar.
 Our `build.rs` file thus looks as follows:
 
 ```rust,noplaypen
-use cfgrammar::yacc::YaccKind;
 use lrlex::CTLexerBuilder;
 
 fn main() {
     CTLexerBuilder::new()
         .lrpar_config(|ctp| {
-            ctp.yacckind(YaccKind::Grmtools)
-                .grammar_in_src_dir("calc.y")
+            ctp.grammar_in_src_dir("calc.y")
                 .unwrap()
         })
         .lexer_in_src_dir("calc.l")
@@ -103,6 +101,7 @@ is lexed, but no lexemes are created from it.
 
 Our initial version of calc.y looks as follows:
 ```rust,noplaypen
+%grmtools{yacckind Grmtools}
 %start Expr
 %%
 Expr -> Result<u64, ()>:

--- a/lrlex/examples/calc_manual_lex/build.rs
+++ b/lrlex/examples/calc_manual_lex/build.rs
@@ -1,4 +1,3 @@
-use cfgrammar::yacc::YaccKind;
 use lrlex::{ct_token_map, DefaultLexerTypes};
 use lrpar::CTParserBuilder;
 
@@ -13,7 +12,6 @@ const TOKENS_MAP: &[(&str, &str)] = &[
 
 fn main() {
     let ctp = CTParserBuilder::<DefaultLexerTypes<u8>>::new()
-        .yacckind(YaccKind::Grmtools)
         .grammar_in_src_dir("calc.y")
         .unwrap()
         .build()

--- a/lrlex/examples/calc_manual_lex/src/calc.y
+++ b/lrlex/examples/calc_manual_lex/src/calc.y
@@ -1,3 +1,4 @@
+%grmtools{yacckind Grmtools}
 %start Expr
 %avoid_insert "INT"
 %expect-unused Unmatched "UNMATCHED"

--- a/lrpar/examples/calc_actions/build.rs
+++ b/lrpar/examples/calc_actions/build.rs
@@ -1,5 +1,4 @@
 #![deny(rust_2018_idioms)]
-use cfgrammar::yacc::YaccKind;
 use lrlex::CTLexerBuilder;
 
 fn main() {
@@ -8,8 +7,7 @@ fn main() {
     CTLexerBuilder::new()
         .rust_edition(lrlex::RustEdition::Rust2021)
         .lrpar_config(|ctp| {
-            ctp.yacckind(YaccKind::Grmtools)
-                .rust_edition(lrpar::RustEdition::Rust2021)
+            ctp.rust_edition(lrpar::RustEdition::Rust2021)
                 .grammar_in_src_dir("calc.y")
                 .unwrap()
         })

--- a/lrpar/examples/calc_actions/src/calc.y
+++ b/lrpar/examples/calc_actions/src/calc.y
@@ -1,6 +1,4 @@
-%grmtools {
-  yacckind Grmtools
-}
+%grmtools {yacckind Grmtools}
 %start Expr
 %avoid_insert "INT"
 %%

--- a/lrpar/examples/calc_ast/build.rs
+++ b/lrpar/examples/calc_ast/build.rs
@@ -1,5 +1,4 @@
 #![deny(rust_2018_idioms)]
-use cfgrammar::yacc::YaccKind;
 use lrlex::CTLexerBuilder;
 
 fn main() {
@@ -8,8 +7,7 @@ fn main() {
     CTLexerBuilder::new()
         .rust_edition(lrlex::RustEdition::Rust2021)
         .lrpar_config(|ctp| {
-            ctp.yacckind(YaccKind::Grmtools)
-                .rust_edition(lrpar::RustEdition::Rust2021)
+            ctp.rust_edition(lrpar::RustEdition::Rust2021)
                 .grammar_in_src_dir("calc.y")
                 .unwrap()
         })

--- a/lrpar/examples/calc_ast/src/calc.y
+++ b/lrpar/examples/calc_ast/src/calc.y
@@ -1,3 +1,4 @@
+%grmtools {yacckind Grmtools}
 %start Expr
 %avoid_insert "INT"
 %expect-unused Unmatched "UNMATCHED"

--- a/lrpar/examples/calc_parsetree/build.rs
+++ b/lrpar/examples/calc_parsetree/build.rs
@@ -1,4 +1,3 @@
-use cfgrammar::yacc::{YaccKind, YaccOriginalActionKind};
 use lrlex::CTLexerBuilder;
 
 fn main() {
@@ -7,8 +6,7 @@ fn main() {
     CTLexerBuilder::new()
         .rust_edition(lrlex::RustEdition::Rust2021)
         .lrpar_config(|ctp| {
-            ctp.yacckind(YaccKind::Original(YaccOriginalActionKind::GenericParseTree))
-                .rust_edition(lrpar::RustEdition::Rust2021)
+            ctp.rust_edition(lrpar::RustEdition::Rust2021)
                 .grammar_in_src_dir("calc.y")
                 .unwrap()
         })

--- a/lrpar/examples/clone_param/build.rs
+++ b/lrpar/examples/clone_param/build.rs
@@ -1,5 +1,4 @@
 #![deny(rust_2018_idioms)]
-use cfgrammar::yacc::YaccKind;
 use lrlex::CTLexerBuilder;
 
 fn main() {
@@ -8,8 +7,7 @@ fn main() {
     CTLexerBuilder::new()
         .rust_edition(lrlex::RustEdition::Rust2021)
         .lrpar_config(|ctp| {
-            ctp.yacckind(YaccKind::Grmtools)
-                .rust_edition(lrpar::RustEdition::Rust2021)
+            ctp.rust_edition(lrpar::RustEdition::Rust2021)
                 .grammar_in_src_dir("param.y")
                 .unwrap()
         })

--- a/lrpar/examples/clone_param/src/param.y
+++ b/lrpar/examples/clone_param/src/param.y
@@ -1,3 +1,4 @@
+%grmtools {yacckind Grmtools}
 %token Incr Decr
 %parse-param val: Rc<RefCell<i64>>
 %%

--- a/lrpar/examples/start_states/build.rs
+++ b/lrpar/examples/start_states/build.rs
@@ -1,4 +1,3 @@
-use cfgrammar::yacc::{YaccKind, YaccOriginalActionKind};
 use lrlex::CTLexerBuilder;
 
 fn main() {
@@ -7,8 +6,7 @@ fn main() {
     CTLexerBuilder::new()
         .rust_edition(lrlex::RustEdition::Rust2021)
         .lrpar_config(|ctp| {
-            ctp.yacckind(YaccKind::Original(YaccOriginalActionKind::GenericParseTree))
-                .rust_edition(lrpar::RustEdition::Rust2021)
+            ctp.rust_edition(lrpar::RustEdition::Rust2021)
                 .grammar_in_src_dir("comment.y")
                 .unwrap()
         })

--- a/lrpar/examples/start_states/src/comment.y
+++ b/lrpar/examples/start_states/src/comment.y
@@ -1,3 +1,4 @@
+%grmtools{yacckind Original(GenericParseTree)}
 %start Expr
 %%
 Expr: Expr Text | ;


### PR DESCRIPTION
During development I'd added the `%grmtools` section to a few of the examples, to test it.
But forgot to add them to all the rest, this adds those, and removes the `.yacckind` calls in `build.rs`. 

Tested using the following shell script, which never specifies a `-y` flag and also performing `cargo run` in the examples,
```
echo -n "/* /* */ */" | ./target/debug/nimbleparse lrpar/examples/start_states/src/comment.{l,y} -
echo -n 5+++ | ./target/debug/nimbleparse ./lrpar/examples/clone_param/src/param.{l,y} -
echo -n 1+1 | ./target/debug/nimbleparse ./lrpar/examples/calc_storaget/src/calc.{l,y} -
echo -n 1+1 | ./target/debug/nimbleparse ./lrpar/examples/calc_parsetree/src/calc.{l,y} -
echo -n 1+1 | ./target/debug/nimbleparse ./lrpar/examples/calc_ast/src/calc.{l,y} -
echo -n 1+1 | ./target/debug/nimbleparse ./lrpar/examples/calc_actions/src/calc.{l,y} -
```

All looked good, the only question I have is about `calc_parsetree` which when I `cargo run` the compile time version,
I don't seem to see a parse tree emitted (just the calc computation), which is not what I had expected, but I'm now uncertain of whether that behavior has changed with these recent patches.

I will need to build a prior release and check the behavior against that.