### PR TITLE
Add comma to grmtools section syntax

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -15,21 +15,20 @@ export PATH=`pwd`/.cargo_install/bin/:$WASMTIME_HOME/bin:$PATH
 
 # Install wasmtime once debian trixie is stablized
 # we can likely just use rust-wasmtime.
+#
+# Needed for wasm32-wasip2
 touch .wasmtime_profile
 if [ "X`which wasmtime`" = "X" ]; then
     PROFILE=".wasmtime_profile" bash -c 'curl https://wasmtime.dev/install.sh -sSf | bash'
 fi
 . ./.wasmtime_profile
 
+# Needed for wasm32-unknown-unknown
 mkdir -p $NVM_DIR
 PROFILE=/dev/null bash -c 'curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash'
 . "$NVM_DIR/nvm.sh"
 # Download and install Node.js:
 nvm install 22
-
-rustup target add wasm32-unknown-unknown
-rustup target add wasm32-wasip2
-cargo install wasm-bindgen-cli
 
 cargo fmt --all -- --check
 
@@ -38,7 +37,13 @@ rustup default stable
 
 cargo test
 cargo test --release
+
+rustup target add wasm32-unknown-unknown
+cargo install wasm-bindgen-cli
 cargo test --target wasm32-unknown-unknown
+
+rustup target add wasm32-wasip2
+cargo install workspace_runner
 cargo test --target wasm32-wasip2
 
 cargo test --lib cfgrammar --features serde

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [target.wasm32-wasip2]
-runner = "wasmtime run --dir ."
+runner = "workspace_runner --target wasm32-wasip2 --"
 
 [target.wasm32-unknown-unknown]
 # Provided by the crate wasm-bindgen-cli.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ lexer can be found in `src/calc.l`:
 and where the definitions for the parser can be found in `src/calc.y`:
 
 ```rust
-%grmtools{yacckind Grmtools}
+%grmtools{yacckind: Grmtools}
 %start Expr
 %avoid_insert "INT"
 %%

--- a/doc/src/errorrecovery.md
+++ b/doc/src/errorrecovery.md
@@ -49,7 +49,7 @@ make use of error recovery.
 A simple calculator grammar looks as follows:
 
 ```rust,noplaypen
-%grmtools{yacckind Grmtools}
+%grmtools{yacckind: Grmtools}
 %start Expr
 %%
 Expr -> u64:
@@ -182,7 +182,7 @@ We thus change the grammar so that inserted integers prevent evaluation from
 occurring:
 
 ```rust,noplaypen
-%grmtools{yacckind Grmtools}
+%grmtools{yacckind: Grmtools}
 %start Expr
 %%
 Expr -> Result<u64, ()>:

--- a/doc/src/lexextensions.md
+++ b/doc/src/lexextensions.md
@@ -15,9 +15,9 @@ other flags should specify their value immediately after the flag name.
 
 ```
 %grmtools {
-    allow_wholeline_comments
-    !octal
-    size_limit 1024
+    allow_wholeline_comments,
+    !octal,
+    size_limit: 1024,
 }
 %%
 . "rule"
@@ -56,7 +56,7 @@ The following flags can change the behavior to match posix lex more closely.
 
 ```
 %grmtools {
-    !dot_matches_new_line
+    !dot_matches_new_line,
     posix_escapes
 }
 %%

--- a/doc/src/quickstart.md
+++ b/doc/src/quickstart.md
@@ -101,7 +101,7 @@ is lexed, but no lexemes are created from it.
 
 Our initial version of calc.y looks as follows:
 ```rust,noplaypen
-%grmtools{yacckind Grmtools}
+%grmtools{yacckind: Grmtools}
 %start Expr
 %%
 Expr -> Result<u64, ()>:

--- a/doc/src/yaccextensions.md
+++ b/doc/src/yaccextensions.md
@@ -11,7 +11,7 @@ But a default can be set or forced by using a `YaccKindResolver`.
 ## Example
 
 ```
-%grmtools{yacckind Grmtools}
+%grmtools{yacckind: Grmtools}
 %%
 Start: ;
 ```

--- a/lrlex/examples/calc_manual_lex/src/calc.y
+++ b/lrlex/examples/calc_manual_lex/src/calc.y
@@ -1,4 +1,4 @@
-%grmtools{yacckind Grmtools}
+%grmtools{yacckind: Grmtools}
 %start Expr
 %avoid_insert "INT"
 %expect-unused Unmatched "UNMATCHED"

