### PR TITLE
Fix cargo deny check license

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -47,6 +47,6 @@ cd $root
 RUSTDOCFLAGS="-Dwarnings" cargo doc --no-deps
 
 which cargo-deny | cargo install cargo-deny || true
-if [ "X`which cargo-deny`" != "X"]; then
+if [ "X`which cargo-deny`" != "X" ]; then
     cargo-deny check license
 fi

--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,8 @@
 [licenses]
-unlicensed = "deny"
 confidence-threshold = 1.0
 allow = [
     "Apache-2.0",
     "MIT",
+    "BSD-3-Clause",
+    "Unicode-3.0",
 ]

--- a/lrpar/cttests_macro/Cargo.toml
+++ b/lrpar/cttests_macro/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cttests_macro"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0/MIT"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
*Note* this adds missing licenses to the allow list, to make the cargo deny check succeed.
Without regard to whether we actually want to allow those licenses
I've never actually read or heard of the Unicode-3.0 license.

In trying to figure out a testing strategy for wasm and the PR in #527
Previously in other things I had been running `.buildbot.sh` on a failing branch, when adding that cache check.
Running it here on a working branch  I noticed the `cargo-deny check license` script was failing, 
for a few reasons.

So now I'm wondering if the `.buildbot.sh` and the ci script are somehow out-of-sync,
This would seem to explain why I could never get #513 to fail.