### PR TITLE
Make prettyplease an optional dependency

### DIFF
--- a/lrlex/Cargo.toml
+++ b/lrlex/Cargo.toml
@@ -17,6 +17,7 @@ name = "lrlex"
 path = "src/lib/mod.rs"
 
 [features]
+prettyplease = ["dep:prettyplease"]
 _unstable_api = []
 _unsealed_unstable_traits = ["_unstable_api"]
 
@@ -32,8 +33,8 @@ lazy_static.workspace = true
 regex.workspace = true
 regex-syntax.workspace = true
 num-traits.workspace = true
+prettyplease = { workspace = true, optional = true }
 proc-macro2.workspace = true
 quote.workspace = true
 serde.workspace = true
-prettyplease.workspace = true
 syn.workspace = true

--- a/lrlex/Cargo.toml
+++ b/lrlex/Cargo.toml
@@ -17,6 +17,8 @@ name = "lrlex"
 path = "src/lib/mod.rs"
 
 [features]
+default = ["prettyplease"]
+# Enable the pretty please code formatter on generated code.
 prettyplease = ["dep:prettyplease"]
 _unstable_api = []
 _unsealed_unstable_traits = ["_unstable_api"]

--- a/lrlex/src/lib/ctbuilder.rs
+++ b/lrlex/src/lib/ctbuilder.rs
@@ -574,14 +574,9 @@ where
         };
         let outs = out_tokens.to_string();
         #[cfg(feature = "prettyplease")]
-        let outs = if let Ok(syntax_tree) = syn::parse_str(&outs) {
-            prettyplease::unparse(&syntax_tree)
-        } else {
-            // We failed to parse the source string before pretty printing.
-            // This is likely due to a syntax error in the source text.
-            // We should still emit the unformatted source text.
-            outs
-        };
+        let outs = syn::parse_str(&outs)
+            .map(|syntax_tree| prettyplease::unparse(&syntax_tree))
+            .unwrap_or(outs);
         // If the file we're about to write out already exists with the same contents, then we
         // don't overwrite it (since that will force a recompile of the file, and relinking of the
         // binary etc).

--- a/lrlex/src/lib/ctbuilder.rs
+++ b/lrlex/src/lib/ctbuilder.rs
@@ -572,11 +572,16 @@ where
                 }
             }
         };
-
-        // Pretty print it.
-        let out_file = syn::parse_file(&out_tokens.to_string()).unwrap();
-        let outs = prettyplease::unparse(&out_file);
-
+        let outs = out_tokens.to_string();
+        #[cfg(feature = "prettyplease")]
+        let outs = if let Ok(syntax_tree) = syn::parse_str(&outs) {
+            prettyplease::unparse(&syntax_tree)
+        } else {
+            // We failed to parse the source string before pretty printing.
+            // This is likely due to a syntax error in the source text.
+            // We should still emit the unformatted source text.
+            outs
+        };
         // If the file we're about to write out already exists with the same contents, then we
         // don't overwrite it (since that will force a recompile of the file, and relinking of the
         // binary etc).

--- a/lrpar/Cargo.toml
+++ b/lrpar/Cargo.toml
@@ -15,7 +15,9 @@ name = "lrpar"
 path = "src/lib/mod.rs"
 
 [features]
+default = ["prettyplease"]
 serde = []
+# Enable the pretty please code formatter on generated code.
 prettyplease = ["dep:prettyplease"]
 _unstable_api = []
 _unsealed_unstable_traits = ["_unstable_api"]

--- a/lrpar/Cargo.toml
+++ b/lrpar/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/lib/mod.rs"
 
 [features]
 serde = []
+prettyplease = ["dep:prettyplease"]
 _unstable_api = []
 _unsealed_unstable_traits = ["_unstable_api"]
 
@@ -33,6 +34,7 @@ indexmap.workspace = true
 lazy_static.workspace = true
 num-traits.workspace = true
 packedvec.workspace = true
+prettyplease = { workspace = true, optional = true }
 proc-macro2.workspace = true
 quote.workspace = true
 regex.workspace = true
@@ -40,7 +42,6 @@ serde = { workspace = true, features = ["derive"] }
 static_assertions.workspace = true
 vob.workspace = true
 syn.workspace = true
-prettyplease.workspace = true
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -811,14 +811,15 @@ where
             } // End of `mod #mod_name`
         };
         let mut f = File::create(outp_rs)?;
-        let unformatted = out_tokens.to_string();
-        let outs = if let Ok(syntax_tree) = syn::parse_str(&unformatted) {
+        let outs = out_tokens.to_string();
+        #[cfg(feature = "prettyplease")]
+        let outs = if let Ok(syntax_tree) = syn::parse_str(&outs) {
             prettyplease::unparse(&syntax_tree)
         } else {
             // We failed to parse the source string before pretty printing.
             // This is likely due to a syntax error in the source text.
             // We should still emit the unformatted source text.
-            unformatted
+            outs
         };
         f.write_all(outs.as_bytes())?;
         f.write_all(cache.as_bytes())?;

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -813,14 +813,9 @@ where
         let mut f = File::create(outp_rs)?;
         let outs = out_tokens.to_string();
         #[cfg(feature = "prettyplease")]
-        let outs = if let Ok(syntax_tree) = syn::parse_str(&outs) {
-            prettyplease::unparse(&syntax_tree)
-        } else {
-            // We failed to parse the source string before pretty printing.
-            // This is likely due to a syntax error in the source text.
-            // We should still emit the unformatted source text.
-            outs
-        };
+        let outs = syn::parse_str(&outs)
+            .map(|syntax_tree| prettyplease::unparse(&syntax_tree))
+            .unwrap_or(outs);
         f.write_all(outs.as_bytes())?;
         f.write_all(cache.as_bytes())?;
         Ok(())


### PR DESCRIPTION
I have mixed feelings on this patch, 

Currently by default we run the prettyplease code formatter over the generated sources.
Which was very useful during development because the unpretty sources are now very unpretty, they get emitted all on a single line.  So without pretty printing they are unreadable.

But I doubt most people do much reading of the generated sources, so I suppose if they do they could enable an option?

This also contains a fix, bringing lrlex in line with lrpar, on pretty printer failure.