### PR TITLE
Use the web-time polyfill

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -2,21 +2,27 @@
 
 set -e
 
-export CARGO_HOME="`pwd`/.cargo"
+export CARGO_HOME="`pwd`/.cargo_install"
 export RUSTUP_HOME="`pwd`/.rustup"
 export RUSTFLAGS="--cfg grmtools_extra_checks"
 
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh
 sh rustup.sh --default-host x86_64-unknown-linux-gnu --default-toolchain stable -y --no-modify-path
 
-export PATH=`pwd`/.cargo/bin/:$PATH
+export PATH=`pwd`/.cargo_install/bin/:$PATH
+rustup target add wasm32-unknown-unknown
+rustup target add wasm32-wasip2
+cargo install wasm-bindgen-cli
 
 cargo fmt --all -- --check
 
 rustup toolchain install stable
 rustup default stable
+
 cargo test
 cargo test --release
+cargo test --target wasm32-unknown-unknown
+cargo test --target wasm32-wasip2
 
 cargo test --lib cfgrammar --features serde
 cargo test --lib lrpar --features serde

--- a/.buildbot_dockerfile_debian
+++ b/.buildbot_dockerfile_debian
@@ -2,7 +2,8 @@ FROM debian:latest
 ARG CI_UID
 RUN useradd -m -u ${CI_UID} ci
 RUN apt-get update && \
-apt-get -y install build-essential curl procps file
+apt-get -y install build-essential curl procps file \
+rust-wasmtime nodejs
 WORKDIR /ci
 RUN chown ${CI_UID}:${CI_UID} .
 COPY --chown=${CI_UID}:${CI_UID} . .

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,6 @@
+[target.wasm32-wasip2]
+runner = "wasmtime run --dir ."
+
+[target.wasm32-unknown-unknown]
+# Provided by the crate wasm-bindgen-cli.
+runner = "wasm-bindgen-test-runner"

--- a/lrpar/Cargo.toml
+++ b/lrpar/Cargo.toml
@@ -42,5 +42,8 @@ vob.workspace = true
 syn.workspace = true
 prettyplease.workspace = true
 
-[dev-dependencies]
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+web-time = "1.1.0"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tempfile = "3.0"

--- a/lrpar/cttests/Cargo.toml
+++ b/lrpar/cttests/Cargo.toml
@@ -6,12 +6,16 @@ edition = "2021"
 license = "Apache-2.0/MIT"
 build = "build.rs"
 
+[lib]
+crate-type = ["cdylib"]
+
 [build-dependencies]
 cfgrammar = { path = "../../cfgrammar" }
 lrlex = { path = "../../lrlex" }
 lrpar = { path = "../" }
 glob = "0.3"
 yaml-rust2 = "0.8"
+cfg_aliases = "0.2.1"
 
 [dependencies]
 cfgrammar = { path = "../../cfgrammar" }
@@ -22,3 +26,9 @@ glob = "0.3"
 
 [dev-dependencies]
 cttests_macro = { path = "../cttests_macro" }
+
+[target.'cfg(all(target_arch = "wasm32", target_os="unknown", target_vendor="unknown"))'.dependencies]
+wasm-bindgen = "0.2.100"
+
+[target.'cfg(all(target_arch = "wasm32", target_os="unknown", target_vendor="unknown"))'.dev-dependencies]
+wasm-bindgen-test = "0.3.50"

--- a/lrpar/cttests/build.rs
+++ b/lrpar/cttests/build.rs
@@ -1,7 +1,7 @@
 use glob::glob;
 #[path = "src/cgen_helper.rs"]
 mod cgen_helper;
-
+use cfg_aliases::cfg_aliases;
 use cgen_helper::run_test_path;
 
 // Compiles the `*.test` files within `src`. Test files are written in Yaml syntax and have 4
@@ -13,5 +13,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for entry in glob("src/*.test")? {
         run_test_path(entry.unwrap())?;
     }
+
+    cfg_aliases! {
+        // Platforms
+        wasm32_unknown: { all(target_arch = "wasm32", target_os="unknown", target_vendor="unknown") },
+    }
+
     Ok(())
 }

