### PR TITLE
Add a manual implementation of the grmtools_section_parser from cttests.

### DIFF
--- a/cfgrammar/src/lib/header.rs
+++ b/cfgrammar/src/lib/header.rs
@@ -1,0 +1,325 @@
+use crate::Span;
+use lazy_static::lazy_static;
+use regex::{Regex, RegexBuilder};
+use std::collections::{hash_map::Entry, HashMap};
+
+#[derive(Debug)]
+pub struct HeaderError {
+    pub kind: HeaderErrorKind,
+    pub spans: Vec<Span>,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+#[non_exhaustive]
+#[doc(hidden)]
+pub enum HeaderErrorKind {
+    MissingGrmtoolsSection,
+    IllegalName,
+    ExpectedToken(char),
+    DuplicateEntry,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+#[doc(hidden)]
+pub enum Path<'a> {
+    Ident(&'a str, Span),
+    Scoped((&'a str, Span), (&'a str, Span)),
+}
+
+#[derive(Debug, Eq, PartialEq)]
+#[doc(hidden)]
+pub enum Setting<'a> {
+    PathLike(Path<'a>),
+    ArgLike(Path<'a>, Path<'a>),
+    Num(u64, Span),
+}
+
+/// Parser for the `%grmtools` section
+#[doc(hidden)]
+pub struct GrmtoolsSectionParser<'input> {
+    src: &'input str,
+    required: bool,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum Value<'a> {
+    Flag(bool),
+    Setting(Setting<'a>),
+}
+
+lazy_static! {
+    static ref RE_LEADING_WS: Regex = Regex::new(r"^[\p{Pattern_White_Space}]*").unwrap();
+    static ref RE_NAME: Regex = RegexBuilder::new(r"^[A-Z][A-Z_]*")
+        .case_insensitive(true)
+        .build()
+        .unwrap();
+    static ref RE_DIGITS: Regex = Regex::new(r"^[0-9]+").unwrap();
+}
+
+const MAGIC: &str = "%grmtools";
+
+fn add_duplicate_occurrence(
+    errs: &mut Vec<HeaderError>,
+    kind: HeaderErrorKind,
+    orig_span: Span,
+    dup_span: Span,
+) {
+    if !errs.iter_mut().any(|e| {
+        if e.kind == kind && e.spans[0] == orig_span {
+            e.spans.push(dup_span);
+            true
+        } else {
+            false
+        }
+    }) {
+        errs.push(HeaderError {
+            kind,
+            spans: vec![orig_span, dup_span],
+        });
+    }
+}
+
+impl<'input> GrmtoolsSectionParser<'input> {
+    pub fn parse_value(
+        &'_ self,
+        mut i: usize,
+    ) -> Result<(&'_ str, Span, Value<'_>, usize), HeaderError> {
+        if let Some(i) = self.lookahead_is("!", i) {
+            let (flag_name, j) = self.parse_name(i)?;
+            Ok((
+                flag_name,
+                Span::new(i, j),
+                Value::Flag(false),
+                self.parse_ws(j),
+            ))
+        } else {
+            let (key_name, j) = self.parse_name(i)?;
+            let key_span = Span::new(i, j);
+            i = self.parse_ws(j);
+            if let Some(j) = self.lookahead_is(":", i) {
+                i = self.parse_ws(j);
+                match RE_DIGITS.find(&self.src[i..]) {
+                    Some(m) => {
+                        let num_span = Span::new(i + m.start(), i + m.end());
+                        let num_str = &self.src[num_span.start()..num_span.end()];
+                        // If the above regex matches we expect this to succeed.
+                        let num = str::parse::<u64>(num_str).unwrap();
+                        let val = Setting::Num(num, num_span);
+                        i = self.parse_ws(num_span.end());
+                        Ok((key_name, key_span, Value::Setting(val), i))
+                    }
+                    None => {
+                        let (path_val, j) = self.parse_path(i)?;
+                        i = self.parse_ws(j);
+                        if let Some(j) = self.lookahead_is("(", i) {
+                            let (arg, j) = self.parse_path(j)?;
+                            i = self.parse_ws(j);
+                            if let Some(j) = self.lookahead_is(")", i) {
+                                i = self.parse_ws(j);
+                                Ok((
+                                    key_name,
+                                    key_span,
+                                    Value::Setting(Setting::ArgLike(path_val, arg)),
+                                    i,
+                                ))
+                            } else {
+                                Err(HeaderError {
+                                    kind: HeaderErrorKind::ExpectedToken(')'),
+                                    spans: vec![Span::new(i, i)],
+                                })
+                            }
+                        } else {
+                            Ok((
+                                key_name,
+                                key_span,
+                                Value::Setting(Setting::PathLike(path_val)),
+                                i,
+                            ))
+                        }
+                    }
+                }
+            } else {
+                Ok((key_name, key_span, Value::Flag(true), i))
+            }
+        }
+    }
+
+    fn parse_path(&'_ self, mut i: usize) -> Result<(Path<'_>, usize), HeaderError> {
+        let (name, j) = self.parse_name(i)?;
+        let name_span = Span::new(i, j);
+        i = self.parse_ws(j);
+        if let Some(j) = self.lookahead_is("::", i) {
+            i = self.parse_ws(j);
+            let (scoped_val, j) = self.parse_name(i)?;
+            let scoped_span = Span::new(i, j);
+            i = self.parse_ws(j);
+            Ok((
+                Path::Scoped((name, name_span), (scoped_val, scoped_span)),
+                i,
+            ))
+        } else {
+            Ok((Path::Ident(name, name_span), i))
+        }
+    }
+
+    /// Parses any `%grmtools` section at the beginning of `src`.
+    /// If `required` is true, the parse function will
+    /// return an error if the `%grmtools` section is
+    /// missing.
+    ///
+    /// If required is set and the section is empty, no error will be
+    /// produced. If a caller requires a value they should
+    /// produce an error that specifies the required value.
+    ///
+    pub fn new(src: &'input str, required: bool) -> Self {
+        Self { src, required }
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub fn parse(
+        &'_ self,
+    ) -> Result<(HashMap<&'_ str, (Span, Value<'_>)>, usize), Vec<HeaderError>> {
+        let mut errs = Vec::new();
+        if let Some(mut i) = self.lookahead_is(MAGIC, 0) {
+            let mut ret = HashMap::new();
+            i = self.parse_ws(i);
+            let section_start_pos = i;
+            if let Some(j) = self.lookahead_is("{", i) {
+                i = self.parse_ws(j);
+                while self.lookahead_is("}", i).is_none() && i < self.src.len() {
+                    let (key, key_span, val, j) = match self.parse_value(i) {
+                        Ok((key, key_span, val, pos)) => (key, key_span, val, pos),
+                        Err(e) => {
+                            errs.push(e);
+                            return Err(errs);
+                        }
+                    };
+                    match ret.entry(key) {
+                        Entry::Occupied(orig) => {
+                            let (orig_span, _) = orig.get();
+                            add_duplicate_occurrence(
+                                &mut errs,
+                                HeaderErrorKind::DuplicateEntry,
+                                *orig_span,
+                                key_span,
+                            )
+                        }
+                        Entry::Vacant(entry) => {
+                            entry.insert((key_span, val));
+                        }
+                    }
+                    if let Some(j) = self.lookahead_is(",", j) {
+                        i = self.parse_ws(j);
+                        continue;
+                    } else {
+                        i = j;
+                        break;
+                    }
+                }
+                if self.lookahead_is("}", i).is_some() {
+                    if errs.is_empty() {
+                        Ok((ret, i))
+                    } else {
+                        Err(errs)
+                    }
+                } else {
+                    errs.push(HeaderError {
+                        kind: HeaderErrorKind::ExpectedToken('}'),
+                        spans: vec![Span::new(section_start_pos, self.src.len())],
+                    });
+                    Err(errs)
+                }
+            } else {
+                errs.push(HeaderError {
+                    kind: HeaderErrorKind::ExpectedToken('{'),
+                    spans: vec![Span::new(i, i)],
+                });
+                Err(errs)
+            }
+        } else if self.required {
+            errs.push(HeaderError {
+                kind: HeaderErrorKind::MissingGrmtoolsSection,
+                spans: vec![Span::new(0, 0)],
+            });
+            Err(errs)
+        } else {
+            Ok((HashMap::new(), 0))
+        }
+    }
+
+    fn parse_name(&self, i: usize) -> Result<(&str, usize), HeaderError> {
+        match RE_NAME.find(&self.src[i..]) {
+            Some(m) => {
+                assert_eq!(m.start(), 0);
+                Ok((&self.src[i..i + m.end()], i + m.end()))
+            }
+            None => Err(HeaderError {
+                kind: HeaderErrorKind::IllegalName,
+                spans: vec![Span::new(i, i)],
+            }),
+        }
+    }
+
+    fn lookahead_is(&self, s: &'static str, i: usize) -> Option<usize> {
+        if self.src[i..].starts_with(s) {
+            Some(i + s.len())
+        } else {
+            None
+        }
+    }
+
+    fn parse_ws(&self, i: usize) -> usize {
+        RE_LEADING_WS
+            .find(&self.src[i..])
+            .map(|m| m.end() + i)
+            .unwrap_or(i)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_header_missing_curly_bracket() {
+        let src = "%grmtools { a, b";
+        for flag in [true, false] {
+            let parser = GrmtoolsSectionParser::new(src, flag);
+            let res = parser.parse();
+            assert!(res.is_err());
+        }
+    }
+
+    #[test]
+    fn test_header_missing_curly_bracket_empty() {
+        let src = "%grmtools {";
+        for flag in [true, false] {
+            let parser = GrmtoolsSectionParser::new(src, flag);
+            let res = parser.parse();
+            assert!(res.is_err());
+        }
+    }
+
+    #[test]
+    fn test_header_missing_curly_bracket_invalid() {
+        let src = "%grmtools {####";
+        for flag in [true, false] {
+            let parser = GrmtoolsSectionParser::new(src, flag);
+            let res = parser.parse();
+            assert!(res.is_err());
+        }
+    }
+
+    #[test]
+    fn test_header_duplicates() {
+        let src = "%grmtools {dupe, !dupe, dupe: test}";
+        for flag in [true, false] {
+            let parser = GrmtoolsSectionParser::new(src, flag);
+            let res = parser.parse();
+            let errs = res.unwrap_err();
+            assert_eq!(errs.len(), 1);
+            assert_eq!(errs[0].kind, HeaderErrorKind::DuplicateEntry);
+            assert_eq!(errs[0].spans.len(), 3);
+        }
+    }
+}

--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -56,6 +56,8 @@ use bincode::{Decode, Encode};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+#[doc(hidden)]
+pub mod header;
 mod idxnewtype;
 pub mod newlinecache;
 pub mod span;

--- a/lrpar/cttests/src/grmtools_section.test
+++ b/lrpar/cttests/src/grmtools_section.test
@@ -3,59 +3,98 @@ grammar: |
     %token MAGIC IDENT NUM
     %epp MAGIC "%grmtools"
     %%
-    start -> Vec<ValBind<'input>>
+    start -> Result<HashMap<&'input str, (Span, Value<'input>)>, Vec<HeaderError>>
     : MAGIC '{' contents '}' { $3 }
     ;
 
-    contents -> Vec<ValBind<'input>>
-    : %empty { vec![] }
+    contents -> Result<HashMap<&'input str, (Span, Value<'input>)>, Vec<HeaderError>>
+    : %empty { Ok(HashMap::new()) }
     | val_seq comma_opt { $1 }
     ;
 
-    val_seq -> Vec<ValBind<'input>>
+    val_seq -> Result<HashMap<&'input str, (Span, Value<'input>)>, Vec<HeaderError>>
     : valbind {
-        vec![$1]
+        let ((key, key_span), val) = $1;
+        let mut ret = HashMap::new();
+        match ret.entry(key) {
+            Entry::Occupied(orig) => {
+                let (orig_span, _) = orig.get();
+                // One difference between the manually written parser and this
+                // is we don't try return multiple errors, or coalesce them.
+                return Err(vec![HeaderError {
+                    kind: HeaderErrorKind::DuplicateEntry,
+                    spans: vec![*orig_span, key_span]
+                }]);
+            }
+            Entry::Vacant(entry) => {
+                entry.insert((key_span, val));
+            }
+        }
+        Ok(ret)
     }
     | val_seq ',' valbind {
-        $1.push($3);
-        $1
+        let ((key, key_span), val) = $3;
+        let mut ret = $1?;
+        match ret.entry(key) {
+            Entry::Occupied(orig) => {
+                let (orig_span, _) = orig.get();
+                // One difference between the manually written parser and this
+                // is we don't try return multiple errors, or coalesce them.
+                return Err(vec![HeaderError {
+                    kind: HeaderErrorKind::DuplicateEntry,
+                    spans: vec![*orig_span, key_span]
+                }]);
+            }
+            Entry::Vacant(entry) => {
+                entry.insert((key_span, val));
+            }
+        }
+        Ok(ret)
     }
     ;
 
     path -> Path<'input>
     : IDENT {
-        let ident = $lexer.span_str($1.as_ref().unwrap().span());
-        Path::Ident(ident)
+        let ident_span = $1.as_ref().unwrap().span();
+        let ident = $lexer.span_str(ident_span);
+        Path::Ident(ident, ident_span)
     }
     | IDENT '::' IDENT {
-        let scope = $lexer.span_str($1.as_ref().unwrap().span());
-        let ident = $lexer.span_str($2.as_ref().unwrap().span());
-        Path::Scoped(scope, ident)
+        let scope_span = $1.as_ref().unwrap().span();
+        let scope = $lexer.span_str(scope_span);
+
+        let ident_span = $3.as_ref().unwrap().span();
+        let ident = $lexer.span_str(ident_span);
+        Path::Scoped((scope, scope_span), (ident, ident_span))
     }
     ;
 
