### PR TITLE
Emit cargo:rerun_if_changed for lex and yacc files

### DIFF
--- a/lrlex/src/lib/ctbuilder.rs
+++ b/lrlex/src/lib/ctbuilder.rs
@@ -352,6 +352,9 @@ where
             .lexer_path
             .as_ref()
             .expect("lexer_path must be specified before processing.");
+        if std::env::var("OUT_DIR").is_ok() {
+            println!("cargo:rerun-if-changed={}", lexerp.display());
+        }
         let outp = self
             .output_path
             .as_ref()

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -473,6 +473,9 @@ where
             .grammar_path
             .as_ref()
             .expect("grammar_path must be specified before processing.");
+        if std::env::var("OUT_DIR").is_ok() {
+            println!("cargo:rerun-if-changed={}", grmp.display());
+        }
         let outp = self
             .output_path
             .as_ref()


### PR DESCRIPTION
This allows `touch src/calc.{l,y}` alone to rebuild the project/rerun the build script.
It is gated so this only gets emitted when running under cargo.
