### PR TITLE
Make `YaccGrammarErrorKind` and `LexErrorKind` `non_exhaustive`.

### DIFF
--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -23,6 +23,7 @@ use super::{
 
 /// The various different possible Yacc parser errors.
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum YaccGrammarErrorKind {
     IllegalInteger,
     IllegalName,

--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -47,6 +47,7 @@ impl Error for LexBuildError {}
 
 /// The various different possible Lex parser errors.
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum LexErrorKind {
     PrematureEnd,
     RoutinesNotSupported,


### PR DESCRIPTION
This adds the `non_exhaustive` attribute to the `*ErrorKind` enums.
It appears they are being used exhaustively everywhere because adding it didn't require any other code changes outside of their respective crates.

This is technically a breaking change that seems unlikely to break anything, but should allow us to add `ErrorKind` variants in the future without risk.