### PR TITLE
The authors of this code are now a fairly wide set of people.

### DIFF
--- a/cfgrammar/Cargo.toml
+++ b/cfgrammar/Cargo.toml
@@ -3,7 +3,6 @@ name = "cfgrammar"
 description = "Grammar manipulation"
 repository = "https://github.com/softdevteam/grmtools"
 version = "0.13.10"
-authors = ["Laurence Tratt <http://tratt.net/laurie/>"]
 edition = "2021"
 readme = "README.md"
 license = "Apache-2.0/MIT"

--- a/lrlex/Cargo.toml
+++ b/lrlex/Cargo.toml
@@ -3,7 +3,6 @@ name = "lrlex"
 description = "Simple lexer generator"
 repository = "https://github.com/softdevteam/grmtools"
 version = "0.13.10"
-authors = ["Laurence Tratt <http://tratt.net/laurie/>"]
 edition = "2021"
 readme = "README.md"
 license = "Apache-2.0/MIT"

--- a/lrpar/Cargo.toml
+++ b/lrpar/Cargo.toml
@@ -3,7 +3,6 @@ name = "lrpar"
 description = "Yacc-compatible parser generator"
 repository = "https://github.com/softdevteam/grmtools"
 version = "0.13.10"
-authors = ["Lukas Diekmann <http://lukasdiekmann.com/>", "Laurence Tratt <http://tratt.net/laurie/>"]
 edition = "2021"
 readme = "README.md"
 license = "Apache-2.0/MIT"

--- a/lrtable/Cargo.toml
+++ b/lrtable/Cargo.toml
@@ -3,7 +3,6 @@ name = "lrtable"
 description = "LR grammar table generation"
 repository = "https://github.com/softdevteam/grmtools"
 version = "0.13.10"
-authors = ["Lukas Diekmann <http://lukasdiekmann.com/>", "Laurence Tratt <http://tratt.net/laurie/>"]
 edition = "2021"
 readme = "README.md"
 license = "Apache-2.0/MIT"

--- a/nimbleparse/Cargo.toml
+++ b/nimbleparse/Cargo.toml
@@ -3,7 +3,6 @@ name = "nimbleparse"
 description = "Simple Yacc grammar debugging tool"
 repository = "https://github.com/softdevteam/grmtools"
 version = "0.13.10"
-authors = ["Laurence Tratt <http://tratt.net/laurie/>"]
 edition = "2021"
 readme = "README.md"
 license = "Apache-2.0/MIT"


### PR DESCRIPTION
Originally I was going to set this to "The grmtools developers" but [RFC 3052](https://rust-lang.github.io/rfcs/3052-optional-authors-field.html) makes fairly clear -- and I think I agree -- that this isn't very useful:

> The contents of the [authors] field also tend to scale poorly as the size
> of a project grows, with projects either making the field useless by just
> stating "The $PROJECT developers" or only naming the original authors
> without mentioning other major contributors.