### PR TITLE
Add a cttest for a non-default StorageT

### DIFF
--- a/lrpar/cttests/build.rs
+++ b/lrpar/cttests/build.rs
@@ -3,6 +3,7 @@ use glob::glob;
 mod cgen_helper;
 use cfg_aliases::cfg_aliases;
 use cgen_helper::run_test_path;
+use lrlex::{CTLexerBuilder, DefaultLexerTypes};
 
 // Compiles the `*.test` files within `src`. Test files are written in Yaml syntax and have 4
 // mandatory sections: name (describing what the test does), yacckind (defining the grammar type
@@ -19,5 +20,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         wasm32_unknown: { all(target_arch = "wasm32", target_os="unknown", target_vendor="unknown") },
     }
 
+    // Because we're modifying the `StorageT` this isn't something `run_test_path` can do,
+    // Since it modifies the type of the builder.
+    CTLexerBuilder::<DefaultLexerTypes<u8>>::new_with_lexemet()
+        .rust_edition(lrlex::RustEdition::Rust2021)
+        .lrpar_config(|ctp| {
+            ctp.rust_edition(lrpar::RustEdition::Rust2021)
+                .grammar_in_src_dir("storaget.y")
+                .unwrap()
+        })
+        .lexer_in_src_dir("storaget.l")
+        .unwrap()
+        .build()
+        .unwrap();
     Ok(())
 }

--- a/lrpar/cttests/src/lib.rs
+++ b/lrpar/cttests/src/lib.rs
@@ -50,6 +50,9 @@ lrpar_mod!("passthrough.y");
 lrlex_mod!("span.l");
 lrpar_mod!("span.y");
 
+lrlex_mod!("storaget.l");
+lrpar_mod!("storaget.y");
+
 #[test]
 fn multitypes() {
     let lexerdef = multitypes_l::lexerdef();
@@ -284,6 +287,19 @@ fn test_passthrough() {
         (Some(Ok(ref s)), _) if s == "$101" => (),
         _ => unreachable!(),
     }
+}
+
+#[test]
+fn test_storaget() {
+    let lexerdef = storaget_l::lexerdef();
+    let lexer = lexerdef.lexer("glasses, keys, umbrella");
+    let expect = ["glasses", "keys", "umbrella"]
+        .iter()
+        .map(|x| x.to_string())
+        .collect::<Vec<_>>();
+    let (val, e) = storaget_y::parse(&lexer);
+    assert_eq!(val, Some(expect));
+    assert!(e.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
I've been struggling to figure out a good way to make a test for a non-default `StorageT`.
Because if you look at [`run_test_path`](https://github.com/softdevteam/grmtools/blob/master/lrpar/cttests/src/cgen_helper.rs#L92) it has a line like the following.

```
let mut cp_build = CTParserBuilder::<DefaultLexerTypes<u32>>::new();
```

There is no real way we can make that local variable have a generic type.
When migrating the wasm tests to cttest it finally dawned on me we can just hard code the build.rs stuff
into cttests/build.rs.

This should fix a gap in our codegen testing, as I don't believe any non-default `StorageT` sizes anywhere else.