### PR TITLE
Experiment with bincode variable width encoding config

### DIFF
--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -981,8 +981,8 @@ where
             _ => unreachable!(),
         };
 
-        let grm_data = encode_to_vec(grm, bincode::config::legacy())?;
-        let stable_data = encode_to_vec(stable, bincode::config::legacy())?;
+        let grm_data = encode_to_vec(grm, bincode::config::standard())?;
+        let stable_data = encode_to_vec(stable, bincode::config::standard())?;
         Ok(quote! {
             const __GRM_DATA: &[u8] = &[#(#grm_data,)*];
             const __STABLE_DATA: &[u8] = &[#(#stable_data,)*];
@@ -1340,8 +1340,8 @@ pub fn _reconstitute<StorageT: Decode<()> + Hash + PrimInt + Unsigned + 'static>
     grm_buf: &[u8],
     stable_buf: &[u8],
 ) -> (YaccGrammar<StorageT>, StateTable<StorageT>) {
-    let (grm, _) = decode_from_slice(grm_buf, bincode::config::legacy()).unwrap();
-    let (stable, _) = decode_from_slice(stable_buf, bincode::config::legacy()).unwrap();
+    let (grm, _) = decode_from_slice(grm_buf, bincode::config::standard()).unwrap();
+    let (stable, _) = decode_from_slice(stable_buf, bincode::config::standard()).unwrap();
     (grm, stable)
 }
 


### PR DESCRIPTION
This is mostly an RFC, it should in theory just modify the encoding but not affect the runtime size of tables (one would hope).  I have only lightly tested it.

When migrating to bincode 2.0, I just used the `bincode::config::legacy()`, since it was compatible with old bincode.
The new default for bincode is `bincode::config::standard()`.  Which defines a variable width encoding.

This is mostly documented here https://docs.rs/bincode/latest/bincode/config/

- Legacy fixed width encoding. (little endian)
- Standard variable width encoding. (little endian)
- Other encoding/endian combinations are available by manually building a `Config`.

I had been playing around with seeing the affected sizes of files by switching to a variable width encoding.
Most of the files i've tested have been fairly small, e.g. the `%grmtools` section parser saved about 8k on a 50k `legacy()` file.

I figured I would see what the saving were using the large grammar in #473 `legacy()` produces a `postgres.y.rs` 37M while `standard()` produces a 23M source file.  I mostly wanted to just point out that this was available, I haven't tried to measure things like how it affects parser load time.  Whether it is possible to let users decide on a configuration (It may not be easy due to the way that `Configuration` has generic parameters, legacy produces a different type than standard)