-    valbind -> ValBind<'input>
+    valbind -> ((&'input str, Span), Value<'input>)
     : IDENT ':' val {
-        let key = $lexer.span_str($1.as_ref().unwrap().span());
-        ValBind::Bind(key, $3)
+        let key_span = $1.as_ref().unwrap().span();
+        let key = $lexer.span_str(key_span);
+        ((key, key_span), Value::Setting($3))
     }
     | IDENT {
-        let key = $lexer.span_str($1.as_ref().unwrap().span());
-        ValBind::TrueKey(key)
+        let key_span = $1.as_ref().unwrap().span();
+        let key = $lexer.span_str(key_span);
+        ((key, key_span), Value::Flag(true))
     }
     | '!' IDENT {
-        let key = $lexer.span_str($2.as_ref().unwrap().span());
-        ValBind::FalseKey(key)
+        let key_span = $2.as_ref().unwrap().span();
+        let key = $lexer.span_str(key_span);
+        ((key, key_span), Value::Flag(false))
     }
     ;
 
-    val -> Val<'input>
-    : path { Val::PathLike($1) }
+    val -> Setting<'input>
+    : path { Setting::PathLike($1) }
     | NUM  {
-        let n = str::parse::<u64>($lexer.span_str($1.as_ref().unwrap().span()));
-        Val::Num(n.expect("convertible"))
+        let num_span = $1.as_ref().unwrap().span();
+        let n = str::parse::<u64>($lexer.span_str(num_span));
+        Setting::Num(n.expect("convertible"), num_span)
     }
-    | path '(' path ')' { Val::ArgLike($1, $3) }
+    | path '(' path ')' { Setting::ArgLike($1, $3) }
     ;
 
     comma_opt -> ()
@@ -66,25 +105,17 @@ grammar: |
     #![allow(dead_code)]
     #![allow(unused)]
 
-    #[derive(Debug)]
-    pub enum ValBind<'a> {
-        FalseKey(&'a str),
-        TrueKey(&'a str),
-        Bind(&'a str, Val<'a>),
-    }
-
-    #[derive(Debug)]
-    pub enum Path<'a> {
-        Ident(&'a str),
-        Scoped(&'a str, &'a str),
-    }
-
-    #[derive(Debug)]
-    pub enum Val<'a> {
-        PathLike(Path<'a>),
-        ArgLike(Path<'a>, Path<'a>),
-        Num(u64),
-    }
+    use std::collections::{hash_map::Entry, HashMap};
+    use cfgrammar::{
+        Span,
+        header::{
+            Path,
+            Value,
+            Setting,
+            HeaderError,
+            HeaderErrorKind
+        }
+    };
 
 lexer: |
     %grmtools{case_insensitive}

--- a/lrpar/cttests/src/lib.rs
+++ b/lrpar/cttests/src/lib.rs
@@ -354,22 +354,17 @@ fn test_grmtools_section_files() {
             let lexerdef = grmtools_section_l::lexerdef();
             let s = String::from_utf8(buf).unwrap();
             let l = lexerdef.lexer(&s);
-            let (val, errs) = grmtools_section_y::parse(&l);
-            if !errs.is_empty() {
-                let mut s = "Errors:\n".to_string();
-                for e in errs {
-                    s.push_str(&format!("\t{}\n", e));
-                }
-                panic!("{}", s);
-            } else {
-                eprintln!("%grmtools {:?} {:?}", file_path.file_name(), val);
-            }
+            let (yacc_parsed, errs) = grmtools_section_y::parse(&l);
+            let parser = cfgrammar::header::GrmtoolsSectionParser::new(&s, true);
+            let (header_parsed, _) = parser.parse().unwrap();
+            assert_eq!(yacc_parsed.unwrap().unwrap(), header_parsed);
+            assert!(errs.is_empty());
         }
     }
 }
 
 #[test]
