### PR TITLE
Allow %empty followed by %prec

### DIFF
--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -863,7 +863,8 @@ impl YaccParser {
                 if !syms.is_empty()
                     | !(self.lookahead_is("|", k).is_some()
                         || self.lookahead_is(";", k).is_some()
-                        || self.lookahead_is("{", k).is_some())
+                        || self.lookahead_is("{", k).is_some()
+                        || self.lookahead_is("%prec", k).is_some())
                 {
                     return Err(self.mk_error(YaccGrammarErrorKind::NonEmptyProduction, i));
                 }
@@ -1903,6 +1904,20 @@ x"
         assert_eq!(grm.prods[grm.rules["expr"].pidxs[3]].symbols.len(), 3);
         assert_eq!(grm.prods[grm.rules["expr"].pidxs[4]].symbols.len(), 2);
         assert_eq!(grm.prods[grm.rules["expr"].pidxs[4]].precedence, Some("*".to_string()));
+    }
+
+    #[test]
+    fn test_prec_empty() {
+        let src = "
+        %%
+        expr : 'a'
+             | %empty %prec 'a';
+        ";
+        let grm = parse(YaccKind::Original(YaccOriginalActionKind::NoAction), src).unwrap();
+        assert_eq!(
+            grm.prods[grm.rules["expr"].pidxs[1]].precedence,
+            Some("a".to_string())
+        );
     }
 
     #[test]


### PR DESCRIPTION
If one applies the following patch to the grammar in the zip archive linked from #473
to uncomment the `%prec` directives, and run the file through nimbleparse.

```
--- postgresql-16-naked.y       2024-11-21 10:36:08.000000000 -0800
+++ postgresql-16-naked.uncommented.y   2025-03-22 10:20:37.708582643 -0700
@@ -4572,7 +4572,7 @@

 opt_existing_window_name :
        ColId
-       | %empty //%prec Op /*16L*/
+       | %empty %prec Op /*16L*/
        ;

 opt_partition_clause :
@@ -4842,7 +4842,7 @@
        | WITH /*13N*/ UNIQUE /*11N*/
        | WITHOUT /*13N*/ UNIQUE /*11N*/ KEYS /*12N*/
        | WITHOUT /*13N*/ UNIQUE /*11N*/
-       | %empty //%prec KEYS /*12N*/
+       | %empty %prec KEYS /*12N*/
        ;

 json_name_and_value_list :
```

You currently get an error "%empty used in non-empty production".

```
[Error] in postgresql-16-naked.uncommented.y
    4575|       | %empty %prec Op /*16L*/
              %empty used in non-empty production

    554|        | MODE_PLPGSQL_EXPR PLpgSQL_Expr
                              ^^^^^^^^^^^^ Unknown reference to rule 'PLpgSQL_Expr'
```

This relaxes that error message so that `%prec` is accepted after `%empty`.
in #453 there was also a question about whether `%prec x` should be accepted without quotes around `'x'`.
I believe that the usage of `%prec Op` here seems to confirm that.

I wasn't able to test this with the provided input.txt, the lexer seems to be missing the necessary tokens.
but with this change I was able to run the modified grammar over the empty string. Producing an empty parse tree.

```
echo -n '' | ./target/release/nimbleparse -y original postgresql-16-naked.l postgresql-16-naked.uncommented.y -
[Warning] in postgresql-16-naked.uncommented.y
    3686|       select_no_parens %prec UMINUS /*22R*/
                                  ^^^^^^ Unused token


parse_toplevel
 stmtmulti
  toplevel_stmt
   stmt
```