### PR TITLE
Fix cache check, add testing mechanism for it

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -4,6 +4,7 @@ set -e
 
 export CARGO_HOME="`pwd`/.cargo"
 export RUSTUP_HOME="`pwd`/.rustup"
+export RUSTFLAGS="--cfg grmtools_extra_checks"
 
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh
 sh rustup.sh --default-host x86_64-unknown-linux-gnu --default-toolchain stable -y --no-modify-path
@@ -23,12 +24,17 @@ cargo test --lib lrpar --features serde
 root=`pwd`
 cd $root/lrlex/examples/calc_manual_lex
 echo "2 + 3 * 4" | cargo run | grep "Result: 14"
+# Touching these files shouldn't invalidate the cache (via --cfg grmtools_extra_checks)
+touch src/main.rs src/calc.y && echo "2 + 3 * 4" | CACHE_EXPECTED=y cargo run | grep "Result: 14"
 cd $root/lrpar/examples/calc_actions
 echo "2 + 3 * 4" | cargo run | grep "Result: 14"
+touch src/main.rs src/calc.y && echo "2 + 3 * 4" | CACHE_EXPECTED=y cargo run | grep "Result: 14"
 cd $root/lrpar/examples/calc_ast
 echo "2 + 3 * 4" | cargo run | grep "Result: 14"
+touch src/main.rs src/calc.y && echo "2 + 3 * 4" | CACHE_EXPECTED=y cargo run | grep "Result: 14"
 cd $root/lrpar/examples/calc_parsetree
 echo "2 + 3 * 4" | cargo run | grep "Result: 14"
+touch src/main.rs src/calc.y && echo "2 + 3 * 4" | CACHE_EXPECTED=y cargo run | grep "Result: 14"
 cd $root
 
 RUSTDOCFLAGS="-Dwarnings" cargo doc --no-deps

--- a/lrpar/build.rs
+++ b/lrpar/build.rs
@@ -1,5 +1,6 @@
 use vergen::EmitBuilder;
 
 fn main() {
+    println!("cargo::rustc-check-cfg=cfg(grmtools_extra_checks)");
     EmitBuilder::builder().build_timestamp().emit().unwrap();
 }


### PR DESCRIPTION
I don't really have buildbot to actually fully test under that however:

   Fix cache check, add testing mechanism for it
    
    In #510 I broke the cache check so it always regenerated the output source.
    Because pretty printing caused changes to the cache module, and the cache
    check uses string equality.
    
    Technically the pretty printer can cause non-whitespace changes, but it is
    stable/deterministic. It isn't going to *randomly* decide to append a
    trailing comma.
    
    So, it is fragile in a way that can be tested, so this adds an environment
    variable to force that the cache check returns true, and runs this from
    the buildbot script.