-fn test_grmtools_section() {
+fn test_grmtools_section_strings() {
     let srcs = [
         "%grmtools{}",
         "%grmtools{x}",
@@ -388,20 +383,21 @@ fn test_grmtools_section() {
         "%grmtools{a, x: y(z)}",
         "%grmtools{a, !b, x: y(z), e: f}",
         "%grmtools{a, !b, x: y(z), e: f,}",
+        "%grmtools{a, !b, x: w::y(z), e: f}",
+        "%grmtools{a, !b, x: w::y(z), e: f,}",
+        "%grmtools{a, !b, x: w::y(z), e: g::f}",
+        "%grmtools{a, !b, x: w::y(z), e: g::f,}",
     ];
 
     let lexerdef = grmtools_section_l::lexerdef();
     for src in srcs {
         let l = lexerdef.lexer(src);
-        let (val, errs) = grmtools_section_y::parse(&l);
-        if !errs.is_empty() {
-            let mut s = "Errors:\n".to_string();
-            for e in errs {
-                s.push_str(&format!("\t{}\n", e));
-            }
-            panic!("{}", s);
-        }
-        println!("{:?}", val);
+        let (yacc_parsed, errs) = grmtools_section_y::parse(&l);
+        let yacc_parsed = yacc_parsed.unwrap().unwrap();
+        let parser = cfgrammar::header::GrmtoolsSectionParser::new(src, true);
+        let (header_parsed, _) = parser.parse().unwrap();
+        assert_eq!(yacc_parsed, header_parsed);
+        assert!(errs.is_empty());
     }
 }
 


### PR DESCRIPTION
This adds a `pub` parser in cfgrammar for parsing the `%grmtools` section.

It is intended to replace both the manually written parser in GrammarAST, as well as the one in LexParser. This is also in preparation of adding values for `RecoveryKind` and `LexerKind` to their respective sections. Since those values live outside of `GrammarAST` and `LexParser` entirely.

The testsuite checks that the return values from this parser, and the yacc generated one in the testsuite are equal. This also fixes a bug in the action code of the `grammar_section.test` Which was return a "::" token in place of a value.

Note to self: need to reword the commit message to match the above.