### PR TITLE
refactor `gen_parse_function` and `output_file` using quote

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ codegen-units = 1
 panic = 'unwind'
 
 [workspace.dependencies]
-bincode = "1.2"
+bincode = { version = "2.0", features = ["serde"] }
 cactus = "1.0"
 filetime = "0.2"
 fnv = "1.0"
@@ -45,5 +45,5 @@ static_assertions = "1.1"
 unicode-width = "0.1.11"
 vob = ">=3.0.2"
 proc-macro2 = "1.0"
-prettyplease = "0.2.30"
+prettyplease = "0.2.31"
 syn = "2.0"

--- a/lrpar/Cargo.toml
+++ b/lrpar/Cargo.toml
@@ -40,6 +40,8 @@ regex.workspace = true
 serde = { workspace = true, features = ["derive"] }
 static_assertions.workspace = true
 vob.workspace = true
+syn.workspace = true
+prettyplease.workspace = true
 
 [dev-dependencies]
 tempfile = "3.0"


### PR DESCRIPTION
I'm going to just make this a draft, and write down some scattered thoughts.

I kind of think that I probably am doing myself a disservice by migrating `output_file` before all the others.
Because that then makes me use the whole `str::parse::<TokenStream>(string)` pattern.

Unlike lrlex, in lrpar we have user actions and user provided code snippets, so we're going to have to 
use the `str::parse<TokenStream>(user_action)?` there, which presumably will end up doing some syntax checking
during this code gen phase.

But here is at least progress on migrating the parser generating code to `quote`.
Just for feedback/etc...