### PR TITLE
Initial experiment with direct bincode/optional serde.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ codegen-units = 1
 panic = 'unwind'
 
 [workspace.dependencies]
-bincode = { version = "2.0", features = ["serde"] }
+bincode = "2.0"
 cactus = "1.0"
 filetime = "0.2"
 fnv = "1.0"
@@ -40,10 +40,10 @@ quote = "1.0"
 regex = "1.3"
 regex-syntax = "0.8"
 serde = "1.0"
-sparsevec = "0.2"
+sparsevec = "0.2.2"
 static_assertions = "1.1"
 unicode-width = "0.1.11"
-vob = ">=3.0.2"
+vob = "3.0.4"
 proc-macro2 = "1.0"
 prettyplease = "0.2.31"
 syn = "2.0"

--- a/cfgrammar/Cargo.toml
+++ b/cfgrammar/Cargo.toml
@@ -10,16 +10,21 @@ license = "Apache-2.0/MIT"
 categories = ["parsing"]
 keywords = ["yacc", "grammar"]
 
+[features]
+serde = ["dep:serde", "serde/derive", "vob/serde"]
+bincode = ["dep:bincode", "vob/bincode"]
+
 [lib]
 name = "cfgrammar"
 path = "src/lib/mod.rs"
 
 [dependencies]
+bincode = { workspace = true, optional = true, features = ["derive"] }
 lazy_static.workspace = true
 indexmap.workspace = true
 num-traits.workspace = true
 regex.workspace = true
-serde = { workspace = true, features = ["derive"], optional = true }
-vob = { workspace = true, features = ["serde"] }
+serde = { workspace = true, optional = true }
+vob = { workspace = true }
 quote.workspace = true
 proc-macro2.workspace = true

--- a/cfgrammar/src/lib/idxnewtype.rs
+++ b/cfgrammar/src/lib/idxnewtype.rs
@@ -3,6 +3,8 @@
 
 use std::mem::size_of;
 