--- a/lrpar/cttests/src/calc_nodefault_yacckind.test
+++ b/lrpar/cttests/src/calc_nodefault_yacckind.test
@@ -1,6 +1,6 @@
 name: Test basic user actions using the calculator grammar
 grammar: |
-    %grmtools {yacckind Original(UserAction)}
+    %grmtools {yacckind: Original(UserAction)}
     %start Expr
     %actiontype Result<u64, ()>
     %avoid_insert 'INT'

--- a/lrpar/cttests/src/calc_wasm.test
+++ b/lrpar/cttests/src/calc_wasm.test
@@ -1,6 +1,6 @@
 name: Test running on wasm targets
 grammar: |
-    %grmtools {yacckind Grmtools}
+    %grmtools {yacckind: Grmtools}
     %start Expr
     %avoid_insert "INT"
     %expect-unused Unmatched "UNMATCHED"

--- a/lrpar/cttests/src/cgen_helper.rs
+++ b/lrpar/cttests/src/cgen_helper.rs
@@ -79,10 +79,10 @@ pub(crate) fn run_test_path<P: AsRef<Path>>(path: P) -> Result<(), Box<dyn std::
         // Create grammar files
         let base = path.file_stem().unwrap().to_str().unwrap();
         let mut pg = PathBuf::from(&out_dir);
-        pg.push(format!("{}.y.rs", base));
+        pg.push(format!("{}.test.y", base));
         fs::write(&pg, grm).unwrap();
         let mut pl = PathBuf::from(&out_dir);
-        pl.push(format!("{}.l.rs", base));
+        pl.push(format!("{}.test.l", base));
         fs::write(&pl, lex).unwrap();
 
         // Build parser and lexer

