### PR TITLE
Emit unformatted code on pretty printer failure

### DIFF
--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -811,8 +811,15 @@ where
             } // End of `mod #mod_name`
         };
         let mut f = File::create(outp_rs)?;
-        let syntax_tree = syn::parse_str(&out_tokens.to_string())?;
-        let outs = prettyplease::unparse(&syntax_tree);
+        let unformatted = out_tokens.to_string();
+        let outs = if let Ok(syntax_tree) = syn::parse_str(&unformatted) {
+            prettyplease::unparse(&syntax_tree)
+        } else {
+            // We failed to parse the source string before pretty printing.
+            // This is likely due to a syntax error in the source text.
+            // We should still emit the unformatted source text.
+            unformatted
+        };
         f.write_all(outs.as_bytes())?;
         Ok(())
     }


### PR DESCRIPTION
When pretty printer failure occurs, it is usually due to a syntax error (which presumably could be inside of a user action).
Rather than emitting an error here, it is more useful to the user if we write the unformatted source string to the output_file over an empty `.y.rs` file.