--- a/lrpar/cttests/src/calc_wasm.rs
+++ b/lrpar/cttests/src/calc_wasm.rs
@@ -1,0 +1,80 @@
+#[cfg(wasm32_unknown)]
+use wasm_bindgen::prelude::*;
+
+use lrlex::lrlex_mod;
+use lrpar::lrpar_mod;
+
+// Using `lrlex_mod!` brings the lexer for `calc.l` into scope. By default the module name will be
+// `calc_l` (i.e. the file name, minus any extensions, with a suffix of `_l`).
+lrlex_mod!("calc_wasm.l");
+// Using `lrpar_mod!` brings the parser for `calc.y` into scope. By default the module name will be
+// `calc_y` (i.e. the file name, minus any extensions, with a suffix of `_y`).
+lrpar_mod!("calc_wasm.y");
+
+#[cfg_attr(wasm32_unknown, wasm_bindgen)]
+#[allow(unused)]
+pub fn calculate(l: &str) -> Result<u64, String> {
+    // Get the `LexerDef` for the `calc` language.
+    let lexerdef = calc_wasm_l::lexerdef();
+    if l.trim().is_empty() {
+        return Err("input is empty".to_string());
+    }
+    // Now we create a lexer with the `lexer` method with which we can lex an input.
+    let lexer = lexerdef.lexer(l);
+    // Pass the lexer to the parser and lex and parse the input.
+    let (res, errs) = calc_wasm_y::parse(&lexer);
+    if !errs.is_empty() {
+        let mut ret = String::new();
+        for e in errs {
+            use lrpar::LexParseError;
+            match e {
+                LexParseError::ParseError(e) => {
+                    let repairs_flag = !e.repairs().is_empty();
+                    ret.push_str(&format!("Error: {}\n Repairs: {}", e, repairs_flag));
+                }
+                e => ret.push_str(&format!("{}\n", e)),
+            };
+        }
+        if let Some(Err(e)) = res {
+            ret.push_str(&format!("{}\n", e));
+        }
+        return Err(ret);
+    }
+    match res {
+        Some(Ok(r)) => Ok(r),
+        Some(Err(e)) => Err(e.to_string()),
+        None => Err("Unable to parse".to_string()),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::calculate;
+    #[cfg(wasm32_unknown)]
+    use wasm_bindgen_test::*;
+
+    #[cfg_attr(wasm32_unknown, wasm_bindgen_test)]
+    #[test]
+    fn test_calc_14() {
+        assert_eq!(calculate("2 + 3 * 4").unwrap(), 14);
+    }
+
+    #[cfg_attr(wasm32_unknown, wasm_bindgen_test)]
+    #[test]
+    fn test_lex_error() {
+        assert!(calculate("#1 + #2").is_err());
+    }
+
+    #[cfg_attr(wasm32_unknown, wasm_bindgen_test)]
+    #[test]
+    fn test_recovery() {
+        // We really want to test this recovery path, since it contains
+        // calls to `Instant::now()` which panics on `std`
+        // Thus we need to check that the `web_time` crate is working.
+        let x = calculate("1+");
+        match x {
+            Err(e) => assert!(e.contains("Repairs: true")),
+            Ok(e) => panic!("unexpectedly parsed {}", e),
+        }
+    }
+}

--- a/lrpar/cttests/src/calc_wasm.test
+++ b/lrpar/cttests/src/calc_wasm.test
@@ -1,0 +1,54 @@
+name: Test running on wasm targets
+grammar: |
+    %grmtools {yacckind Grmtools}
+    %start Expr
+    %avoid_insert "INT"
+    %expect-unused Unmatched "UNMATCHED"
+    %epp INT "Int"
+    %%
+    Expr -> Result<u64, Box<dyn Error>>:
+        Expr '+' Term {
+            $1?.checked_add($3?)
+                .ok_or_else(|| Box::<dyn Error>::from("Overflow detected."))
+        }
+        | Term { $1 }
+        ;
+
+    Term -> Result<u64, Box<dyn Error>>:
+        Term '*' Factor {
+            $1?.checked_mul($3?)
+                .ok_or_else(|| Box::<dyn Error>::from("Overflow detected."))
+        }
+        | Factor { $1 }
+        ;
+
+    Factor -> Result<u64, Box<dyn Error>>:
+        '(' Expr ')' { $2 }
+        | 'INT' {
+            parse_int($lexer.span_str($1.map_err(|_| "<evaluation aborted>")?.span()))
+        }
+        ;
+    Unmatched -> (): "UNMATCHED" { };
+    %%
+    // Any imports here are in scope for all the grammar actions above.
+
+    use std::error::Error;
+
+    fn parse_int(s: &str) -> Result<u64, Box<dyn Error>> {
+        match s.parse::<u64>() {
+            Ok(val) => Ok(val),
+            Err(_) => {
+                Err(Box::from(format!("{} cannot be represented as a u64", s)))
+            }
+        }
+    }
+lexer: |
+    %%
+    [0-9]+ "INT"
+    \+ "+"
+    \* "*"
+    \( "("
+    \) ")"
+    [\t ]+ ;
+    . "UNMATCHED"
+

--- a/lrpar/cttests/src/lib.rs
+++ b/lrpar/cttests/src/lib.rs
@@ -1,8 +1,12 @@
 #[cfg(test)]
 use cfgrammar::Span;
+
 mod cgen_helper;
 #[allow(unused)]
 use cgen_helper::run_test_path;
+
+mod calc_wasm;
+
 #[cfg(test)]
 use cttests_macro::generate_codegen_fail_tests;
 use lrlex::lrlex_mod;

--- a/lrpar/src/lib/cpctplus.rs
+++ b/lrpar/src/lib/cpctplus.rs
@@ -3,8 +3,13 @@ use std::{
     collections::HashSet,
     fmt::Debug,
     hash::{Hash, Hasher},
-    time::Instant,
 };
+
+// web_time can be used on non-wasm32 but to avoid the dependency.
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Instant;
+#[cfg(target_arch = "wasm32")]
+use web_time::Instant;
 
 use cactus::Cactus;
 use cfgrammar::{Span, TIdx};

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -1398,7 +1398,8 @@ where
     }
 }
 
