### PR TITLE
print cargo::rerun-if-changed directives from cttests/build.rs

### DIFF
--- a/lrpar/cttests/src/cgen_helper.rs
+++ b/lrpar/cttests/src/cgen_helper.rs
@@ -12,7 +12,7 @@ pub(crate) fn run_test_path<P: AsRef<Path>>(path: P) -> Result<(), Box<dyn std::
     let out_dir = env::var("OUT_DIR").unwrap();
     let path = path.as_ref();
     if path.is_file() {
-        println!("cargo:rerun-if-changed={}", path.display());
+        println!("cargo::rerun-if-changed={}", path.display());
         // Parse test file
         let s = fs::read_to_string(path).unwrap();
         let docs = YamlLoader::load_from_str(&s).unwrap();


### PR DESCRIPTION
Emit cargo::rerun-if-changed from src/*.rs, src/*.test, storaget.l, storaget.y, storaget.l.rs storaget.y.rs.

Files that are not emitted include *.test.l, *.test.y, and their respective .l.rs and .y.rs files. This is because the .test cgen_helper don't check timestamps and would always result in spurious rebuilds.