### PR TITLE
Make `LRNonStreamingLexerDef::lex_flags()` pub

### DIFF
--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -577,6 +577,8 @@ where
         self.start_states.iter().find(|state| state.id == id)
     }
 
+    /// Returns the final `LexFlags` used for this lex source
+    /// after all forced and default flags have been resolved.
     pub fn lex_flags(&self) -> Option<&LexFlags> {
         self.lex_flags.as_ref()
     }

--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -577,7 +577,7 @@ where
         self.start_states.iter().find(|state| state.id == id)
     }
 
-    pub(crate) fn lex_flags(&self) -> Option<&LexFlags> {
+    pub fn lex_flags(&self) -> Option<&LexFlags> {
         self.lex_flags.as_ref()
     }
 }


### PR DESCRIPTION
in #477 `re_str()` was made readable `pub`, with all of my changes adding the grmtools section
It occurred to me that if one is rebuilding a regex from `re_str()`, the `lex_flags` variable that was read
from the `.l` file is also pertinent.

So this makes the existing `LRNonStreamingLexerDef::lex_flags()` pub.
I think the simplest example of a given regex being valid under multiple interpretations is the `case_insensitive` flag.

```
%grmtools{case_insensitive}
%%
a 'a'
```

Where flipping the `%grmtools{!case_insensitive}` changes things.