+#[cfg(feature = "bincode")]
+use bincode::{Decode, Encode};
 use num_traits::{PrimInt, Unsigned};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -12,6 +14,7 @@ macro_rules! IdxNewtype {
         $(#[$attr])*
         #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
         #[cfg_attr(feature="serde", derive(Serialize, Deserialize))]
+        #[cfg_attr(feature="bincode", derive(Encode, Decode))]
         pub struct $n<T>(pub T);
 
         impl<T: PrimInt + Unsigned> From<$n<T>> for usize {

--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -51,6 +51,8 @@
 //! [`YaccGrammar::new_with_storaget()`](yacc/grammar/struct.YaccGrammar.html#method.new_with_storaget)
 //! which take as input a Yacc grammar.
 
+#[cfg(feature = "bincode")]
+use bincode::{Decode, Encode};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -67,6 +69,7 @@ pub use crate::idxnewtype::{PIdx, RIdx, SIdx, TIdx};
 
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 pub enum Symbol<StorageT> {
     Rule(RIdx<StorageT>),
     Token(TIdx<StorageT>),

--- a/cfgrammar/src/lib/span.rs
+++ b/cfgrammar/src/lib/span.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "bincode")]
+use bincode::{Decode, Encode};
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens, TokenStreamExt};
 #[cfg(feature = "serde")]
@@ -7,6 +9,7 @@ use serde::{Deserialize, Serialize};
 /// references (i.e. the `Span` doesn't hold a reference / copy of the actual input).
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 pub struct Span {
     start: usize,
     end: usize,

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -1,5 +1,7 @@
 // Note: this is the parser for both YaccKind::Original(YaccOriginalActionKind::GenericParseTree) and YaccKind::Eco yacc kinds.
 
+#[cfg(feature = "bincode")]
+use bincode::{Decode, Encode};
 use lazy_static::lazy_static;
 use num_traits::PrimInt;
 use regex::Regex;
@@ -160,6 +162,7 @@ impl fmt::Display for YaccGrammarErrorKind {
 /// The various different possible Yacc parser errors.
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[non_exhaustive]
 pub enum YaccGrammarWarningKind {
     UnusedRule,
@@ -169,6 +172,7 @@ pub enum YaccGrammarWarningKind {
 /// Any Warning from the Yacc parser returns an instance of this struct.
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 pub struct YaccGrammarWarning {
     /// The specific kind of warning.
     pub(crate) kind: YaccGrammarWarningKind,

--- a/lrlex/Cargo.toml
+++ b/lrlex/Cargo.toml
@@ -35,6 +35,7 @@ regex-syntax.workspace = true
 num-traits.workspace = true
 proc-macro2.workspace = true
 quote.workspace = true
-serde.workspace = true
+bincode.workspace = true
+serde = { workspace = true, optional = true }
 prettyplease.workspace = true
 syn.workspace = true

--- a/lrlex/src/lib/ctbuilder.rs
+++ b/lrlex/src/lib/ctbuilder.rs
@@ -14,6 +14,7 @@ use std::{
     sync::Mutex,
 };
 
+use bincode::Encode;
 use cfgrammar::{newlinecache::NewlineCache, Spanned};
 use lazy_static::lazy_static;
 use lrpar::{CTParserBuilder, LexerTypes};
@@ -21,7 +22,6 @@ use num_traits::{AsPrimitive, PrimInt, Unsigned};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, ToTokens, TokenStreamExt};
 use regex::Regex;
-use serde::Serialize;
 
 use crate::{DefaultLexerTypes, LRNonStreamingLexerDef, LexFlags, LexerDef, UNSPECIFIED_LEX_FLAGS};
 
@@ -150,7 +150,7 @@ impl CTLexerBuilder<'_, DefaultLexerTypes<u32>> {
 impl<'a, LexerTypesT: LexerTypes> CTLexerBuilder<'a, LexerTypesT>
 where
     LexerTypesT::StorageT:
-        'static + Debug + Eq + Hash + PrimInt + Serialize + TryFrom<usize> + Unsigned + ToTokens,
+        'static + Debug + Eq + Hash + PrimInt + Encode + TryFrom<usize> + Unsigned + ToTokens,
     usize: AsPrimitive<LexerTypesT::StorageT>,
 {
     /// Create a new [CTLexerBuilder].

--- a/lrpar/Cargo.toml
+++ b/lrpar/Cargo.toml
@@ -16,7 +16,7 @@ name = "lrpar"
 path = "src/lib/mod.rs"
 
 [features]
-serde = []
+serde = ["dep:serde", "cfgrammar/serde", "lrtable/serde"]
 _unstable_api = []
 _unsealed_unstable_traits = ["_unstable_api"]
 
@@ -24,10 +24,10 @@ _unsealed_unstable_traits = ["_unstable_api"]
 vergen = { version = "8", default-features = false, features = ["build"] }
 
 [dependencies]
-cfgrammar = { path="../cfgrammar", version = "0.13", features=["serde"] }
-lrtable = { path="../lrtable", version = "0.13", features=["serde"] }
+cfgrammar = { path="../cfgrammar", version = "0.13", features = ["bincode"] }
+lrtable = { path="../lrtable", version = "0.13", features = ["bincode"] }
 
-bincode.workspace = true
+bincode = { workspace = true, features = ["derive"] }
 cactus.workspace = true
 filetime.workspace = true
 indexmap.workspace = true
@@ -37,7 +37,7 @@ packedvec.workspace = true
 proc-macro2.workspace = true
 quote.workspace = true
 regex.workspace = true
-serde = { workspace = true, features = ["derive"] }
+serde = { workspace = true, features = ["derive"], optional = true }
 static_assertions.workspace = true
 vob.workspace = true
 syn.workspace = true

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -15,7 +15,7 @@ use std::{
 };
 
 use crate::{LexerTypes, RecoveryKind};
-use bincode::serde::{decode_from_slice, encode_to_vec};
+use bincode::{decode_from_slice, encode_to_vec, Decode, Encode};
 use cfgrammar::{
     newlinecache::NewlineCache,
     yacc::{
@@ -30,7 +30,6 @@ use num_traits::{AsPrimitive, PrimInt, Unsigned};
 use proc_macro2::{Literal, TokenStream};
 use quote::{format_ident, quote, ToTokens, TokenStreamExt};
 use regex::Regex;
-use serde::{de::DeserializeOwned, Serialize};
 
 const ACTION_PREFIX: &str = "__gt_";
 const GLOBAL_PREFIX: &str = "__GT_";
@@ -248,7 +247,7 @@ where
 
 impl<
         'a,
-        StorageT: 'static + Debug + Hash + PrimInt + Serialize + Unsigned,
+        StorageT: 'static + Debug + Hash + PrimInt + Encode + Unsigned,
         LexerTypesT: LexerTypes<StorageT = StorageT>,
     > CTParserBuilder<'a, LexerTypesT>
 where
@@ -1339,9 +1338,9 @@ where
 }
 
 /// This function is called by generated files; it exists so that generated files don't require a
-/// dependency on serde and rmps.
+/// direct dependency on bincode.
 #[doc(hidden)]
-pub fn _reconstitute<StorageT: DeserializeOwned + Hash + PrimInt + Unsigned>(
+pub fn _reconstitute<StorageT: Decode<()> + Hash + PrimInt + Unsigned + 'static>(
     grm_buf: &[u8],
     stable_buf: &[u8],
 ) -> (YaccGrammar<StorageT>, StateTable<StorageT>) {

--- a/lrtable/Cargo.toml
+++ b/lrtable/Cargo.toml
@@ -9,15 +9,20 @@ readme = "README.md"
 license = "Apache-2.0/MIT"
 categories = ["parsing"]
 
+[features]
+bincode = ["dep:bincode", "sparsevec/bincode", "cfgrammar/bincode"]
+serde = ["dep:serde", "sparsevec/serde", "cfgrammar/serde"]
+
 [lib]
 name = "lrtable"
 path = "src/lib/mod.rs"
 
 [dependencies]
-cfgrammar = { path="../cfgrammar", version = "0.13", features=["serde"] }
+cfgrammar = { path="../cfgrammar", version = "0.13" }
 
+bincode = { workspace = true, features = ["derive"], optional = true }
 fnv.workspace = true
 num-traits.workspace = true
 serde = { workspace = true, features = ["derive"], optional = true }
-vob = { workspace = true, features = ["serde"] }
-sparsevec = { workspace = true, features = ["serde"] }
+vob.workspace = true
+sparsevec.workspace = true

--- a/lrtable/src/lib/mod.rs
+++ b/lrtable/src/lib/mod.rs
@@ -6,6 +6,8 @@
 
 use std::{hash::Hash, mem::size_of};
 
+#[cfg(feature = "bincode")]
+use bincode::{Decode, Encode};
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -26,6 +28,7 @@ macro_rules! IdxNewtype {
         $(#[$attr])*
         #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
         #[cfg_attr(feature="serde", derive(Serialize, Deserialize))]
+        #[cfg_attr(feature="bincode", derive(Encode, Decode))]
         pub struct $n<T>(pub T);
 
         impl<T: PrimInt + Unsigned> From<$n<T>> for usize {

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -8,6 +8,8 @@ use std::{
     marker::PhantomData,
 };
 
+#[cfg(feature = "bincode")]
+use bincode::{Decode, Encode};
 use cfgrammar::{
     yacc::{AssocKind, YaccGrammar},
     PIdx, RIdx, Symbol, TIdx,
@@ -21,6 +23,7 @@ use vob::{IterSetBits, Vob};
 use crate::{stategraph::StateGraph, StIdx};
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Debug)]
 pub struct Conflicts<StorageT> {
     reduce_reduce: Vec<(
@@ -145,6 +148,7 @@ impl<StorageT> fmt::Display for StateTableError<StorageT> {
 /// A representation of a `StateTable` for a grammar. `actions` and `gotos` are split into two
 /// separate hashmaps, rather than a single table, due to the different types of their values.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 pub struct StateTable<StorageT> {
     actions: SparseVec<usize>,
     state_actions: Vob<u64>,


### PR DESCRIPTION
Currently the derive macro for the bincode crate has a bug that fails to automatically derive the trait for types default type parameters.

This patch implements the `Decode` trait manually for YaccGrammar. It contains a modified copy of the derive macro output.