### PR TITLE
Remove author from examples/clone_param

### DIFF
--- a/lrpar/examples/clone_param/Cargo.toml
+++ b/lrpar/examples/clone_param/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "clone_param"
 version = "0.1.0"
-authors = ["Matt Rice <ratmice@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0/MIT"
 


### PR DESCRIPTION
This removes me as author from examples/clone_param, in #529 we removed the authors code from the main crates because there were many unlisted authors.

I wanted to remove my name from this example mainly because examples often get copied,
then modified and if the user doesn't update the example field you can get into situations where there is incorrect attribution.