--- a/lrpar/cttests/src/grmtools_section.test
+++ b/lrpar/cttests/src/grmtools_section.test
@@ -1,0 +1,103 @@
+grammar: |
+    %grmtools{yacckind: Grmtools}
+    %token MAGIC IDENT NUM
+    %epp MAGIC "%grmtools"
+    %%
+    start -> Vec<ValBind<'input>>
+    : MAGIC '{' contents '}' { $3 }
+    ;
+
+    contents -> Vec<ValBind<'input>>
+    : %empty { vec![] }
+    | val_seq comma_opt { $1 }
+    ;
+
+    val_seq -> Vec<ValBind<'input>>
+    : valbind {
+        vec![$1]
+    }
+    | val_seq ',' valbind {
+        $1.push($3);
+        $1
+    }
+    ;
+
+    path -> Path<'input>
+    : IDENT {
+        let ident = $lexer.span_str($1.as_ref().unwrap().span());
+        Path::Ident(ident)
+    }
+    | IDENT '::' IDENT {
+        let scope = $lexer.span_str($1.as_ref().unwrap().span());
+        let ident = $lexer.span_str($2.as_ref().unwrap().span());
+        Path::Scoped(scope, ident)
+    }
+    ;
+
+    valbind -> ValBind<'input>
+    : IDENT ':' val {
+        let key = $lexer.span_str($1.as_ref().unwrap().span());
+        ValBind::Bind(key, $3)
+    }
+    | IDENT {
+        let key = $lexer.span_str($1.as_ref().unwrap().span());
+        ValBind::TrueKey(key)
+    }
+    | '!' IDENT {
+        let key = $lexer.span_str($2.as_ref().unwrap().span());
+        ValBind::FalseKey(key)
+    }
+    ;
+
+    val -> Val<'input>
+    : path { Val::PathLike($1) }
+    | NUM  {
+        let n = str::parse::<u64>($lexer.span_str($1.as_ref().unwrap().span()));
+        Val::Num(n.expect("convertible"))
+    }
+    | path '(' path ')' { Val::ArgLike($1, $3) }
+    ;
+
+    comma_opt -> ()
+    : %empty { }
+    | ',' { }
+    ;
+    %%
+    #![allow(dead_code)]
+    #![allow(unused)]
+
+    #[derive(Debug)]
+    pub enum ValBind<'a> {
+        FalseKey(&'a str),
+        TrueKey(&'a str),
+        Bind(&'a str, Val<'a>),
+    }
+
+    #[derive(Debug)]
+    pub enum Path<'a> {
+        Ident(&'a str),
+        Scoped(&'a str, &'a str),
+    }
+
+    #[derive(Debug)]
+    pub enum Val<'a> {
+        PathLike(Path<'a>),
+        ArgLike(Path<'a>, Path<'a>),
+        Num(u64),
+    }
+
+lexer: |
+    %grmtools{case_insensitive}
+    %%
+    %grmtools 'MAGIC'
+    ! '!'
+    [A-Z][A-Z_]* 'IDENT'
+    [0-9]+ 'NUM'
+    , ','
+    \{ '{'
+    \} '}'
+    \( '('
+    \) ')'
+    :: '::'
+    : ':'
+    [\n\t\ ] ;

--- a/lrpar/cttests/src/lex_flags.test
+++ b/lrpar/cttests/src/lex_flags.test
@@ -1,0 +1,13 @@
+name: Lex flags in the grmtools section
+grammar: |
+    %grmtools{yacckind: Original(NoAction)}
+    %start Start
+    %%
+    Start: 'ANY' | 'a' | 'NL';
+
+lexer: |
+    %grmtools{!dot_matches_new_line, octal, size_limit: 1048576}
+    %%
+    \141 'a'
+    . 'ANY'
+    [\n] 'NL'

--- a/lrpar/cttests/src/regex_opt.test
+++ b/lrpar/cttests/src/regex_opt.test
@@ -1,4 +1,4 @@
-name: Test NoAction using the calculator grammar
+name: Test regex options via builder.
 yacckind: Original(YaccOriginalActionKind::NoAction)
 lex_flags: ['!dot_matches_new_line', 'octal']
 grammar: |

--- a/lrpar/cttests/src/storaget.y
+++ b/lrpar/cttests/src/storaget.y
@@ -1,4 +1,4 @@
-%grmtools{yacckind Grmtools}
+%grmtools{yacckind: Grmtools}
 %%
 word_seq -> Vec<String>
     : "word" {vec![$lexer.span_str($1.as_ref().unwrap().span()).to_string()]

--- a/lrpar/examples/calc_actions/src/calc.y
+++ b/lrpar/examples/calc_actions/src/calc.y
@@ -1,4 +1,4 @@
-%grmtools {yacckind Grmtools}
+%grmtools {yacckind: Grmtools}
 %start Expr
 %avoid_insert "INT"
 %%

--- a/lrpar/examples/calc_ast/src/calc.y
+++ b/lrpar/examples/calc_ast/src/calc.y
@@ -1,4 +1,4 @@
-%grmtools {yacckind Grmtools}
+%grmtools {yacckind: Grmtools}
 %start Expr
 %avoid_insert "INT"
 %expect-unused Unmatched "UNMATCHED"

--- a/lrpar/examples/calc_parsetree/src/calc.y
+++ b/lrpar/examples/calc_parsetree/src/calc.y
@@ -1,4 +1,4 @@
-%grmtools{yacckind Original(GenericParseTree)}
+%grmtools{yacckind: Original(GenericParseTree)}
 %start Expr
 %avoid_insert "INT"
 %%

--- a/lrpar/examples/clone_param/src/param.y
+++ b/lrpar/examples/clone_param/src/param.y
@@ -1,4 +1,4 @@
-%grmtools {yacckind Grmtools}
+%grmtools {yacckind: Grmtools}
 %token Incr Decr
 %parse-param val: Rc<RefCell<i64>>
 %%

--- a/lrpar/examples/start_states/src/comment.y
+++ b/lrpar/examples/start_states/src/comment.y
@@ -1,4 +1,4 @@
-%grmtools{yacckind Original(GenericParseTree)}
+%grmtools{yacckind: Original(GenericParseTree)}
 %start Expr
 %%
 Expr: Expr Text | ;


### PR DESCRIPTION
This uses the modified grmtools section grammar from #490 which adds a comma to make it unambiguous.
This isn't what is currently parsed by the section parsing code in `parser.rs`.

using a self hosted grammar isn't something we currently do,
This patch doesn't intend to add it.  However it occurred to me that we could still run it in
`cttests/` over the `lrpar/example/*.{l,y}` and those generated by cttests.

This currently works for all the files in the repository,
you need to have at least 3 entries in the grmtools section before it realizes something is awry.
because it reads the first and second entries as key/value.

Marking this as draft for the following purposes
1. until there is agreement on whether this change of syntax is acceptable and good...
2. until we change the parser.rs files to accept it.

Edit:
  The other thing this doesn't try to do is add a specialized parser for lex or one for yacc files.
  Accepting just the keys for the respective files, I guess we could do a separate parser each?