-#[cfg(test)]
+// Tests dealing with the filesystem not supported under wasm32
+#[cfg(all(not(target_arch = "wasm32"), test))]
 mod test {
     use std::{fs::File, io::Write, path::PathBuf};
 

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -4,9 +4,14 @@ use std::{
     fmt::{self, Debug, Display, Write as _},
     hash::Hash,
     marker::PhantomData,
-    time::{Duration, Instant},
     vec,
 };
+
+// Can be used on non-wasm32 but to avoid the dependency.
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::{Duration, Instant};
+#[cfg(target_arch = "wasm32")]
+use web_time::{Duration, Instant};
 
 use cactus::Cactus;
 use cfgrammar::{yacc::YaccGrammar, RIdx, Span, TIdx};

--- a/nimbleparse/src/diagnostics.rs
+++ b/nimbleparse/src/diagnostics.rs
@@ -163,7 +163,7 @@ impl<'a> SpannedDiagnosticFormatter<'a> {
                     SpansKind::Error => {
                         unreachable!("Should contain a single span at the site of the error")
                     }
-                    _ => format!("Unrecognized spanskind"),
+                    _ => "Unrecognized spanskind".to_string(),
                 };
                 out.push_str(&self.prefixed_underline_span_with_text(dots, *span, s, '-'));
             }


### PR DESCRIPTION
This adds a poly-fill crate to fix #461

I don't really know anything about wasm etc, but web_time is a complete drop in replacement for `std::time`,
On platforms where std::time is available, it is simply just a [re-export](https://github.com/daxpedda/web-time/blob/main/src/lib.rs#L185-L186) of std::time as shown in the link.

@stephanemagnenat Curious if you are still interested in testing whether this fixes things for you?