### PR TITLE
Initial attempt at adding RecoveryKind to yacc %grmtools section

### DIFF
--- a/cfgrammar/src/lib/header.rs
+++ b/cfgrammar/src/lib/header.rs
@@ -4,7 +4,6 @@ use crate::{
     Span,
 };
 use lazy_static::lazy_static;
-use quote::{quote, ToTokens};
 use regex::{Regex, RegexBuilder};
 use std::{error::Error, fmt};
 
@@ -93,20 +92,6 @@ pub struct Namespaced {
     pub member: (String, Span),
 }
 
-impl ToTokens for Namespaced {
-    fn to_tokens(&self, toks: &mut proc_macro2::TokenStream) {
-        let namespace = self.namespace.as_ref().map(|(str, _)| str);
-        let member = &self.member.0;
-        toks.extend(if namespace.is_some() {
-            quote! {
-                #namespace::#member
-            }
-        } else {
-            quote!(#member)
-        })
-    }
-}
-
 #[derive(Debug, Eq, PartialEq)]
 #[doc(hidden)]
 pub enum Setting {
@@ -122,16 +107,6 @@ pub enum Setting {
     Num(u64, Span),
 }
 
-impl ToTokens for Setting {
-    fn to_tokens(&self, toks: &mut proc_macro2::TokenStream) {
-        toks.extend(match self {
-            Self::Unitary(namespaced) => quote!(#namespaced),
-            Self::Constructor { ctor, arg } => quote!(#ctor(#arg)),
-            Self::Num(num, _) => quote!(#num),
-        })
-    }
-}
-
 /// Parser for the `%grmtools` section
 #[doc(hidden)]
 pub struct GrmtoolsSectionParser<'input> {
@@ -143,15 +118,6 @@ pub struct GrmtoolsSectionParser<'input> {
 pub enum Value {
     Flag(bool),
     Setting(Setting),
-}
-
-impl ToTokens for Value {
-    fn to_tokens(&self, toks: &mut proc_macro2::TokenStream) {
-        match self {
-            Value::Flag(flag) => toks.extend(quote!(#flag)),
-            Value::Setting(setting) => toks.extend(quote!(#setting)),
-        }
-    }
 }
 
 impl Value {

--- a/cfgrammar/src/lib/header.rs
+++ b/cfgrammar/src/lib/header.rs
@@ -122,7 +122,7 @@ pub enum Value {
 
 impl Value {
     pub fn matches_query_mask(&self, mask: u16) -> bool {
-        let q = self.query_bits() as u16;
+        let q = self.query_bits();
         (q & mask) == q
     }
     pub fn query_bits(&self) -> u16 {
@@ -160,9 +160,9 @@ pub enum ValueQuery {
 /// The last 8 bits is reserved for `SettingQuery`
 #[repr(u16)]
 pub enum SettingQuery {
-    Unitary = (ValueQuery::Setting as u16) | 1 << 8,
-    Constructor = (ValueQuery::Setting as u16) | 1 << 9,
-    Num = (ValueQuery::Setting as u16) | 1 << 10,
+    Unitary = (ValueQuery::Setting as u16) | (1 << 8),
+    Constructor = (ValueQuery::Setting as u16) | (1 << 9),
+    Num = (ValueQuery::Setting as u16) | (1 << 10),
 }
 
 lazy_static! {
@@ -431,7 +431,7 @@ impl Header {
         &mut self.contents
     }
 
-    pub fn mark_key_used(self: &mut Self, key: &str) {
+    pub fn mark_key_used(&mut self, key: &str) {
         let key = key.to_owned();
         let pos = self.used.binary_search(&key);
         match pos {

--- a/cfgrammar/src/lib/header.rs
+++ b/cfgrammar/src/lib/header.rs
@@ -435,7 +435,7 @@ impl Header {
         // simple to implement.
         self.contents
             .iter()
-            .filter(|(key, _)| self.used.binary_search(key).is_ok())
+            .filter(|(key, _)| self.used.binary_search(key).is_err())
     }
 
     pub fn query_key(

--- a/cfgrammar/src/lib/header.rs
+++ b/cfgrammar/src/lib/header.rs
@@ -1,12 +1,24 @@
 use crate::Span;
 use lazy_static::lazy_static;
 use regex::{Regex, RegexBuilder};
-use std::collections::{hash_map::Entry, HashMap};
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    error::Error,
+    fmt,
+};
 
 #[derive(Debug)]
 pub struct HeaderError {
     pub kind: HeaderErrorKind,
     pub spans: Vec<Span>,
+}
+
+impl Error for HeaderError {}
+
+impl fmt::Display for HeaderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.kind)
+    }
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -17,6 +29,18 @@ pub enum HeaderErrorKind {
     IllegalName,
     ExpectedToken(char),
     DuplicateEntry,
+}
+
+impl fmt::Display for HeaderErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let s = match self {
+            HeaderErrorKind::MissingGrmtoolsSection => "Missing %grmtools section",
+            HeaderErrorKind::IllegalName => "Illegal name",
+            HeaderErrorKind::ExpectedToken(c) => &format!("Expected token: '{}", c),
+            HeaderErrorKind::DuplicateEntry => "DuplicateEntry",
+        };
+        write!(f, "{}", s)
+    }
 }
 /// Indicates a value prefixed by an optional namespace.
 /// `Foo::Bar` with optional `Foo` specified being

--- a/cfgrammar/src/lib/header.rs
+++ b/cfgrammar/src/lib/header.rs
@@ -53,13 +53,13 @@ pub struct HeaderContentsError {
 #[non_exhaustive]
 #[doc(hidden)]
 pub enum HeaderContentsErrorKind {
-    WrongValueVariant,
+    QueryTypeMismatch,
 }
 
 impl fmt::Display for HeaderContentsErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let s = match self {
-            HeaderContentsErrorKind::WrongValueVariant => "value has an unexpected type",
+            HeaderContentsErrorKind::QueryTypeMismatch => "value has an unexpected type",
         };
         write!(f, "{}", s)
     }
@@ -485,11 +485,11 @@ impl Header {
             } else {
                 Some(match value {
                     Value::Flag(_) => Err(HeaderContentsError {
-                        kind: HeaderContentsErrorKind::WrongValueVariant,
+                        kind: HeaderContentsErrorKind::QueryTypeMismatch,
                         spans: vec![*key_span],
                     }),
                     Value::Setting(Setting::Num(_, num_span)) => Err(HeaderContentsError {
-                        kind: HeaderContentsErrorKind::WrongValueVariant,
+                        kind: HeaderContentsErrorKind::QueryTypeMismatch,
                         spans: if num_span.is_some() {
                             vec![num_span.unwrap()]
                         } else {
@@ -506,7 +506,7 @@ impl Header {
                             member_span
                         };
                         Err(HeaderContentsError {
-                            kind: HeaderContentsErrorKind::WrongValueVariant,
+                            kind: HeaderContentsErrorKind::QueryTypeMismatch,
                             spans: if let (Some(first_span), Some(member_span)) =
                                 (first_span, member_span)
                             {
@@ -534,7 +534,7 @@ impl Header {
                             ctor_span
                         };
                         Err(HeaderContentsError {
-                            kind: HeaderContentsErrorKind::WrongValueVariant,
+                            kind: HeaderContentsErrorKind::QueryTypeMismatch,
                             spans: if let (Some(first_span), Some(arg_span)) =
                                 (first_span, arg_span)
                             {

--- a/cfgrammar/src/lib/header.rs
+++ b/cfgrammar/src/lib/header.rs
@@ -593,7 +593,10 @@ mod test {
             let res = parser.parse();
             let errs = res.unwrap_err();
             assert_eq!(errs.len(), 1);
-            assert_eq!(errs[0].kind, HeaderErrorKind::DuplicateEntry("dupe".to_string()));
+            assert_eq!(
+                errs[0].kind,
+                HeaderErrorKind::DuplicateEntry("dupe".to_string())
+            );
             assert_eq!(errs[0].spans.len(), 3);
         }
     }

--- a/cfgrammar/src/lib/markmap.rs
+++ b/cfgrammar/src/lib/markmap.rs
@@ -1,0 +1,587 @@
+use std::borrow::Borrow;
+
+#[repr(u8)]
+#[derive(Clone, Copy)]
+enum Mark {
+    Used,
+    Required,
+    MergeBehavior(MergeBehavior),
+}
+
+impl Mark {
+    fn repr(self) -> u16 {
+        match self {
+            Self::Used => 1 << 0,
+            Self::Required => 1 << 1,
+            Self::MergeBehavior(mb) => (1 << 2) | ((mb as u16) << 8),
+        }
+    }
+}
+
+#[repr(u8)]
+#[derive(Clone, Copy)]
+pub enum MergeBehavior {
+    Theirs = 1 << 0,
+    Ours = 1 << 1,
+    // Only one of Ours or Theirs, never both but sometimes neither.
+    // The default if no merge behavior is set.
+    MutuallyExclusive = 1 << 2,
+}
+
+pub enum MergeError {
+    // Both theirs and ours were some.
+    Exclusivity,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct MarkMap<K, V> {
+    contents: Vec<(K, Option<u16>, Option<V>)>,
+}
+
+pub enum Entry<'a, K, V> {
+    Occupied(OccupiedEntry<'a, K, V>),
+    Vacant(VacantEntry<'a, K, V>),
+}
+
+impl<K: Ord + Clone, V> VacantEntry<'_, K, V> {
+    pub fn insert(self, val: V) {
+        match self.pos {
+            Ok(pos) => {
+                self.map.contents[pos].2 = Some(val);
+            }
+            Err(pos) => self.map.contents.insert(pos, (self.key, None, Some(val))),
+        }
+    }
+
+    pub fn key(&self) -> &K {
+        &self.key
+    }
+}
+
+impl<K: Ord, V> OccupiedEntry<'_, K, V> {
+    pub fn get(&self) -> &V {
+        self.map.contents[self.pos].2.as_ref().unwrap()
+    }
+
+    pub fn insert(self, val: V) -> V {
+        let v: Option<V> = self.map.contents[self.pos].2.take();
+        self.map.contents[self.pos].2 = Some(val);
+        v.unwrap()
+    }
+
+    pub fn mark(&self) -> Option<u16> {
+        self.map.contents[self.pos].1
+    }
+}
+
+pub struct OccupiedEntry<'a, K, V> {
+    pos: usize,
+    map: &'a mut MarkMap<K, V>,
+}
+
+pub struct VacantEntry<'a, K, V> {
+    pos: Result<usize, usize>,
+    key: K,
+    map: &'a mut MarkMap<K, V>,
+}
+
+impl<K: Ord + Clone, V> MarkMap<K, V> {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        MarkMap { contents: vec![] }
+    }
+
+    pub fn insert(&mut self, key: K, val: V) -> Option<V> {
+        let pos = self.contents.binary_search_by(|(k, _, _)| k.cmp(&key));
+        match pos {
+            Ok(pos) => {
+                let ret = self.contents[pos].2.take();
+                self.contents[pos].2 = Some(val);
+                ret
+            }
+            Err(pos) => {
+                self.contents.insert(pos, (key, None, Some(val)));
+                None
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn get_mark(&mut self, key: &K) -> Option<u16> {
+        let pos = self.contents.binary_search_by(|(k, _, _)| k.cmp(key));
+        match pos {
+            Ok(pos) => self.contents[pos].1,
+            Err(_) => None,
+        }
+    }
+
+    pub fn mark_used(&mut self, key: &K) {
+        let pos = self.contents.binary_search_by(|(k, _, _)| k.cmp(key));
+        match pos {
+            Ok(pos) => {
+                let mut repr = self.contents[pos].1.unwrap_or(0);
+                repr |= Mark::Used.repr();
+                self.contents[pos].1 = Some(repr);
+            }
+            Err(pos) => {
+                self.contents
+                    .insert(pos, (key.to_owned(), Some(Mark::Used.repr()), None));
+            }
+        }
+    }
+
+    pub fn mark_required(&mut self, key: &K) {
+        let pos = self.contents.binary_search_by(|(k, _, _)| k.cmp(key));
+        match pos {
+            Ok(pos) => {
+                let mut repr = self.contents[pos].1.unwrap_or(0);
+                repr |= Mark::Required.repr();
+                self.contents[pos].1 = Some(repr);
+            }
+            Err(pos) => {
+                self.contents
+                    .insert(pos, (key.to_owned(), Some(Mark::Required.repr()), None));
+            }
+        }
+    }
+
+    pub fn set_merge_behavior(&mut self, key: &K, mb: MergeBehavior) {
+        let pos = self.contents.binary_search_by(|(k, _, _)| k.cmp(key));
+        match pos {
+            Ok(pos) => {
+                let mut repr = self.contents[pos].1.unwrap_or(0);
+                let merge_reprs = Mark::MergeBehavior(MergeBehavior::MutuallyExclusive).repr()
+                    | Mark::MergeBehavior(MergeBehavior::Ours).repr()
+                    | Mark::MergeBehavior(MergeBehavior::Theirs).repr();
+                // Zap just the MergeBehavior bits.
+                repr ^= repr & merge_reprs;
+                repr |= Mark::MergeBehavior(mb).repr();
+                self.contents[pos].1 = Some(repr);
+            }
+            Err(pos) => {
+                self.contents.insert(
+                    pos,
+                    (key.to_owned(), Some(Mark::MergeBehavior(mb).repr()), None),
+                );
+            }
+        }
+    }
+
+    pub fn get<Q>(&self, key: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        let pos = self.contents.binary_search_by(|(k, _, _)| {
+            let q: &Q = k.borrow();
+            q.cmp(key)
+        });
+        match pos {
+            Err(_) => None,
+            Ok(pos) => self.contents[pos].2.as_ref(),
+        }
+    }
+
+    pub fn contains_key<Q>(&self, key: &Q) -> bool
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        self.get(key).is_some()
+    }
+
+    pub fn remove(&mut self, key: &K) -> Option<V> {
+        let pos = self.contents.binary_search_by(|(k, _, _)| k.cmp(key));
+        match pos {
+            Err(_) => None,
+            Ok(pos) => self.contents.remove(pos).2,
+        }
+    }
+
+    pub fn entry(&mut self, key: K) -> Entry<K, V> {
+        let pos = self.contents.binary_search_by(|(k, _, _)| k.cmp(&key));
+        match pos {
+            Err(pos) => Entry::Vacant(VacantEntry {
+                pos: Err(pos),
+                key,
+                map: self,
+            }),
+            Ok(pos) => {
+                if self.contents[pos].2.is_some() {
+                    Entry::Occupied(OccupiedEntry { pos, map: self })
+                } else {
+                    Entry::Vacant(VacantEntry {
+                        pos: Ok(pos),
+                        key,
+                        map: self,
+                    })
+                }
+            }
+        }
+    }
+
+    /// Merges items from `other` into `self`, for each value it checks the `MergeBehavior` of self.
+    /// The `MergeBehavior` of other is not considered.
+    ///
+    /// * `MergeBehavior::Ours`: If a value is set in `other`, a value set in self takes precedence.
+    /// * `MergeBehavior::Theirs`: if a value in `other` `is_some()`, then it will overwrite values in self.
+    /// * `MergeBehavior::MutuallyExclusive` If a value is set in `other`, that value should be `None` in self.
+    /// * If `MergeBehavior` is unset, defaults to `MergeBehavior::MutuallyExclusive`.
+    ///
+    /// For the behavior of exclusive or mark the behavior as also `Mark::Required`, then after merge call `missing()`
+    /// to check all required values.
+    pub fn merge_from(&mut self, other: Self) -> Result<(), MergeError> {
+        for (their_key, their_mark, their_val) in other.contents {
+            let pos = self.contents.binary_search_by(|x| x.0.cmp(&their_key));
+            match pos {
+                Ok(pos) => {
+                    let (_, my_mark, my_val) = &self.contents[pos];
+                    let theirs_mark = Mark::MergeBehavior(MergeBehavior::Theirs).repr();
+                    let ours_mark = Mark::MergeBehavior(MergeBehavior::Ours).repr();
+                    let exclusive_mark =
+                        Mark::MergeBehavior(MergeBehavior::MutuallyExclusive).repr();
+                    let merge_behavior = my_mark
+                        .map(|my_mark| {
+                            (my_mark & exclusive_mark)
+                                | (my_mark & ours_mark)
+                                | (my_mark & theirs_mark)
+                        })
+                        .unwrap_or(0);
+                    eprintln!("{:?}", merge_behavior);
+                    if merge_behavior == exclusive_mark || merge_behavior == 0 {
+                        if my_val.is_some() && their_val.is_some() {
+                            return Err(MergeError::Exclusivity);
+                        } else if my_val.is_none() {
+                            self.contents[pos].2 = their_val;
+                            return Ok(());
+                        }
+                    }
+                    if merge_behavior == theirs_mark && their_val.is_some() {
+                        self.contents[pos].2 = their_val;
+                        return Ok(());
+                    }
+
+                    if merge_behavior == ours_mark && my_val.is_none() {
+                        self.contents[pos].2 = their_val;
+                        return Ok(());
+                    }
+                }
+                Err(pos) => {
+                    self.contents
+                        .insert(pos, (their_key, their_mark, their_val));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn unused(&self) -> Vec<K> {
+        let mut ret = Vec::new();
+        for (k, mark, v) in &self.contents {
+            let used_mark = Mark::Used.repr();
+            if v.is_some() && mark.map(|mark| mark & used_mark) != Some(used_mark) {
+                ret.push(k.to_owned())
+            }
+        }
+        ret
+    }
+
+    pub fn missing(&self) -> Vec<&K> {
+        let mut ret = Vec::new();
+        for (k, mark, v) in &self.contents {
+            let required_mark = Mark::Required.repr();
+            if v.is_none() && mark.map(|mark| mark & required_mark) == Some(required_mark) {
+                ret.push(k)
+            }
+        }
+        ret
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn test_insert_get_remove() {
+        let mut mm = MarkMap::new();
+        mm.insert("a", "test");
+        assert_eq!(mm.get(&"a"), Some(&"test"));
+        assert_eq!(mm.remove(&"a"), Some("test"));
+        assert_eq!(mm.get(&"a"), None);
+    }
+
+    #[test]
+    fn test_entry_occupied() {
+        let mut mm = MarkMap::new();
+        mm.insert("a", "test");
+        let ent = mm.entry("a");
+        match ent {
+            Entry::Occupied(o) => {
+                assert_eq!(o.get(), &"test");
+            }
+            Entry::Vacant(_) => {
+                panic!("Expected occupied entry");
+            }
+        }
+    }
+
+    #[test]
+    fn test_entry_vacant() {
+        let mut mm = MarkMap::new();
+        mm.insert("a", "test");
+        let ent = mm.entry("b");
+        match ent {
+            Entry::Occupied(_) => {
+                panic!("Expected vacant entry");
+            }
+            Entry::Vacant(v) => {
+                v.insert("test b");
+            }
+        }
+    }
+
+    #[test]
+    fn test_mark() {
+        let mut mm = MarkMap::new();
+        assert!(mm.insert("a", "test").is_none());
+        mm.mark_used(&"a");
+        mm.set_merge_behavior(&"b", MergeBehavior::MutuallyExclusive);
+        assert_eq!(mm.get_mark(&"a"), Some(Mark::Used.repr()));
+        assert_eq!(
+            mm.get_mark(&"b"),
+            Some(Mark::MergeBehavior(MergeBehavior::MutuallyExclusive).repr())
+        );
+        assert_eq!(mm.get_mark(&"c"), None);
+        assert_eq!(mm.get(&"a"), Some(&"test"));
+        assert_eq!(mm.insert("a", "changed"), Some("test"));
+        assert_eq!(mm.get(&"b"), None);
+        assert_eq!(mm.insert("b", "added"), None);
+        assert_eq!(
+            mm.get_mark(&"b"),
+            Some(Mark::MergeBehavior(MergeBehavior::MutuallyExclusive).repr())
+        );
+        assert_eq!(mm.get(&"a"), Some(&"changed"));
+        assert_eq!(mm.get(&"c"), None);
+    }
+
+    #[test]
+    fn test_mark_stable() {
+        let mut mm: MarkMap<&str, &str> = MarkMap::new();
+        mm.mark_used(&"a");
+        assert_eq!(mm.get_mark(&"a"), Some(Mark::Used.repr()));
+        mm.mark_required(&"a");
+        assert_eq!(
+            mm.get_mark(&"a"),
+            Some(Mark::Used.repr() | Mark::Required.repr())
+        );
+        mm.set_merge_behavior(&"a", MergeBehavior::MutuallyExclusive);
+        assert_eq!(
+            mm.get_mark(&"a"),
+            Some(
+                Mark::Used.repr()
+                    | Mark::Required.repr()
+                    | Mark::MergeBehavior(MergeBehavior::MutuallyExclusive).repr()
+            )
+        );
+        mm.set_merge_behavior(&"a", MergeBehavior::Theirs);
+        assert_eq!(
+            mm.get_mark(&"a"),
+            Some(
+                Mark::Used.repr()
+                    | Mark::Required.repr()
+                    | Mark::MergeBehavior(MergeBehavior::Theirs).repr()
+            )
+        );
+        mm.set_merge_behavior(&"a", MergeBehavior::Ours);
+        assert_eq!(
+            mm.get_mark(&"a"),
+            Some(
+                Mark::Used.repr()
+                    | Mark::Required.repr()
+                    | Mark::MergeBehavior(MergeBehavior::Ours).repr()
+            )
+        );
+    }
+
+    #[test]
+    fn test_unused() {
+        {
+            let mut mm = MarkMap::new();
+            assert!(mm.insert("a", "test").is_none());
+            mm.mark_used(&"a");
+            assert_eq!(mm.get_mark(&"a"), Some(Mark::Used.repr()));
+            let empty: &[&String] = &[];
+            assert_eq!(mm.unused().as_slice(), empty);
+        }
+
+        {
+            let mut mm = MarkMap::new();
+            assert!(mm.insert("a", "test").is_none());
+            mm.mark_used(&"a");
+            assert!(mm.insert("b", "unused").is_none());
+            assert_eq!(mm.get_mark(&"a"), Some(Mark::Used.repr()));
+            assert_eq!(mm.get_mark(&"b"), None);
+            assert_eq!(mm.unused().as_slice(), &["b"]);
+        }
+    }
+
+    #[test]
+    fn test_required() {
+        {
+            let mut mm = MarkMap::new();
+            let empty: &[&String] = &[];
+            mm.mark_required(&"a");
+            assert!(mm.insert("a", "test").is_none());
+            assert_eq!(mm.get_mark(&"a"), Some(Mark::Required.repr()));
+            assert_eq!(mm.missing().as_slice(), empty);
+        }
+
+        {
+            let mut mm = MarkMap::new();
+            mm.mark_required(&"a");
+            mm.insert("for", "inference");
+            assert_eq!(mm.get_mark(&"a"), Some(Mark::Required.repr()));
+            assert_eq!(mm.missing().as_slice(), &[&"a"]);
+        }
+    }
+
+    #[test]
+    fn test_merge_empty() {
+        {
+            let mut ours: MarkMap<&str, &str> = MarkMap::new();
+            let theirs = MarkMap::new();
+            assert!(ours.merge_from(theirs).is_ok());
+        }
+        {
+            let mut ours: MarkMap<&str, &str> = MarkMap::new();
+            let theirs: MarkMap<&str, &str> = MarkMap::new();
+            ours.mark_required(&"a");
+            assert!(ours.merge_from(theirs).is_ok());
+            assert_eq!(ours.missing().as_slice(), &[&"a"]);
+        }
+
+        {
+            let mut ours: MarkMap<&str, &str> = MarkMap::new();
+            let theirs: MarkMap<&str, &str> = MarkMap::new();
+            ours.mark_required(&"a");
+            ours.set_merge_behavior(&"a", MergeBehavior::Ours);
+            assert!(ours.merge_from(theirs).is_ok());
+            assert_eq!(ours.missing().as_slice(), &[&"a"]);
+        }
+
+        {
+            let mut ours: MarkMap<&str, &str> = MarkMap::new();
+            let theirs: MarkMap<&str, &str> = MarkMap::new();
+            ours.mark_required(&"a");
+            ours.set_merge_behavior(&"a", MergeBehavior::Theirs);
+            assert!(ours.merge_from(theirs).is_ok());
+            assert_eq!(ours.missing().as_slice(), &[&"a"]);
+        }
+    }
+
+    #[test]
+    fn test_merge_conflict() {
+        {
+            let mut ours = MarkMap::new();
+            let mut theirs = MarkMap::new();
+            ours.insert("a", "ours");
+            ours.set_merge_behavior(&"a", MergeBehavior::MutuallyExclusive);
+            theirs.insert("a", "theirs");
+            assert!(ours.merge_from(theirs).is_err());
+            assert_eq!(ours.get(&"a"), Some(&"ours"));
+        }
+        {
+            // Default behavior should match `MutuallyExclusive`
+            let mut ours = MarkMap::new();
+            let mut theirs = MarkMap::new();
+            ours.insert("a", "ours");
+            theirs.insert("a", "theirs");
+            assert!(ours.merge_from(theirs).is_err());
+            assert_eq!(ours.get(&"a"), Some(&"ours"));
+        }
+    }
+
+    #[test]
+    fn test_merge_ours() {
+        {
+            let mut ours: MarkMap<&str, &str> = MarkMap::new();
+            let mut theirs: MarkMap<&str, &str> = MarkMap::new();
+            ours.insert("a", "ours");
+            theirs.set_merge_behavior(&"a", MergeBehavior::MutuallyExclusive);
+            assert!(ours.merge_from(theirs).is_ok());
+            assert_eq!(ours.get(&"a"), Some(&"ours"));
+        }
+        {
+            // Default behavior should match MutuallyExclusive
+            let mut ours: MarkMap<&str, &str> = MarkMap::new();
+            let theirs: MarkMap<&str, &str> = MarkMap::new();
+            ours.insert("a", "ours");
+            assert!(ours.merge_from(theirs).is_ok());
+            assert_eq!(ours.get(&"a"), Some(&"ours"));
+        }
+
+        {
+            let mut ours: MarkMap<&str, &str> = MarkMap::new();
+            let theirs: MarkMap<&str, &str> = MarkMap::new();
+            ours.insert("a", "ours");
+            ours.set_merge_behavior(&"a", MergeBehavior::MutuallyExclusive);
+            assert!(ours.merge_from(theirs).is_ok());
+            assert_eq!(ours.get(&"a"), Some(&"ours"));
+        }
+        {
+            let mut ours = MarkMap::new();
+            let mut theirs = MarkMap::new();
+            ours.insert("a", "ours");
+            ours.set_merge_behavior(&"a", MergeBehavior::Ours);
+            theirs.insert("a", "theirs");
+            assert!(ours.merge_from(theirs).is_ok());
+            assert_eq!(ours.get(&"a"), Some(&"ours"));
+        }
+    }
+
+    #[test]
+    fn test_merge_theirs() {
+        {
+            let mut ours: MarkMap<&str, &str> = MarkMap::new();
+            let mut theirs: MarkMap<&str, &str> = MarkMap::new();
+            ours.set_merge_behavior(&"a", MergeBehavior::MutuallyExclusive);
+            theirs.insert("a", "theirs");
+            assert!(ours.merge_from(theirs).is_ok());
+            assert_eq!(ours.get(&"a"), Some(&"theirs"));
+        }
+
+        {
+            // Should match default behavior.
+            let mut ours: MarkMap<&str, &str> = MarkMap::new();
+            let mut theirs: MarkMap<&str, &str> = MarkMap::new();
+            theirs.insert("a", "theirs");
+            assert!(ours.merge_from(theirs).is_ok());
+            assert_eq!(ours.get(&"a"), Some(&"theirs"));
+        }
+        {
+            let mut ours = MarkMap::new();
+            let mut theirs = MarkMap::new();
+            ours.insert("a", "ours");
+            ours.set_merge_behavior(&"a", MergeBehavior::Theirs);
+            eprintln!("{:?}", ours.get_mark(&"a"));
+            theirs.insert("a", "theirs");
+            assert!(ours.merge_from(theirs).is_ok());
+            assert_eq!(ours.get(&"a"), Some(&"theirs"));
+        }
+    }
+
+    #[test]
+    fn test_merge_both() {
+        {
+            let mut ours = MarkMap::new();
+            let mut theirs = MarkMap::new();
+            ours.insert("a", "ours");
+            ours.set_merge_behavior(&"a", MergeBehavior::MutuallyExclusive);
+            theirs.insert("b", "theirs");
+            theirs.set_merge_behavior(&"b", MergeBehavior::MutuallyExclusive);
+            assert!(ours.merge_from(theirs).is_ok());
+            assert_eq!(ours.get(&"a"), Some(&"ours"));
+            assert_eq!(ours.get(&"b"), Some(&"theirs"));
+        }
+    }
+}

--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -59,10 +59,10 @@ use serde::{Deserialize, Serialize};
 #[doc(hidden)]
 pub mod header;
 mod idxnewtype;
+pub mod markmap;
 pub mod newlinecache;
 pub mod span;
 pub mod yacc;
-
 pub use newlinecache::NewlineCache;
 pub use span::{Span, Spanned};
 

--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -66,7 +66,7 @@ pub mod span;
 pub mod yacc;
 
 pub use newlinecache::NewlineCache;
-pub use span::{Span, Spanned};
+pub use span::{Location, Span, Spanned};
 
 #[cfg(test)]
 pub mod test_utils;

--- a/cfgrammar/src/lib/mod.rs
+++ b/cfgrammar/src/lib/mod.rs
@@ -59,12 +59,17 @@ use serde::{Deserialize, Serialize};
 #[doc(hidden)]
 pub mod header;
 mod idxnewtype;
+
 pub mod markmap;
 pub mod newlinecache;
 pub mod span;
 pub mod yacc;
+
 pub use newlinecache::NewlineCache;
 pub use span::{Span, Spanned};
+
+#[cfg(test)]
+pub mod test_utils;
 
 /// A type specifically for rule indices.
 pub use crate::idxnewtype::{PIdx, RIdx, SIdx, TIdx};

--- a/cfgrammar/src/lib/span.rs
+++ b/cfgrammar/src/lib/span.rs
@@ -15,6 +15,15 @@ pub struct Span {
     end: usize,
 }
 
+/// A possibly inexact location which could either be a `Span`,
+/// a command-line option, or some other location described textually.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Location {
+    Span(Span),
+    CommandLine,
+    Other(String),
+}
+
 impl Span {
     /// Create a new span starting at byte `start` and ending at byte `end`.
     ///

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -6,8 +6,9 @@ use std::{
 use indexmap::{IndexMap, IndexSet};
 
 use super::{
-    parser::YaccParser, Precedence, YaccGrammarError, YaccGrammarErrorKind, YaccGrammarWarning,
-    YaccGrammarWarningKind, YaccKind,
+    parser::{ParserError, YaccParser},
+    Precedence, YaccGrammarError, YaccGrammarErrorKind, YaccGrammarWarning, YaccGrammarWarningKind,
+    YaccKind,
 };
 
 use crate::{header::Header, Span};
@@ -16,7 +17,7 @@ use crate::{header::Header, Span};
 pub struct ASTWithValidityInfo {
     yacc_kind: Option<YaccKind>,
     ast: GrammarAST,
-    errs: Vec<YaccGrammarError>,
+    errs: Vec<ParserError>,
 }
 
 impl ASTWithValidityInfo {
@@ -31,7 +32,9 @@ impl ASTWithValidityInfo {
             yp.parse().map_err(|e| errs.extend(e)).ok();
             let (yacc_kind, mut ast) = yp.build();
             if yacc_kind.is_some() {
-                ast.complete_and_validate().map_err(|e| errs.push(e)).ok();
+                ast.complete_and_validate()
+                    .map_err(|e| errs.push(ParserError::YaccGrammarError(e)))
+                    .ok();
             }
             (yacc_kind, ast)
         };
@@ -62,7 +65,7 @@ impl ASTWithValidityInfo {
     }
 
     /// Returns all errors which were encountered during AST construction.
-    pub fn errors(&self) -> &[YaccGrammarError] {
+    pub fn errors(&self) -> &[ParserError] {
         self.errs.as_slice()
     }
 }

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -24,7 +24,7 @@ impl ASTWithValidityInfo {
     /// encountered during the construction of it.  The `ASTWithValidityInfo` can be
     /// then unused to construct a `YaccGrammar`, which will either produce an
     /// `Ok(YaccGrammar)` or an `Err` which includes these errors.
-    pub fn new<'a>(header: &'a mut Header, s: &'_ str) -> Self {
+    pub fn new(header: &mut Header, s: &'_ str) -> Self {
         let mut errs = Vec::new();
         let (yacc_kind, ast) = {
             let mut yp = YaccParser::new(header, s.to_string());

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -10,11 +10,12 @@ use super::{
     YaccGrammarWarningKind, YaccKind, YaccKindResolver,
 };
 
-use crate::Span;
+use crate::{header::Header, Span};
 /// Contains a `GrammarAST` structure produced from a grammar source file.
 /// As well as any errors which occurred during the construction of the AST.
 pub struct ASTWithValidityInfo {
     yacc_kind: Option<YaccKind>,
+    header: Header,
     ast: GrammarAST,
     errs: Vec<YaccGrammarError>,
 }
@@ -26,18 +27,19 @@ impl ASTWithValidityInfo {
     /// `Ok(YaccGrammar)` or an `Err` which includes these errors.
     pub fn new(yacc_kind_resolver: YaccKindResolver, s: &str) -> Self {
         let mut errs = Vec::new();
-        let (yacc_kind, ast) = {
+        let (yacc_kind, header, ast) = {
             let mut yp = YaccParser::new(yacc_kind_resolver, s.to_string());
             yp.parse().map_err(|e| errs.extend(e)).ok();
-            let (yacc_kind, mut ast) = yp.build();
+            let (yacc_kind, header, mut ast) = yp.build();
             if yacc_kind.is_some() {
                 ast.complete_and_validate().map_err(|e| errs.push(e)).ok();
             }
-            (yacc_kind, ast)
+            (yacc_kind, header, ast)
         };
         ASTWithValidityInfo {
             ast,
             errs,
+            header,
             yacc_kind,
         }
     }
@@ -64,6 +66,17 @@ impl ASTWithValidityInfo {
     /// Returns all errors which were encountered during AST construction.
     pub fn errors(&self) -> &[YaccGrammarError] {
         self.errs.as_slice()
+    }
+
+    /// Returns a mutable reference to the parsed contents
+    /// of the `%grmtools` section from the file header.
+    pub fn header_mut(&mut self) -> &mut Header {
+        &mut self.header
+    }
+    /// Returns a reference to the parsed contents
+    /// of the `%grmtools` section from the file header.
+    pub fn header(&self) -> &Header {
+        &self.header
     }
 }
 

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -7,7 +7,7 @@ use indexmap::{IndexMap, IndexSet};
 
 use super::{
     parser::YaccParser, Precedence, YaccGrammarError, YaccGrammarErrorKind, YaccGrammarWarning,
-    YaccGrammarWarningKind, YaccKind, YaccKindResolver,
+    YaccGrammarWarningKind, YaccKind,
 };
 
 use crate::{header::Header, Span};
@@ -25,10 +25,10 @@ impl ASTWithValidityInfo {
     /// encountered during the construction of it.  The `ASTWithValidityInfo` can be
     /// then unused to construct a `YaccGrammar`, which will either produce an
     /// `Ok(YaccGrammar)` or an `Err` which includes these errors.
-    pub fn new(yacc_kind_resolver: YaccKindResolver, s: &str) -> Self {
+    pub fn new(header: Header, s: &str) -> Self {
         let mut errs = Vec::new();
         let (yacc_kind, header, ast) = {
-            let mut yp = YaccParser::new(yacc_kind_resolver, s.to_string());
+            let mut yp = YaccParser::new(header, s.to_string());
             yp.parse().map_err(|e| errs.extend(e)).ok();
             let (yacc_kind, header, mut ast) = yp.build();
             if yacc_kind.is_some() {

--- a/cfgrammar/src/lib/yacc/firsts.rs
+++ b/cfgrammar/src/lib/yacc/firsts.rs
@@ -149,6 +149,7 @@ mod test {
         },
         YaccFirsts,
     };
+    use crate::test_utils::*;
     use num_traits::{AsPrimitive, PrimInt, Unsigned};
 
     fn has<StorageT: 'static + PrimInt + Unsigned>(
@@ -182,20 +183,8 @@ mod test {
 
     #[test]
     fn test_first() {
-        let mut header = Header::new();
-        header
-            .contents_mut()
-            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert(
-            "yacckind".into(),
-            (
-                Span::new(0, 0),
-                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
-            ),
-        );
         let grm = YaccGrammar::new(
-            &mut header,
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
           %start C
           %token c d
@@ -216,20 +205,8 @@ mod test {
 
     #[test]
     fn test_first_no_subsequent_rules() {
-        let mut header = Header::new();
-        header
-            .contents_mut()
-            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert(
-            "yacckind".into(),
-            (
-                Span::new(0, 0),
-                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
-            ),
-        );
         let grm = YaccGrammar::new(
-            &mut header,
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
           %start C
           %token c d
@@ -246,20 +223,8 @@ mod test {
 
     #[test]
     fn test_first_epsilon() {
-        let mut header = Header::new();
-        header
-            .contents_mut()
-            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert(
-            "yacckind".into(),
-            (
-                Span::new(0, 0),
-                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
-            ),
-        );
         let grm = YaccGrammar::new(
-            &mut header,
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
           %start A
           %token a b c
@@ -279,20 +244,8 @@ mod test {
 
     #[test]
     fn test_last_epsilon() {
-        let mut header = Header::new();
-        header
-            .contents_mut()
-            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert(
-            "yacckind".into(),
-            (
-                Span::new(0, 0),
-                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
-            ),
-        );
         let grm = YaccGrammar::new(
-            &mut header,
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
           %start A
           %token b c
@@ -311,20 +264,8 @@ mod test {
 
     #[test]
     fn test_first_no_multiples() {
-        let mut header = Header::new();
-        header
-            .contents_mut()
-            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert(
-            "yacckind".into(),
-            (
-                Span::new(0, 0),
-                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
-            ),
-        );
         let grm = YaccGrammar::new(
-            &mut header,
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
           %start A
           %token b c
@@ -339,20 +280,8 @@ mod test {
     }
 
     fn eco_grammar() -> YaccGrammar {
-        let mut header = Header::new();
-        header
-            .contents_mut()
-            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert(
-            "yacckind".into(),
-            (
-                Span::new(0, 0),
-                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
-            ),
-        );
         YaccGrammar::new(
-            &mut header,
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
           %start S
           %token a b c d f
@@ -382,20 +311,8 @@ mod test {
 
     #[test]
     fn test_first_from_eco_bug() {
-        let mut header = Header::new();
-        header
-            .contents_mut()
-            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert(
-            "yacckind".into(),
-            (
-                Span::new(0, 0),
-                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
-            ),
-        );
         let grm = YaccGrammar::new(
-            &mut header,
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
           %start E
           %token a b c d e f

--- a/cfgrammar/src/lib/yacc/firsts.rs
+++ b/cfgrammar/src/lib/yacc/firsts.rs
@@ -195,7 +195,7 @@ mod test {
             ),
         );
         let grm = YaccGrammar::new(
-            header,
+            &mut header,
             "
           %start C
           %token c d
@@ -229,7 +229,7 @@ mod test {
             ),
         );
         let grm = YaccGrammar::new(
-            header,
+            &mut header,
             "
           %start C
           %token c d
@@ -259,7 +259,7 @@ mod test {
             ),
         );
         let grm = YaccGrammar::new(
-            header,
+            &mut header,
             "
           %start A
           %token a b c
@@ -292,7 +292,7 @@ mod test {
             ),
         );
         let grm = YaccGrammar::new(
-            header,
+            &mut header,
             "
           %start A
           %token b c
@@ -324,7 +324,7 @@ mod test {
             ),
         );
         let grm = YaccGrammar::new(
-            header,
+            &mut header,
             "
           %start A
           %token b c
@@ -352,7 +352,7 @@ mod test {
             ),
         );
         YaccGrammar::new(
-            header,
+            &mut header,
             "
           %start S
           %token a b c d f
@@ -395,7 +395,7 @@ mod test {
             ),
         );
         let grm = YaccGrammar::new(
-            header,
+            &mut header,
             "
           %start E
           %token a b c d e f

--- a/cfgrammar/src/lib/yacc/firsts.rs
+++ b/cfgrammar/src/lib/yacc/firsts.rs
@@ -143,7 +143,10 @@ where
 #[cfg(test)]
 mod test {
     use super::{
-        super::{YaccGrammar, YaccKind, YaccKindResolver, YaccOriginalActionKind},
+        super::{
+            super::{header::Header, markmap::MergeBehavior, Span},
+            YaccGrammar, YaccKind, YaccOriginalActionKind,
+        },
         YaccFirsts,
     };
     use num_traits::{AsPrimitive, PrimInt, Unsigned};
@@ -179,8 +182,20 @@ mod test {
 
     #[test]
     fn test_first() {
+        let mut header = Header::new();
+        header
+            .contents_mut()
+            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
+        header.contents_mut().mark_required(&"yacckind".to_string());
+        header.contents_mut().insert(
+            "yacckind".into(),
+            (
+                Span::new(0, 0),
+                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
+            ),
+        );
         let grm = YaccGrammar::new(
-            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
+            header,
             "
           %start C
           %token c d
@@ -201,8 +216,20 @@ mod test {
 
     #[test]
     fn test_first_no_subsequent_rules() {
+        let mut header = Header::new();
+        header
+            .contents_mut()
+            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
+        header.contents_mut().mark_required(&"yacckind".to_string());
+        header.contents_mut().insert(
+            "yacckind".into(),
+            (
+                Span::new(0, 0),
+                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
+            ),
+        );
         let grm = YaccGrammar::new(
-            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
+            header,
             "
           %start C
           %token c d
@@ -219,8 +246,20 @@ mod test {
 
     #[test]
     fn test_first_epsilon() {
+        let mut header = Header::new();
+        header
+            .contents_mut()
+            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
+        header.contents_mut().mark_required(&"yacckind".to_string());
+        header.contents_mut().insert(
+            "yacckind".into(),
+            (
+                Span::new(0, 0),
+                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
+            ),
+        );
         let grm = YaccGrammar::new(
-            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
+            header,
             "
           %start A
           %token a b c
@@ -240,8 +279,20 @@ mod test {
 
     #[test]
     fn test_last_epsilon() {
+        let mut header = Header::new();
+        header
+            .contents_mut()
+            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
+        header.contents_mut().mark_required(&"yacckind".to_string());
+        header.contents_mut().insert(
+            "yacckind".into(),
+            (
+                Span::new(0, 0),
+                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
+            ),
+        );
         let grm = YaccGrammar::new(
-            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
+            header,
             "
           %start A
           %token b c
@@ -260,8 +311,20 @@ mod test {
 
     #[test]
     fn test_first_no_multiples() {
+        let mut header = Header::new();
+        header
+            .contents_mut()
+            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
+        header.contents_mut().mark_required(&"yacckind".to_string());
+        header.contents_mut().insert(
+            "yacckind".into(),
+            (
+                Span::new(0, 0),
+                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
+            ),
+        );
         let grm = YaccGrammar::new(
-            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
+            header,
             "
           %start A
           %token b c
@@ -276,8 +339,20 @@ mod test {
     }
 
     fn eco_grammar() -> YaccGrammar {
+        let mut header = Header::new();
+        header
+            .contents_mut()
+            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
+        header.contents_mut().mark_required(&"yacckind".to_string());
+        header.contents_mut().insert(
+            "yacckind".into(),
+            (
+                Span::new(0, 0),
+                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
+            ),
+        );
         YaccGrammar::new(
-            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
+            header,
             "
           %start S
           %token a b c d f
@@ -307,8 +382,20 @@ mod test {
 
     #[test]
     fn test_first_from_eco_bug() {
+        let mut header = Header::new();
+        header
+            .contents_mut()
+            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
+        header.contents_mut().mark_required(&"yacckind".to_string());
+        header.contents_mut().insert(
+            "yacckind".into(),
+            (
+                Span::new(0, 0),
+                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
+            ),
+        );
         let grm = YaccGrammar::new(
-            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
+            header,
             "
           %start E
           %token a b c d e f

--- a/cfgrammar/src/lib/yacc/follows.rs
+++ b/cfgrammar/src/lib/yacc/follows.rs
@@ -121,6 +121,7 @@ mod test {
         },
         YaccFollows,
     };
+    use crate::test_utils::*;
     use num_traits::{AsPrimitive, PrimInt, Unsigned};
 
     fn has<StorageT: 'static + PrimInt + Unsigned>(
@@ -151,20 +152,8 @@ mod test {
     #[test]
     fn test_follow() {
         // Adapted from p2 of https://www.cs.uaf.edu/~cs331/notes/FirstFollow.pdf
-        let mut header = Header::new();
-        header
-            .contents_mut()
-            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert(
-            "yacckind".into(),
-            (
-                Span::new(0, 0),
-                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
-            ),
-        );
         let grm = YaccGrammar::new(
-            &mut header,
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
                 %start E
                 %%
@@ -187,20 +176,8 @@ mod test {
     #[test]
     fn test_follow2() {
         // Adapted from https://www.l2f.inesc-id.pt/~david/w/pt/Top-Down_Parsing/Exercise_5:_Test_2010/07/01
-        let mut header = Header::new();
-        header
-            .contents_mut()
-            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert(
-            "yacckind".into(),
-            (
-                Span::new(0, 0),
-                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
-            ),
-        );
         let grm = YaccGrammar::new(
-            &mut header,
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
                 %start A
                 %%
@@ -222,20 +199,8 @@ mod test {
 
     #[test]
     fn test_follow3() {
-        let mut header = Header::new();
-        header
-            .contents_mut()
-            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert(
-            "yacckind".into(),
-            (
-                Span::new(0, 0),
-                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
-            ),
-        );
         let grm = YaccGrammar::new(
-            &mut header,
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
                 %start S
                 %%
@@ -251,20 +216,8 @@ mod test {
 
     #[test]
     fn test_follow_corchuelo() {
-        let mut header = Header::new();
-        header
-            .contents_mut()
-            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert(
-            "yacckind".into(),
-            (
-                Span::new(0, 0),
-                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
-            ),
-        );
         let grm = YaccGrammar::new(
-            &mut header,
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
                 %start E
                 %%

--- a/cfgrammar/src/lib/yacc/follows.rs
+++ b/cfgrammar/src/lib/yacc/follows.rs
@@ -164,7 +164,7 @@ mod test {
             ),
         );
         let grm = YaccGrammar::new(
-            header,
+            &mut header,
             "
                 %start E
                 %%
@@ -200,7 +200,7 @@ mod test {
             ),
         );
         let grm = YaccGrammar::new(
-            header,
+            &mut header,
             "
                 %start A
                 %%
@@ -235,7 +235,7 @@ mod test {
             ),
         );
         let grm = YaccGrammar::new(
-            header,
+            &mut header,
             "
                 %start S
                 %%
@@ -264,7 +264,7 @@ mod test {
             ),
         );
         let grm = YaccGrammar::new(
-            header,
+            &mut header,
             "
                 %start E
                 %%

--- a/cfgrammar/src/lib/yacc/follows.rs
+++ b/cfgrammar/src/lib/yacc/follows.rs
@@ -115,7 +115,10 @@ where
 #[cfg(test)]
 mod test {
     use super::{
-        super::{YaccGrammar, YaccKind, YaccKindResolver, YaccOriginalActionKind},
+        super::{
+            super::{header::Header, markmap::MergeBehavior, Span},
+            YaccGrammar, YaccKind, YaccOriginalActionKind,
+        },
         YaccFollows,
     };
     use num_traits::{AsPrimitive, PrimInt, Unsigned};
@@ -148,8 +151,20 @@ mod test {
     #[test]
     fn test_follow() {
         // Adapted from p2 of https://www.cs.uaf.edu/~cs331/notes/FirstFollow.pdf
+        let mut header = Header::new();
+        header
+            .contents_mut()
+            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
+        header.contents_mut().mark_required(&"yacckind".to_string());
+        header.contents_mut().insert(
+            "yacckind".into(),
+            (
+                Span::new(0, 0),
+                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
+            ),
+        );
         let grm = YaccGrammar::new(
-            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
+            header,
             "
                 %start E
                 %%
@@ -172,8 +187,20 @@ mod test {
     #[test]
     fn test_follow2() {
         // Adapted from https://www.l2f.inesc-id.pt/~david/w/pt/Top-Down_Parsing/Exercise_5:_Test_2010/07/01
+        let mut header = Header::new();
+        header
+            .contents_mut()
+            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
+        header.contents_mut().mark_required(&"yacckind".to_string());
+        header.contents_mut().insert(
+            "yacckind".into(),
+            (
+                Span::new(0, 0),
+                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
+            ),
+        );
         let grm = YaccGrammar::new(
-            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
+            header,
             "
                 %start A
                 %%
@@ -195,8 +222,20 @@ mod test {
 
     #[test]
     fn test_follow3() {
+        let mut header = Header::new();
+        header
+            .contents_mut()
+            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
+        header.contents_mut().mark_required(&"yacckind".to_string());
+        header.contents_mut().insert(
+            "yacckind".into(),
+            (
+                Span::new(0, 0),
+                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
+            ),
+        );
         let grm = YaccGrammar::new(
-            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
+            header,
             "
                 %start S
                 %%
@@ -212,8 +251,20 @@ mod test {
 
     #[test]
     fn test_follow_corchuelo() {
+        let mut header = Header::new();
+        header
+            .contents_mut()
+            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
+        header.contents_mut().mark_required(&"yacckind".to_string());
+        header.contents_mut().insert(
+            "yacckind".into(),
+            (
+                Span::new(0, 0),
+                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
+            ),
+        );
         let grm = YaccGrammar::new(
-            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
+            header,
             "
                 %start E
                 %%

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -176,7 +176,7 @@ where
 // create the start rule ourselves (without relying on user input), this is a safe assumption.
 
 impl YaccGrammar<u32> {
-    pub fn new(header: Header, s: &str) -> YaccGrammarResult<Self> {
+    pub fn new<'a>(header: &'a mut Header, s: &str) -> YaccGrammarResult<Self> {
         YaccGrammar::new_with_storaget(header, s)
     }
 }
@@ -192,7 +192,7 @@ where
     /// As we're compiling the `YaccGrammar`, we add a new start rule (which we'll refer to as `^`,
     /// though the actual name is a fresh name that is guaranteed to be unique) that references the
     /// user defined start rule.
-    pub fn new_with_storaget(header: Header, s: &str) -> YaccGrammarResult<Self> {
+    pub fn new_with_storaget<'a>(header: &'a mut Header, s: &str) -> YaccGrammarResult<Self> {
         let ast_validation = ast::ASTWithValidityInfo::new(header, s);
         Self::new_from_ast_with_validity_info(&ast_validation)
     }
@@ -1156,7 +1156,7 @@ mod test {
                 YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
             ),
         );
-        let grm = YaccGrammar::new(header, "%start R %token T %% R: 'T';").unwrap();
+        let grm = YaccGrammar::new(&mut header, "%start R %token T %% R: 'T';").unwrap();
 
         assert_eq!(grm.start_prod, PIdx(1));
         assert_eq!(grm.implicit_rule(), None);
@@ -1195,7 +1195,7 @@ mod test {
                 YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
             ),
         );
-        let grm = YaccGrammar::new(header, "%start R %token T %% R : S; S: 'T';").unwrap();
+        let grm = YaccGrammar::new(&mut header, "%start R %token T %% R : S; S: 'T';").unwrap();
 
         grm.rule_idx("^").unwrap();
         grm.rule_idx("R").unwrap();
@@ -1225,7 +1225,7 @@ mod test {
         header.contents_mut().mark_required(&"yacckind".to_string());
         header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            header,
+            &mut header,
             "%start R %token T1 T2 %% R : S 'T1' S; S: 'T2';"
         ).unwrap();
 
@@ -1268,7 +1268,7 @@ mod test {
             ),
         );
         let grm = YaccGrammar::new(
-            header,
+            &mut header,
             "
             %start A
             %%
@@ -1295,7 +1295,7 @@ mod test {
         header.contents_mut().mark_required(&"yacckind".to_string());
         header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            header,
+            &mut header,
             "
             %start Expr
             %right '='
@@ -1332,7 +1332,7 @@ mod test {
         header.contents_mut().mark_required(&"yacckind".to_string());
         header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            header,
+            &mut header,
             "
             %start expr
             %left '+' '-'
@@ -1364,7 +1364,7 @@ mod test {
         header.contents_mut().mark_required(&"yacckind".to_string());
         header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Eco.into()));
         let grm = YaccGrammar::new(
-            header,
+            &mut header,
             "
           %implicit_tokens ws1 ws2
           %start S
@@ -1444,7 +1444,7 @@ mod test {
         header.contents_mut().mark_required(&"yacckind".to_string());
         header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            header,
+            &mut header,
             "
             %start A
             %%
@@ -1475,7 +1475,7 @@ mod test {
         header.contents_mut().mark_required(&"yacckind".to_string());
         header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            header,
+            &mut header,
             "
             %start A
             %%
@@ -1510,7 +1510,7 @@ mod test {
             ),
         );
         let grm = YaccGrammar::new(
-            header,
+            &mut header,
             "
             %start A
             %%
@@ -1562,7 +1562,7 @@ mod test {
         header.contents_mut().mark_required(&"yacckind".to_string());
         header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            header,
+            &mut header,
             "
             %start A
             %%
@@ -1590,7 +1590,7 @@ mod test {
         header.contents_mut().mark_required(&"yacckind".to_string());
         header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            header,
+            &mut header,
             "
             %start A
             %%
@@ -1624,7 +1624,7 @@ mod test {
             ),
         );
         let grm = YaccGrammar::new(
-            header,
+            &mut header,
             "
             %start S
             %%
@@ -1667,7 +1667,7 @@ mod test {
                 YaccKind::Original(YaccOriginalActionKind::NoAction).into(),
             ),
         );
-        let grm = YaccGrammar::new(header, src).unwrap();
+        let grm = YaccGrammar::new(&mut header, src).unwrap();
         let token_map = grm.tokens_map();
         let a_tidx = token_map.get("a");
         let foo_tidx = token_map.get("foo");
@@ -1703,7 +1703,7 @@ mod test {
                 YaccKind::Original(YaccOriginalActionKind::NoAction).into(),
             ),
         );
-        let grm = YaccGrammar::new(header, src).unwrap();
+        let grm = YaccGrammar::new(&mut header, src).unwrap();
         let token_map = grm.tokens_map();
         let c_tidx = token_map.get("c").unwrap();
         assert_eq!(grm.token_name(*c_tidx), Some("c"));

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -176,7 +176,7 @@ where
 // create the start rule ourselves (without relying on user input), this is a safe assumption.
 
 impl YaccGrammar<u32> {
-    pub fn new<'a>(header: &'a mut Header, s: &str) -> YaccGrammarResult<Self> {
+    pub fn new(header: &mut Header, s: &str) -> YaccGrammarResult<Self> {
         YaccGrammar::new_with_storaget(header, s)
     }
 }
@@ -192,7 +192,7 @@ where
     /// As we're compiling the `YaccGrammar`, we add a new start rule (which we'll refer to as `^`,
     /// though the actual name is a fresh name that is guaranteed to be unique) that references the
     /// user defined start rule.
-    pub fn new_with_storaget<'a>(header: &'a mut Header, s: &str) -> YaccGrammarResult<Self> {
+    pub fn new_with_storaget(header: &mut Header, s: &str) -> YaccGrammarResult<Self> {
         let ast_validation = ast::ASTWithValidityInfo::new(header, s);
         Self::new_from_ast_with_validity_info(&ast_validation)
     }
@@ -1125,6 +1125,7 @@ mod test {
         },
         rule_max_costs, rule_min_costs, IMPLICIT_RULE, IMPLICIT_START_RULE,
     };
+    use crate::test_utils::*;
     use crate::{PIdx, RIdx, Span, Symbol, TIdx};
     use std::collections::HashMap;
 
@@ -1144,19 +1145,11 @@ mod test {
 
     #[test]
     fn test_minimal() {
-        let mut header = Header::new();
-        header
-            .contents_mut()
-            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert(
-            "yacckind".into(),
-            (
-                Span::new(0, 0),
-                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
-            ),
-        );
-        let grm = YaccGrammar::new(&mut header, "%start R %token T %% R: 'T';").unwrap();
+        let grm = YaccGrammar::new(
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
+            "%start R %token T %% R: 'T';",
+        )
+        .unwrap();
 
         assert_eq!(grm.start_prod, PIdx(1));
         assert_eq!(grm.implicit_rule(), None);
@@ -1183,19 +1176,11 @@ mod test {
 
     #[test]
     fn test_rule_ref() {
-        let mut header = Header::new();
-        header
-            .contents_mut()
-            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert(
-            "yacckind".into(),
-            (
-                Span::new(0, 0),
-                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
-            ),
-        );
-        let grm = YaccGrammar::new(&mut header, "%start R %token T %% R : S; S: 'T';").unwrap();
+        let grm = YaccGrammar::new(
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
+            "%start R %token T %% R : S; S: 'T';",
+        )
+        .unwrap();
 
         grm.rule_idx("^").unwrap();
         grm.rule_idx("R").unwrap();
@@ -1220,12 +1205,8 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_long_prod() {
-        let mut header = Header::new();
-        header.contents_mut().set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            &mut header,
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "%start R %token T1 T2 %% R : S 'T1' S; S: 'T2';"
         ).unwrap();
 
@@ -1255,20 +1236,8 @@ mod test {
 
     #[test]
     fn test_prods_rules() {
-        let mut header = Header::new();
-        header
-            .contents_mut()
-            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert(
-            "yacckind".into(),
-            (
-                Span::new(0, 0),
-                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
-            ),
-        );
         let grm = YaccGrammar::new(
-            &mut header,
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
             %start A
             %%
@@ -1290,12 +1259,8 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_left_right_nonassoc_precs() {
-        let mut header = Header::new();
-        header.contents_mut().set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            &mut header,
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
             %start Expr
             %right '='
@@ -1327,12 +1292,8 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_prec_override() {
-        let mut header = Header::new();
-        header.contents_mut().set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            &mut header,
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
             %start expr
             %left '+' '-'
@@ -1359,13 +1320,8 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_implicit_tokens_rewrite() {
-        let mut header = Header::new();
-        header.contents_mut().set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Eco.into()));
         let grm = YaccGrammar::new(
-            &mut header,
-            "
+            &mut header_for_yacckind!(YaccKind::Eco),"
           %implicit_tokens ws1 ws2
           %start S
           %%
@@ -1439,12 +1395,8 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_has_path() {
-        let mut header = Header::new();
-        header.contents_mut().set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            &mut header,
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
             %start A
             %%
@@ -1470,12 +1422,8 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_rule_min_costs() {
-        let mut header = Header::new();
-        header.contents_mut().set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            &mut header,
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
             %start A
             %%
@@ -1497,20 +1445,8 @@ mod test {
 
     #[test]
     fn test_min_sentences() {
-        let mut header = Header::new();
-        header
-            .contents_mut()
-            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert(
-            "yacckind".into(),
-            (
-                Span::new(0, 0),
-                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
-            ),
-        );
         let grm = YaccGrammar::new(
-            &mut header,
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
             %start A
             %%
@@ -1557,12 +1493,8 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_rule_max_costs1() {
-        let mut header = Header::new();
-        header.contents_mut().set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            &mut header,
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
             %start A
             %%
@@ -1585,12 +1517,8 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_rule_max_costs2() {
-        let mut header = Header::new();
-        header.contents_mut().set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            &mut header,
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
             %start A
             %%
@@ -1611,20 +1539,8 @@ mod test {
     #[test]
     fn test_out_of_order_productions() {
         // Example taken from p54 of Locally least-cost error repair in LR parsers, Carl Cerecke
-        let mut header = Header::new();
-        header
-            .contents_mut()
-            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert(
-            "yacckind".into(),
-            (
-                Span::new(0, 0),
-                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
-            ),
-        );
         let grm = YaccGrammar::new(
-            &mut header,
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
             %start S
             %%
@@ -1655,19 +1571,11 @@ mod test {
     #[test]
     fn test_token_spans() {
         let src = "%%\nAB: 'a' | 'foo';";
-        let mut header = Header::new();
-        header
-            .contents_mut()
-            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert(
-            "yacckind".into(),
-            (
-                Span::new(0, 0),
-                YaccKind::Original(YaccOriginalActionKind::NoAction).into(),
-            ),
-        );
-        let grm = YaccGrammar::new(&mut header, src).unwrap();
+        let grm = YaccGrammar::new(
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::NoAction)),
+            src,
+        )
+        .unwrap();
         let token_map = grm.tokens_map();
         let a_tidx = token_map.get("a");
         let foo_tidx = token_map.get("foo");
@@ -1691,19 +1599,11 @@ mod test {
                    AB: A AB | B ';' AB;
                    %%
                    ";
-        let mut header = Header::new();
-        header
-            .contents_mut()
-            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert(
-            "yacckind".into(),
-            (
-                Span::new(0, 0),
-                YaccKind::Original(YaccOriginalActionKind::NoAction).into(),
-            ),
-        );
-        let grm = YaccGrammar::new(&mut header, src).unwrap();
+        let grm = YaccGrammar::new(
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::NoAction)),
+            src,
+        )
+        .unwrap();
         let token_map = grm.tokens_map();
         let c_tidx = token_map.get("c").unwrap();
         assert_eq!(grm.token_name(*c_tidx), Some("c"));

--- a/cfgrammar/src/lib/yacc/mod.rs
+++ b/cfgrammar/src/lib/yacc/mod.rs
@@ -16,23 +16,6 @@ use quote::quote;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum YaccKindResolver {
-    /// The user can specify `%grmtools` in their grammar but unless it is compatible with this `YaccKind`, it's an error
-    Force(YaccKind),
-    /// Use `YaccKind` if the user doesn't specify `%grmtools` in their grammar
-    Default(YaccKind),
-    /// The user must specify `%grmtools` in their grammars or we throw an error
-    NoDefault,
-}
-
-impl YaccKindResolver {
-    fn forced(self) -> bool {
-        matches!(self, Self::Force(_))
-    }
-}
-
 /// The particular Yacc variant this grammar makes use of.
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -17,7 +17,7 @@ use std::{
 pub type YaccGrammarResult<T> = Result<T, Vec<YaccGrammarError>>;
 
 use crate::{
-    header::{GrmtoolsSectionParser, HeaderErrorKind, Namespaced, Setting, Value},
+    header::{GrmtoolsSectionParser, Header, HeaderErrorKind, Namespaced, Setting, Value},
     Span, Spanned,
 };
 
@@ -353,7 +353,7 @@ impl YaccParser {
         let section_required = matches!(self.yacc_kind_resolver, YaccKindResolver::NoDefault);
         let header_parser = GrmtoolsSectionParser::new(&self.src, section_required);
         let result = match header_parser.parse() {
-            Ok((header, i)) => self.update_yacckind(header, i),
+            Ok((mut header, i)) => self.update_yacckind(&mut header, i),
             Err(es) => {
                 errs.extend(es.iter().map(|e| YaccGrammarError {
                     kind: match e.kind {
@@ -427,10 +427,10 @@ impl YaccParser {
 
     fn update_yacckind(
         &mut self,
-        header: HashMap<String, (Span, Value)>,
+        header: &mut Header,
         i: usize,
     ) -> Result<usize, Vec<YaccGrammarError>> {
-        if let Some((key_span, yk_setting)) = header.get("yacckind") {
+        if let Some((key_span, yk_setting)) = header.contents().get("yacckind") {
             match yk_setting {
                 Value::Flag(_) => {
                     return Err(vec![YaccGrammarError {

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -374,7 +374,6 @@ impl YaccParser {
                 self.update_yacckind(i)
             }
             Err(es) => {
-
                 errs.extend(es.iter().map(|e| YaccGrammarError {
                     kind: match e.kind {
                         HeaderErrorKind::MissingGrmtoolsSection => {

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -299,6 +299,7 @@ impl Spanned for YaccGrammarError {
 pub(crate) struct YaccParser {
     yacc_kind_resolver: YaccKindResolver,
     yacc_kind: Option<YaccKind>,
+    header: Header,
     src: String,
     num_newlines: usize,
     ast: GrammarAST,
@@ -338,6 +339,7 @@ impl YaccParser {
         YaccParser {
             yacc_kind_resolver,
             yacc_kind: None,
+            header: Header::new(),
             src,
             num_newlines: 0,
             ast: GrammarAST::new(),
@@ -547,8 +549,8 @@ impl YaccParser {
         Ok(i)
     }
 
-    pub(crate) fn build(self) -> (Option<YaccKind>, GrammarAST) {
-        (self.yacc_kind, self.ast)
+    pub(crate) fn build(self) -> (Option<YaccKind>, Header, GrammarAST) {
+        (self.yacc_kind, self.header, self.ast)
     }
 
     fn parse_declarations(
@@ -1241,7 +1243,7 @@ mod test {
     fn parse(yacc_kind: YaccKind, s: &str) -> Result<GrammarAST, Vec<YaccGrammarError>> {
         let mut yp = YaccParser::new(YaccKindResolver::Force(yacc_kind), s.to_string());
         yp.parse()?;
-        Ok(yp.build().1)
+        Ok(yp.build().2)
     }
 
     fn rule(n: &str) -> Symbol {

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -254,6 +254,9 @@ pub enum SpansKind {
     DuplicationError,
     /// Contains a single span at the site of the error.
     Error,
+    /// May contain an empty list of spans indicating the error does not originate from a source location.
+    /// Otherwise the spans may contain a single span at the site of the error.
+    OptionalSpan,
 }
 
 impl Spanned for YaccGrammarError {
@@ -293,12 +296,7 @@ impl Spanned for YaccGrammarError {
             | YaccGrammarErrorKind::NoPrecForToken(_)
             | YaccGrammarErrorKind::MissingGrmtoolsSection
             | YaccGrammarErrorKind::InvalidGrmtoolsSectionEntry
-            | YaccGrammarErrorKind::InvalidYaccKind
-            | YaccGrammarErrorKind::InvalidYaccKindNamespace
-            | YaccGrammarErrorKind::InvalidActionKind
-            | YaccGrammarErrorKind::InvalidActionKindNamespace
             | YaccGrammarErrorKind::ExpectedInput(_)
-            | YaccGrammarErrorKind::HeaderContents(_)
             | YaccGrammarErrorKind::UnknownEPP(_) => SpansKind::Error,
             YaccGrammarErrorKind::DuplicatePrecedence
             | YaccGrammarErrorKind::DuplicateAvoidInsertDeclaration
@@ -309,6 +307,11 @@ impl Spanned for YaccGrammarError {
             | YaccGrammarErrorKind::DuplicateActiontypeDeclaration
             | YaccGrammarErrorKind::DuplicateGrmtoolsSectionEntry
             | YaccGrammarErrorKind::DuplicateEPP => SpansKind::DuplicationError,
+            YaccGrammarErrorKind::HeaderContents(_)
+            | YaccGrammarErrorKind::InvalidActionKind
+            | YaccGrammarErrorKind::InvalidYaccKindNamespace
+            | YaccGrammarErrorKind::InvalidActionKindNamespace
+            | YaccGrammarErrorKind::InvalidYaccKind => SpansKind::OptionalSpan,
         }
     }
 }
@@ -456,7 +459,11 @@ impl<'a> YaccParser<'a> {
                         if ns != "yacckind" {
                             errs.push(YaccGrammarError {
                                 kind: YaccGrammarErrorKind::InvalidYaccKindNamespace,
-                                spans: vec![*ns_span],
+                                spans: if let Some(ns_span) = ns_span {
+                                    vec![*ns_span]
+                                } else {
+                                    vec![]
+                                },
                             });
                         }
                     }
@@ -477,7 +484,11 @@ impl<'a> YaccParser<'a> {
                     } else {
                         errs.push(YaccGrammarError {
                             kind: YaccGrammarErrorKind::InvalidYaccKind,
-                            spans: vec![*yk_value_span],
+                            spans: if let Some(yk_value_span) = yk_value_span {
+                                vec![*yk_value_span]
+                            } else {
+                                vec![]
+                            },
                         });
                         return Err(errs);
                     }
@@ -504,7 +515,11 @@ impl<'a> YaccParser<'a> {
                         if yk_ns != "yacckind" {
                             errs.push(YaccGrammarError {
                                 kind: YaccGrammarErrorKind::InvalidYaccKindNamespace,
-                                spans: vec![*yk_ns_span],
+                                spans: if let Some(yk_ns_span) = yk_ns_span {
+                                    vec![*yk_ns_span]
+                                } else {
+                                    vec![]
+                                },
                             });
                         }
                     }
@@ -512,7 +527,11 @@ impl<'a> YaccParser<'a> {
                     if yk_str != "original" {
                         errs.push(YaccGrammarError {
                             kind: YaccGrammarErrorKind::InvalidYaccKind,
-                            spans: vec![*yk_span],
+                            spans: if let Some(yk_span) = yk_span {
+                                vec![*yk_span]
+                            } else {
+                                vec![]
+                            },
                         });
                     }
 
@@ -520,7 +539,11 @@ impl<'a> YaccParser<'a> {
                         if ak_ns != "yaccoriginalactionkind" {
                             errs.push(YaccGrammarError {
                                 kind: YaccGrammarErrorKind::InvalidActionKindNamespace,
-                                spans: vec![*ak_ns_span],
+                                spans: if let Some(ak_ns_span) = ak_ns_span {
+                                    vec![*ak_ns_span]
+                                } else {
+                                    vec![]
+                                },
                             });
                         }
                     }
@@ -543,7 +566,11 @@ impl<'a> YaccParser<'a> {
                     } else {
                         errs.push(YaccGrammarError {
                             kind: YaccGrammarErrorKind::InvalidActionKind,
-                            spans: vec![*ak_span],
+                            spans: if let Some(ak_span) = ak_span {
+                                vec![*ak_span]
+                            } else {
+                                vec![]
+                            },
                         });
                         return Err(errs);
                     }

--- a/lrpar/cttests/src/grmtools_section.test
+++ b/lrpar/cttests/src/grmtools_section.test
@@ -24,7 +24,7 @@ grammar: |
                 // is we don't try return multiple errors, or coalesce them.
                 return Err(vec![HeaderError {
                     kind: HeaderErrorKind::DuplicateEntry(key),
-                    spans: vec![*orig_span, key_span]
+                    locations: vec![Location::Span(*orig_span), Location::Span(key_span)]
                 }]);
             }
             Entry::Vacant(entry) => {
@@ -43,7 +43,7 @@ grammar: |
                 // is we don't try return multiple errors, or coalesce them.
                 return Err(vec![HeaderError {
                     kind: HeaderErrorKind::DuplicateEntry(key),
-                    spans: vec![*orig_span, key_span]
+                    locations: vec![Location::Span(*orig_span), Location::Span(key_span)]
                 }]);
             }
             Entry::Vacant(entry) => {
@@ -60,7 +60,7 @@ grammar: |
         let ident = $lexer.span_str(ident_span).to_string().to_lowercase();
         Namespaced{
             namespace: None,
-            member: (ident, Some(ident_span))
+            member: (ident, Location::Span(ident_span))
         }
     }
     | IDENT '::' IDENT {
@@ -70,8 +70,8 @@ grammar: |
         let ident_span = $3.as_ref().unwrap().span();
         let ident = $lexer.span_str(ident_span).to_string().to_lowercase();
         Namespaced {
-            namespace: Some((namespace, Some(namespace_span))),
-            member: (ident, Some(ident_span))
+            namespace: Some((namespace, Location::Span(namespace_span))),
+            member: (ident, Location::Span(ident_span))
         }
     }
     ;
@@ -99,7 +99,7 @@ grammar: |
     | NUM  {
         let num_span = $1.as_ref().unwrap().span();
         let n = str::parse::<u64>($lexer.span_str(num_span));
-        Setting::Num(n.expect("convertible"), Some(num_span))
+        Setting::Num(n.expect("convertible"), Location::Span(num_span))
     }
     | namespaced '(' namespaced ')' { Setting::Constructor{ctor: $1, arg: $3} }
     ;
@@ -114,6 +114,7 @@ grammar: |
 
     use cfgrammar::{
         Span,
+        span::Location,
         header::{
             Value,
             Setting,

--- a/lrpar/cttests/src/grmtools_section.test
+++ b/lrpar/cttests/src/grmtools_section.test
@@ -112,7 +112,6 @@ grammar: |
     #![allow(dead_code)]
     #![allow(unused)]
 
-    use std::collections::{hash_map::Entry, HashMap};
     use cfgrammar::{
         Span,
         header::{
@@ -122,7 +121,8 @@ grammar: |
             HeaderErrorKind,
             Namespaced,
             Header
-        }
+        },
+        markmap::{Entry, MarkMap},
     };
 
 lexer: |

--- a/lrpar/cttests/src/grmtools_section.test
+++ b/lrpar/cttests/src/grmtools_section.test
@@ -17,13 +17,13 @@ grammar: |
         let ((key, key_span), val) = $1;
         let mut ret = Header::new();
         let mut map = ret.contents_mut();
-        match map.entry(key) {
+        match map.entry(key.clone()) {
             Entry::Occupied(orig) => {
                 let (orig_span, _) = orig.get();
                 // One difference between the manually written parser and this
                 // is we don't try return multiple errors, or coalesce them.
                 return Err(vec![HeaderError {
-                    kind: HeaderErrorKind::DuplicateEntry,
+                    kind: HeaderErrorKind::DuplicateEntry(key),
                     spans: vec![*orig_span, key_span]
                 }]);
             }
@@ -36,13 +36,13 @@ grammar: |
     | val_seq ',' valbind {
         let ((key, key_span), val) = $3;
         let mut ret = $1?;
-        match ret.contents_mut().entry(key) {
+        match ret.contents_mut().entry(key.clone()) {
             Entry::Occupied(orig) => {
                 let (orig_span, _) = orig.get();
                 // One difference between the manually written parser and this
                 // is we don't try return multiple errors, or coalesce them.
                 return Err(vec![HeaderError {
-                    kind: HeaderErrorKind::DuplicateEntry,
+                    kind: HeaderErrorKind::DuplicateEntry(key),
                     spans: vec![*orig_span, key_span]
                 }]);
             }

--- a/lrpar/cttests/src/grmtools_section.test
+++ b/lrpar/cttests/src/grmtools_section.test
@@ -3,20 +3,21 @@ grammar: |
     %token MAGIC IDENT NUM
     %epp MAGIC "%grmtools"
     %%
-    start -> Result<HashMap<String, (Span, Value)>, Vec<HeaderError>>
+    start -> Result<Header, Vec<HeaderError>>
     : MAGIC '{' contents '}' { $3 }
     ;
 
-    contents -> Result<HashMap<String, (Span, Value)>, Vec<HeaderError>>
-    : %empty { Ok(HashMap::new()) }
+    contents -> Result<Header, Vec<HeaderError>>
+    : %empty { Ok(Header::new()) }
     | val_seq comma_opt { $1 }
     ;
 
-    val_seq -> Result<HashMap<String, (Span, Value)>, Vec<HeaderError>>
+    val_seq -> Result<Header, Vec<HeaderError>>
     : valbind {
         let ((key, key_span), val) = $1;
-        let mut ret = HashMap::new();
-        match ret.entry(key) {
+        let mut ret = Header::new();
+        let mut map = ret.contents_mut();
+        match map.entry(key) {
             Entry::Occupied(orig) => {
                 let (orig_span, _) = orig.get();
                 // One difference between the manually written parser and this
@@ -35,7 +36,7 @@ grammar: |
     | val_seq ',' valbind {
         let ((key, key_span), val) = $3;
         let mut ret = $1?;
-        match ret.entry(key) {
+        match ret.contents_mut().entry(key) {
             Entry::Occupied(orig) => {
                 let (orig_span, _) = orig.get();
                 // One difference between the manually written parser and this
@@ -120,6 +121,7 @@ grammar: |
             HeaderError,
             HeaderErrorKind,
             Namespaced,
+            Header
         }
     };
 

--- a/lrpar/cttests/src/grmtools_section.test
+++ b/lrpar/cttests/src/grmtools_section.test
@@ -60,7 +60,7 @@ grammar: |
         let ident = $lexer.span_str(ident_span).to_string().to_lowercase();
         Namespaced{
             namespace: None,
-            member: (ident, ident_span)
+            member: (ident, Some(ident_span))
         }
     }
     | IDENT '::' IDENT {
@@ -70,8 +70,8 @@ grammar: |
         let ident_span = $3.as_ref().unwrap().span();
         let ident = $lexer.span_str(ident_span).to_string().to_lowercase();
         Namespaced {
-            namespace: Some((namespace, namespace_span)),
-            member: (ident, ident_span)
+            namespace: Some((namespace, Some(namespace_span))),
+            member: (ident, Some(ident_span))
         }
     }
     ;
@@ -99,7 +99,7 @@ grammar: |
     | NUM  {
         let num_span = $1.as_ref().unwrap().span();
         let n = str::parse::<u64>($lexer.span_str(num_span));
-        Setting::Num(n.expect("convertible"), num_span)
+        Setting::Num(n.expect("convertible"), Some(num_span))
     }
     | namespaced '(' namespaced ')' { Setting::Constructor{ctor: $1, arg: $3} }
     ;

--- a/lrpar/cttests/src/grmtools_section.test
+++ b/lrpar/cttests/src/grmtools_section.test
@@ -1,5 +1,5 @@
 grammar: |
-    %grmtools{yacckind: Grmtools}
+    %grmtools{yacckind: Grmtools, recoverer:RecoveryKind::CPCTPlus}
     %token MAGIC IDENT NUM
     %epp MAGIC "%grmtools"
     %%

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -554,11 +554,7 @@ where
             }
         }
 
-        let unused: Vec<String> = ast_validation
-            .header()
-            .unused()
-            .map(|(key, _)| key.clone())
-            .collect::<Vec<_>>();
+        let unused: Vec<String> = ast_validation.header().contents().unused();
         if !unused.is_empty() {
             return Err(format!("Unused header settings:\n {}", unused.join("\n")).into());
         }

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -545,9 +545,7 @@ where
                         )
                         .into());
                     }
-                    if self.recoverer.is_none() {
-                        self.recoverer = rk;
-                    }
+                    self.recoverer = rk;
                 }
                 Some(err) => {
                     err?;

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -513,14 +513,20 @@ where
             lk.insert(outp.clone());
         }
 
-        let span_fmt = |span: cfgrammar::Span, s: &str, inc: &str, line_cache: &NewlineCache| {
-            if let Some((line, column)) = line_cache.byte_to_line_num_and_col_num(inc, span.start())
-            {
-                format!("{} at line {line} column {column}", s)
-            } else {
-                s.to_string()
-            }
-        };
+        let span_fmt =
+            |span: Option<cfgrammar::Span>, s: &str, inc: &str, line_cache: &NewlineCache| {
+                if let Some(span) = span {
+                    if let Some((line, column)) =
+                        line_cache.byte_to_line_num_and_col_num(inc, span.start())
+                    {
+                        format!("{} at line {line} column {column}", s)
+                    } else {
+                        s.to_string()
+                    }
+                } else {
+                    s.to_string()
+                }
+            };
 
         let inc =
             read_to_string(grmp).map_err(|e| format!("When reading '{}': {e}", grmp.display()))?;
@@ -586,7 +592,7 @@ where
         let warnings = ast_validation.ast().warnings();
         let res = YaccGrammar::<StorageT>::new_from_ast_with_validity_info(&ast_validation);
         let spanned_fmt = |x: &dyn Spanned, inc: &str, line_cache: &NewlineCache| {
-            span_fmt(x.spans()[0], &format!("{}", x), inc, line_cache)
+            span_fmt(Some(x.spans()[0]), &format!("{}", x), inc, line_cache)
         };
 
         let grm = match res {

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -526,11 +526,9 @@ where
             read_to_string(grmp).map_err(|e| format!("When reading '{}': {e}", grmp.display()))?;
         let mut line_cache = NewlineCache::new();
         line_cache.feed(&inc);
-        let mut ast_validation = ASTWithValidityInfo::new(builder_header, &inc);
+        let ast_validation = ASTWithValidityInfo::new(&mut builder_header, &inc);
         if self.recoverer.is_none() {
-            let recoverer_setting = ast_validation
-                .header_mut()
-                .query("recoverer", SettingQuery::Unitary as u16);
+            let recoverer_setting = builder_header.query("recoverer", SettingQuery::Unitary as u16);
             match recoverer_setting {
                 Some(Ok((
                     _,
@@ -575,7 +573,7 @@ where
             }
         }
 
-        let unused: Vec<String> = ast_validation.header().contents().unused();
+        let unused: Vec<String> = builder_header.contents().unused();
         assert!(unused.is_empty());
         if !unused.is_empty() {
             return Err(

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -507,6 +507,7 @@ where
         let header_parser = cfgrammar::header::GrmtoolsSectionParser::new(&inc, false);
         match header_parser.parse() {
             Ok((header, _)) => {
+                let header = header.contents();
                 if self.recoverer.is_none() {
                     if let Some((key_span, recoverer)) = header.get("recoverer") {
                         use cfgrammar::header::{Namespaced, Setting, Value};
@@ -540,14 +541,26 @@ where
                                 .iter()
                                 .find_map(|(rk_str, rk)| (member == rk_str).then_some(*rk));
                                 if rk.is_none() {
-                                    return Err(span_fmt(*member_span, "Invalid RecoveryKind specified in %grmtools section", &inc, &line_cache).into());
+                                    return Err(span_fmt(
+                                        *member_span,
+                                        "Invalid RecoveryKind specified in %grmtools section",
+                                        &inc,
+                                        &line_cache,
+                                    )
+                                    .into());
                                 }
                                 if self.recoverer.is_none() {
                                     self.recoverer = rk;
                                 }
                             }
                             Value::Setting(Setting::Constructor { ctor: _, arg: _ }) => {
-                                return Err(span_fmt(*key_span, "Invalid RecoveryKind specified in %grmtools section.", &inc, &line_cache).into());
+                                return Err(span_fmt(
+                                    *key_span,
+                                    "Invalid RecoveryKind specified in %grmtools section.",
+                                    &inc,
+                                    &line_cache,
+                                )
+                                .into());
                             }
                         }
                     }

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -553,6 +553,16 @@ where
                 None => {}
             }
         }
+
+        let unused: Vec<String> = ast_validation
+            .header()
+            .unused()
+            .map(|(key, _)| key.clone())
+            .collect::<Vec<_>>();
+        if !unused.is_empty() {
+            return Err(format!("Unused header settings:\n {}", unused.join("\n")).into());
+        }
+
         self.recoverer = Some(self.recoverer.unwrap_or(RecoveryKind::CPCTPlus));
         self.yacckind = ast_validation.yacc_kind();
         let warnings = ast_validation.ast().warnings();

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -201,7 +201,7 @@ pub mod lex_api;
 #[doc(hidden)]
 pub mod parser;
 #[cfg(test)]
-mod test_utils;
+pub mod test_utils;
 
 pub use crate::{
     ctbuilder::{CTParser, CTParserBuilder, RustEdition, Visibility},

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -987,8 +987,6 @@ pub(crate) mod test {
     use std::collections::HashMap;
 
     use cfgrammar::{
-        header::Header,
-        markmap::MergeBehavior,
         yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
         Span,
     };
@@ -997,6 +995,7 @@ pub(crate) mod test {
     use regex::Regex;
 
     use super::*;
+    use crate::test_utils::*;
     use crate::{
         test_utils::{TestLexError, TestLexeme, TestLexerTypes},
         Lexeme, Lexer,
@@ -1038,19 +1037,11 @@ pub(crate) mod test {
             ),
         >,
     ) {
-        let mut header = Header::new();
-        header
-            .contents_mut()
-            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert(
-            "yacckind".into(),
-            (
-                Span::new(0, 0),
-                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
-            ),
-        );
-        let grm = YaccGrammar::<u16>::new_with_storaget(&mut header, grms).unwrap();
+        let grm = YaccGrammar::<u16>::new_with_storaget(
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
+            grms,
+        )
+        .unwrap();
         let (_, stable) = from_yacc(&grm, Minimiser::Pager).unwrap();
         let rule_ids = grm
             .tokens_map()

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -14,7 +14,7 @@ use std::time::{Duration, Instant};
 use web_time::{Duration, Instant};
 
 use cactus::Cactus;
-use cfgrammar::{header, yacc::YaccGrammar, RIdx, Span, TIdx};
+use cfgrammar::{header, span::Location, yacc::YaccGrammar, RIdx, Span, TIdx};
 use lrtable::{Action, StIdx, StateTable};
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 use proc_macro2::TokenStream;
@@ -642,13 +642,16 @@ impl From<RecoveryKind> for header::Value {
     fn from(val: RecoveryKind) -> Self {
         use header::{Namespaced, Setting};
         header::Value::Setting(Setting::Unitary(Namespaced {
-            namespace: Some(("recoverykind".to_string(), None)),
+            namespace: Some((
+                "recoverykind".to_string(),
+                Location::Other("From<RecoveryKind>".to_string()),
+            )),
             member: (
                 match val {
                     RecoveryKind::CPCTPlus => "ctcplus".to_string(),
                     RecoveryKind::None => "none".to_string(),
                 },
-                None,
+                Location::Other("From<RecoveryKind>".to_string()),
             ),
         }))
     }

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -642,13 +642,13 @@ impl From<RecoveryKind> for header::Value {
     fn from(val: RecoveryKind) -> Self {
         use header::{Namespaced, Setting};
         header::Value::Setting(Setting::Unitary(Namespaced {
-            namespace: Some(("recoverykind".to_string(), Span::new(0, 0))),
+            namespace: Some(("recoverykind".to_string(), None)),
             member: (
                 match val {
                     RecoveryKind::CPCTPlus => "ctcplus".to_string(),
                     RecoveryKind::None => "none".to_string(),
                 },
-                Span::new(0, 0),
+                None,
             ),
         }))
     }

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -1050,7 +1050,7 @@ pub(crate) mod test {
                 YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
             ),
         );
-        let grm = YaccGrammar::<u16>::new_with_storaget(header, grms).unwrap();
+        let grm = YaccGrammar::<u16>::new_with_storaget(&mut header, grms).unwrap();
         let (_, stable) = from_yacc(&grm, Minimiser::Pager).unwrap();
         let rule_ids = grm
             .tokens_map()

--- a/lrpar/src/lib/test_utils.rs
+++ b/lrpar/src/lib/test_utils.rs
@@ -86,3 +86,22 @@ impl fmt::Display for TestLexError {
         unreachable!();
     }
 }
+
+#[macro_export]
+#[cfg(test)]
+macro_rules! header_for_yacckind {
+    ($yk:expr) => {{
+        use cfgrammar::{header::Header, markmap::MergeBehavior, Span};
+        let mut header = Header::new();
+        header
+            .contents_mut()
+            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
+        header.contents_mut().mark_required(&"yacckind".to_string());
+        header
+            .contents_mut()
+            .insert("yacckind".into(), (Span::new(0, 0), $yk.into()));
+        header
+    }};
+}
+
+pub use header_for_yacckind;

--- a/lrtable/src/lib/itemset.rs
+++ b/lrtable/src/lib/itemset.rs
@@ -159,8 +159,10 @@ where
 #[cfg(test)]
 mod test {
     use cfgrammar::{
-        yacc::{YaccGrammar, YaccKind, YaccKindResolver, YaccOriginalActionKind},
-        SIdx, Symbol,
+        header::Header,
+        markmap::MergeBehavior,
+        yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
+        SIdx, Span, Symbol,
     };
     use vob::Vob;
 
@@ -171,8 +173,12 @@ mod test {
     #[rustfmt::skip]
     fn test_dragon_grammar() {
         // From http://binarysculpting.com/2012/02/04/computing-lr1-closure/
+        let mut header = Header::new();
+        header.contents_mut().set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
+        header.contents_mut().mark_required(&"yacckind".to_string());
+        header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
+            header,
             "
           %start S
           %%
@@ -199,8 +205,21 @@ mod test {
     }
 
     fn eco_grammar() -> YaccGrammar {
+        let mut header = Header::new();
+        header
+            .contents_mut()
+            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
+        header.contents_mut().mark_required(&"yacckind".to_string());
+        // FIXME seems like this this should be Eco!
+        header.contents_mut().insert(
+            "yacckind".into(),
+            (
+                Span::new(0, 0),
+                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
+            ),
+        );
         YaccGrammar::new(
-            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
+            header,
             "
           %start S
           %token a b c d f
@@ -250,8 +269,20 @@ mod test {
     //     a
     //     aSb
     fn grammar3() -> YaccGrammar {
+        let mut header = Header::new();
+        header
+            .contents_mut()
+            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
+        header.contents_mut().mark_required(&"yacckind".to_string());
+        header.contents_mut().insert(
+            "yacckind".into(),
+            (
+                Span::new(0, 0),
+                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
+            ),
+        );
         YaccGrammar::new(
-            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
+            header,
             "
           %start S
           %token a b c d

--- a/lrtable/src/lib/itemset.rs
+++ b/lrtable/src/lib/itemset.rs
@@ -178,7 +178,7 @@ mod test {
         header.contents_mut().mark_required(&"yacckind".to_string());
         header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            header,
+            &mut header,
             "
           %start S
           %%
@@ -219,7 +219,7 @@ mod test {
             ),
         );
         YaccGrammar::new(
-            header,
+            &mut header,
             "
           %start S
           %token a b c d f
@@ -282,7 +282,7 @@ mod test {
             ),
         );
         YaccGrammar::new(
-            header,
+            &mut header,
             "
           %start S
           %token a b c d

--- a/lrtable/src/lib/itemset.rs
+++ b/lrtable/src/lib/itemset.rs
@@ -158,11 +158,10 @@ where
 
 #[cfg(test)]
 mod test {
+    use crate::test_utils::*;
     use cfgrammar::{
-        header::Header,
-        markmap::MergeBehavior,
-        yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
-        SIdx, Span, Symbol,
+        yacc::{YaccGrammar, YaccOriginalActionKind},
+        SIdx, Symbol,
     };
     use vob::Vob;
 
@@ -173,12 +172,8 @@ mod test {
     #[rustfmt::skip]
     fn test_dragon_grammar() {
         // From http://binarysculpting.com/2012/02/04/computing-lr1-closure/
-        let mut header = Header::new();
-        header.contents_mut().set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            &mut header,
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
           %start S
           %%
@@ -205,21 +200,9 @@ mod test {
     }
 
     fn eco_grammar() -> YaccGrammar {
-        let mut header = Header::new();
-        header
-            .contents_mut()
-            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        // FIXME seems like this this should be Eco!
-        header.contents_mut().insert(
-            "yacckind".into(),
-            (
-                Span::new(0, 0),
-                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
-            ),
-        );
         YaccGrammar::new(
-            &mut header,
+            // FIXME should be Eco?
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
           %start S
           %token a b c d f
@@ -269,20 +252,8 @@ mod test {
     //     a
     //     aSb
     fn grammar3() -> YaccGrammar {
-        let mut header = Header::new();
-        header
-            .contents_mut()
-            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert(
-            "yacckind".into(),
-            (
-                Span::new(0, 0),
-                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
-            ),
-        );
         YaccGrammar::new(
-            &mut header,
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
           %start S
           %token a b c d

--- a/lrtable/src/lib/mod.rs
+++ b/lrtable/src/lib/mod.rs
@@ -17,6 +17,9 @@ mod pager;
 mod stategraph;
 pub mod statetable;
 
+#[cfg(test)]
+pub mod test_utils;
+
 pub use crate::{
     stategraph::StateGraph,
     statetable::{Action, StateTable, StateTableError, StateTableErrorKind},

--- a/lrtable/src/lib/pager.rs
+++ b/lrtable/src/lib/pager.rs
@@ -398,12 +398,11 @@ where
 mod test {
     use vob::Vob;
 
+    use crate::test_utils::*;
     use crate::{pager::pager_stategraph, stategraph::state_exists, StIdx};
     use cfgrammar::{
-        header::Header,
-        markmap::MergeBehavior,
-        yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
-        SIdx, Span, Symbol,
+        yacc::{YaccGrammar, YaccOriginalActionKind},
+        SIdx, Symbol,
     };
 
     use super::vob_intersect;
@@ -441,20 +440,8 @@ mod test {
     //     a
     //     aSb
     fn grammar3() -> YaccGrammar {
-        let mut header = Header::new();
-        header
-            .contents_mut()
-            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert(
-            "yacckind".into(),
-            (
-                Span::new(0, 0),
-                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
-            ),
-        );
         YaccGrammar::new(
-            &mut header,
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
           %start S
           %token a b c d
@@ -532,20 +519,8 @@ mod test {
 
     // Pager grammar
     fn grammar_pager() -> YaccGrammar {
-        let mut header = Header::new();
-        header
-            .contents_mut()
-            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert(
-            "yacckind".into(),
-            (
-                Span::new(0, 0),
-                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
-            ),
-        );
         YaccGrammar::new(
-            &mut header,
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
             %start X
             %%

--- a/lrtable/src/lib/pager.rs
+++ b/lrtable/src/lib/pager.rs
@@ -400,8 +400,10 @@ mod test {
 
     use crate::{pager::pager_stategraph, stategraph::state_exists, StIdx};
     use cfgrammar::{
-        yacc::{YaccGrammar, YaccKind, YaccKindResolver, YaccOriginalActionKind},
-        SIdx, Symbol,
+        header::Header,
+        markmap::MergeBehavior,
+        yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
+        SIdx, Span, Symbol,
     };
 
     use super::vob_intersect;
@@ -439,8 +441,20 @@ mod test {
     //     a
     //     aSb
     fn grammar3() -> YaccGrammar {
+        let mut header = Header::new();
+        header
+            .contents_mut()
+            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
+        header.contents_mut().mark_required(&"yacckind".to_string());
+        header.contents_mut().insert(
+            "yacckind".into(),
+            (
+                Span::new(0, 0),
+                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
+            ),
+        );
         YaccGrammar::new(
-            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
+            header,
             "
           %start S
           %token a b c d
@@ -518,8 +532,20 @@ mod test {
 
     // Pager grammar
     fn grammar_pager() -> YaccGrammar {
+        let mut header = Header::new();
+        header
+            .contents_mut()
+            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
+        header.contents_mut().mark_required(&"yacckind".to_string());
+        header.contents_mut().insert(
+            "yacckind".into(),
+            (
+                Span::new(0, 0),
+                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
+            ),
+        );
         YaccGrammar::new(
-            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
+            header,
             "
             %start X
             %%

--- a/lrtable/src/lib/pager.rs
+++ b/lrtable/src/lib/pager.rs
@@ -454,7 +454,7 @@ mod test {
             ),
         );
         YaccGrammar::new(
-            header,
+            &mut header,
             "
           %start S
           %token a b c d
@@ -545,7 +545,7 @@ mod test {
             ),
         );
         YaccGrammar::new(
-            header,
+            &mut header,
             "
             %start X
             %%

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -261,7 +261,7 @@ mod test {
         // Taken from p13 of https://link.springer.com/article/10.1007/s00236-010-0115-6
         let grm = YaccGrammar::new(
             &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
-                        "
+            "
             %start A
             %%
             A: 'OPEN_BRACKET' A 'CLOSE_BRACKET'

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -248,25 +248,20 @@ pub(crate) fn state_exists<StorageT: 'static + Hash + PrimInt + Unsigned>(
 
 #[cfg(test)]
 mod test {
+    use crate::test_utils::*;
     use crate::{pager::pager_stategraph, StIdx};
     use cfgrammar::{
-        header::Header,
-        markmap::MergeBehavior,
-        yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
-        Span, Symbol,
+        yacc::{YaccGrammar, YaccOriginalActionKind},
+        Symbol,
     };
 
     #[test]
     #[rustfmt::skip]
     fn test_statetable_core() {
         // Taken from p13 of https://link.springer.com/article/10.1007/s00236-010-0115-6
-        let mut header = Header::new();
-        header.contents_mut().set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            &mut header,
-            "
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
+                        "
             %start A
             %%
             A: 'OPEN_BRACKET' A 'CLOSE_BRACKET'

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -265,7 +265,7 @@ mod test {
         header.contents_mut().mark_required(&"yacckind".to_string());
         header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            header,
+            &mut header,
             "
             %start A
             %%

--- a/lrtable/src/lib/stategraph.rs
+++ b/lrtable/src/lib/stategraph.rs
@@ -250,16 +250,22 @@ pub(crate) fn state_exists<StorageT: 'static + Hash + PrimInt + Unsigned>(
 mod test {
     use crate::{pager::pager_stategraph, StIdx};
     use cfgrammar::{
-        yacc::{YaccGrammar, YaccKind, YaccKindResolver, YaccOriginalActionKind},
-        Symbol,
+        header::Header,
+        markmap::MergeBehavior,
+        yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind},
+        Span, Symbol,
     };
 
     #[test]
     #[rustfmt::skip]
     fn test_statetable_core() {
         // Taken from p13 of https://link.springer.com/article/10.1007/s00236-010-0115-6
+        let mut header = Header::new();
+        header.contents_mut().set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
+        header.contents_mut().mark_required(&"yacckind".to_string());
+        header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
+            header,
             "
             %start A
             %%

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -638,7 +638,7 @@ mod test {
         header.contents_mut().mark_required(&"yacckind".to_string());
         header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            header,
+            &mut header,
             "
             %start Expr
             %%
@@ -724,7 +724,7 @@ mod test {
         header.contents_mut().mark_required(&"yacckind".to_string());
         header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            header, "
+            &mut header, "
             %start A
             %%
             A : B 'x' | C 'x' 'x';
@@ -753,7 +753,7 @@ mod test {
         header.contents_mut().mark_required(&"yacckind".to_string());
         header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            header, "
+            &mut header, "
             %start Expr
             %%
             Expr : Expr '+' Expr
@@ -788,7 +788,7 @@ mod test {
         header.contents_mut().mark_required(&"yacckind".to_string());
         header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            header, "
+            &mut header, "
             %start S
             %%
             S: A 'c' 'd'
@@ -818,7 +818,7 @@ mod test {
         header.contents_mut().mark_required(&"yacckind".to_string());
         header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            header, "
+            &mut header, "
             %start Expr
             %left '+'
             %left '*'
@@ -862,7 +862,7 @@ mod test {
         header.contents_mut().mark_required(&"yacckind".to_string());
         header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = &YaccGrammar::new(
-            header, "
+            &mut header, "
             %start Expr
             %right '='
             %left '+'
@@ -923,7 +923,7 @@ mod test {
         header.contents_mut().mark_required(&"yacckind".to_string());
         header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            header, "
+            &mut header, "
             %start Expr
             %right '='
             %left '+'
@@ -1010,7 +1010,7 @@ mod test {
             ),
         );
         let grm = YaccGrammar::new(
-            header,
+            &mut header,
             "
 %start A
 %%
@@ -1059,7 +1059,7 @@ C : 'a';
             ),
         );
         let grm = YaccGrammar::new(
-            header,
+            &mut header,
             "
 %start S
 %%
@@ -1105,7 +1105,7 @@ X: '1' ; Y: '2' ;
             ),
         );
         let grm = YaccGrammar::new(
-            header,
+            &mut header,
             "
 %start D
 %%
@@ -1140,7 +1140,7 @@ S: S | ;";
                 YaccKind::Original(YaccOriginalActionKind::NoAction).into(),
             ),
         );
-        let ast_validity = ASTWithValidityInfo::new(header, src);
+        let ast_validity = ASTWithValidityInfo::new(&mut header, src);
         let grm = YaccGrammar::<u32>::new_from_ast_with_validity_info(&ast_validity).unwrap();
         let sg = pager_stategraph(&grm);
         match StateTable::new(&grm, &sg) {
@@ -1203,7 +1203,7 @@ T: S | ;";
                 YaccKind::Original(YaccOriginalActionKind::NoAction).into(),
             ),
         );
-        let ast_validity = ASTWithValidityInfo::new(header, src);
+        let ast_validity = ASTWithValidityInfo::new(&mut header, src);
         let grm = YaccGrammar::<u32>::new_from_ast_with_validity_info(&ast_validity).unwrap();
         let sg = pager_stategraph(&grm);
         match StateTable::new(&grm, &sg) {

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -617,10 +617,9 @@ fn resolve_shift_reduce<StorageT: 'static + Hash + PrimInt + Unsigned>(
 #[cfg(test)]
 mod test {
     use super::{Action, StateTable, StateTableError, StateTableErrorKind};
+    use crate::test_utils::*;
     use crate::{pager::pager_stategraph, StIdx};
     use cfgrammar::{
-        header::Header,
-        markmap::MergeBehavior,
         yacc::{
             ast::{self, ASTWithValidityInfo},
             YaccGrammar, YaccKind, YaccOriginalActionKind,
@@ -633,13 +632,8 @@ mod test {
     #[rustfmt::skip]
     fn test_statetable() {
         // Taken from p19 of www.cs.umd.edu/~mvz/cmsc430-s07/M10lr.pdf
-        let mut header = Header::new();
-        header.contents_mut().set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            &mut header,
-            "
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),           "
             %start Expr
             %%
             Expr : Term '-' Expr | Term;
@@ -719,12 +713,8 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_default_reduce_reduce() {
-        let mut header = Header::new();
-        header.contents_mut().set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            &mut header, "
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),  "
             %start A
             %%
             A : B 'x' | C 'x' 'x';
@@ -748,12 +738,8 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_default_shift_reduce() {
-        let mut header = Header::new();
-        header.contents_mut().set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            &mut header, "
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)), "
             %start Expr
             %%
             Expr : Expr '+' Expr
@@ -783,12 +769,8 @@ mod test {
     #[rustfmt::skip]
     fn test_conflict_resolution() {
         // Example taken from p54 of Locally least-cost error repair in LR parsers, Carl Cerecke
-        let mut header = Header::new();
-        header.contents_mut().set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            &mut header, "
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)), "
             %start S
             %%
             S: A 'c' 'd'
@@ -813,12 +795,8 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_left_associativity() {
-        let mut header = Header::new();
-        header.contents_mut().set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            &mut header, "
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)), "
             %start Expr
             %left '+'
             %left '*'
@@ -857,12 +835,8 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_left_right_associativity() {
-        let mut header = Header::new();
-        header.contents_mut().set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = &YaccGrammar::new(
-            &mut header, "
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)), "
             %start Expr
             %right '='
             %left '+'
@@ -918,12 +892,8 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_left_right_nonassoc_associativity() {
-        let mut header = Header::new();
-        header.contents_mut().set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            &mut header, "
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)), "
             %start Expr
             %right '='
             %left '+'
@@ -997,20 +967,8 @@ mod test {
 
     #[test]
     fn conflicts() {
-        let mut header = Header::new();
-        header
-            .contents_mut()
-            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert(
-            "yacckind".into(),
-            (
-                Span::new(0, 0),
-                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
-            ),
-        );
         let grm = YaccGrammar::new(
-            &mut header,
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
 %start A
 %%
@@ -1046,20 +1004,8 @@ C : 'a';
 
     #[test]
     fn reduce_reduce_conflict() {
-        let mut header = Header::new();
-        header
-            .contents_mut()
-            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert(
-            "yacckind".into(),
-            (
-                Span::new(0, 0),
-                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
-            ),
-        );
         let grm = YaccGrammar::new(
-            &mut header,
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
 %start S
 %%
@@ -1092,20 +1038,8 @@ X: '1' ; Y: '2' ;
 
     #[test]
     fn accept_reduce_conflict() {
-        let mut header = Header::new();
-        header
-            .contents_mut()
-            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert(
-            "yacckind".into(),
-            (
-                Span::new(0, 0),
-                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
-            ),
-        );
         let grm = YaccGrammar::new(
-            &mut header,
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
             "
 %start D
 %%
@@ -1128,19 +1062,10 @@ D : D;
     fn test_accept_reduce_conflict_spans1() {
         let src = "%%
 S: S | ;";
-        let mut header = Header::new();
-        header
-            .contents_mut()
-            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert(
-            "yacckind".into(),
-            (
-                Span::new(0, 0),
-                YaccKind::Original(YaccOriginalActionKind::NoAction).into(),
-            ),
+        let ast_validity = ASTWithValidityInfo::new(
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::NoAction)),
+            src,
         );
-        let ast_validity = ASTWithValidityInfo::new(&mut header, src);
         let grm = YaccGrammar::<u32>::new_from_ast_with_validity_info(&ast_validity).unwrap();
         let sg = pager_stategraph(&grm);
         match StateTable::new(&grm, &sg) {
@@ -1191,19 +1116,10 @@ S: S | ;";
         let src = "%%
 S: T | ;
 T: S | ;";
-        let mut header = Header::new();
-        header
-            .contents_mut()
-            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
-        header.contents_mut().mark_required(&"yacckind".to_string());
-        header.contents_mut().insert(
-            "yacckind".into(),
-            (
-                Span::new(0, 0),
-                YaccKind::Original(YaccOriginalActionKind::NoAction).into(),
-            ),
+        let ast_validity = ASTWithValidityInfo::new(
+            &mut header_for_yacckind!(YaccKind::Original(YaccOriginalActionKind::NoAction)),
+            src,
         );
-        let ast_validity = ASTWithValidityInfo::new(&mut header, src);
         let grm = YaccGrammar::<u32>::new_from_ast_with_validity_info(&ast_validity).unwrap();
         let sg = pager_stategraph(&grm);
         match StateTable::new(&grm, &sg) {

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -619,9 +619,11 @@ mod test {
     use super::{Action, StateTable, StateTableError, StateTableErrorKind};
     use crate::{pager::pager_stategraph, StIdx};
     use cfgrammar::{
+        header::Header,
+        markmap::MergeBehavior,
         yacc::{
             ast::{self, ASTWithValidityInfo},
-            YaccGrammar, YaccKind, YaccKindResolver, YaccOriginalActionKind,
+            YaccGrammar, YaccKind, YaccOriginalActionKind,
         },
         PIdx, Span, Symbol, TIdx,
     };
@@ -631,8 +633,12 @@ mod test {
     #[rustfmt::skip]
     fn test_statetable() {
         // Taken from p19 of www.cs.umd.edu/~mvz/cmsc430-s07/M10lr.pdf
+        let mut header = Header::new();
+        header.contents_mut().set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
+        header.contents_mut().mark_required(&"yacckind".to_string());
+        header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
         let grm = YaccGrammar::new(
-            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
+            header,
             "
             %start Expr
             %%
@@ -713,7 +719,12 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_default_reduce_reduce() {
-        let grm = YaccGrammar::new(YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)), "
+        let mut header = Header::new();
+        header.contents_mut().set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
+        header.contents_mut().mark_required(&"yacckind".to_string());
+        header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
+        let grm = YaccGrammar::new(
+            header, "
             %start A
             %%
             A : B 'x' | C 'x' 'x';
@@ -737,7 +748,12 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_default_shift_reduce() {
-        let grm = YaccGrammar::new(YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)), "
+        let mut header = Header::new();
+        header.contents_mut().set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
+        header.contents_mut().mark_required(&"yacckind".to_string());
+        header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
+        let grm = YaccGrammar::new(
+            header, "
             %start Expr
             %%
             Expr : Expr '+' Expr
@@ -767,7 +783,12 @@ mod test {
     #[rustfmt::skip]
     fn test_conflict_resolution() {
         // Example taken from p54 of Locally least-cost error repair in LR parsers, Carl Cerecke
-        let grm = YaccGrammar::new(YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)), "
+        let mut header = Header::new();
+        header.contents_mut().set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
+        header.contents_mut().mark_required(&"yacckind".to_string());
+        header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
+        let grm = YaccGrammar::new(
+            header, "
             %start S
             %%
             S: A 'c' 'd'
@@ -792,7 +813,12 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_left_associativity() {
-        let grm = YaccGrammar::new(YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)), "
+        let mut header = Header::new();
+        header.contents_mut().set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
+        header.contents_mut().mark_required(&"yacckind".to_string());
+        header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
+        let grm = YaccGrammar::new(
+            header, "
             %start Expr
             %left '+'
             %left '*'
@@ -831,7 +857,12 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_left_right_associativity() {
-        let grm = &YaccGrammar::new(YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)), "
+        let mut header = Header::new();
+        header.contents_mut().set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
+        header.contents_mut().mark_required(&"yacckind".to_string());
+        header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
+        let grm = &YaccGrammar::new(
+            header, "
             %start Expr
             %right '='
             %left '+'
@@ -887,7 +918,12 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn test_left_right_nonassoc_associativity() {
-        let grm = YaccGrammar::new(YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)), "
+        let mut header = Header::new();
+        header.contents_mut().set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
+        header.contents_mut().mark_required(&"yacckind".to_string());
+        header.contents_mut().insert("yacckind".into(), (Span::new(0, 0), YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into()));
+        let grm = YaccGrammar::new(
+            header, "
             %start Expr
             %right '='
             %left '+'
@@ -961,8 +997,20 @@ mod test {
 
     #[test]
     fn conflicts() {
+        let mut header = Header::new();
+        header
+            .contents_mut()
+            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
+        header.contents_mut().mark_required(&"yacckind".to_string());
+        header.contents_mut().insert(
+            "yacckind".into(),
+            (
+                Span::new(0, 0),
+                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
+            ),
+        );
         let grm = YaccGrammar::new(
-            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
+            header,
             "
 %start A
 %%
@@ -998,8 +1046,20 @@ C : 'a';
 
     #[test]
     fn reduce_reduce_conflict() {
+        let mut header = Header::new();
+        header
+            .contents_mut()
+            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
+        header.contents_mut().mark_required(&"yacckind".to_string());
+        header.contents_mut().insert(
+            "yacckind".into(),
+            (
+                Span::new(0, 0),
+                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
+            ),
+        );
         let grm = YaccGrammar::new(
-            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
+            header,
             "
 %start S
 %%
@@ -1032,8 +1092,20 @@ X: '1' ; Y: '2' ;
 
     #[test]
     fn accept_reduce_conflict() {
+        let mut header = Header::new();
+        header
+            .contents_mut()
+            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
+        header.contents_mut().mark_required(&"yacckind".to_string());
+        header.contents_mut().insert(
+            "yacckind".into(),
+            (
+                Span::new(0, 0),
+                YaccKind::Original(YaccOriginalActionKind::GenericParseTree).into(),
+            ),
+        );
         let grm = YaccGrammar::new(
-            YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)),
+            header,
             "
 %start D
 %%
@@ -1056,8 +1128,19 @@ D : D;
     fn test_accept_reduce_conflict_spans1() {
         let src = "%%
 S: S | ;";
-        let yk = YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::NoAction));
-        let ast_validity = ASTWithValidityInfo::new(yk, src);
+        let mut header = Header::new();
+        header
+            .contents_mut()
+            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
+        header.contents_mut().mark_required(&"yacckind".to_string());
+        header.contents_mut().insert(
+            "yacckind".into(),
+            (
+                Span::new(0, 0),
+                YaccKind::Original(YaccOriginalActionKind::NoAction).into(),
+            ),
+        );
+        let ast_validity = ASTWithValidityInfo::new(header, src);
         let grm = YaccGrammar::<u32>::new_from_ast_with_validity_info(&ast_validity).unwrap();
         let sg = pager_stategraph(&grm);
         match StateTable::new(&grm, &sg) {
@@ -1108,8 +1191,19 @@ S: S | ;";
         let src = "%%
 S: T | ;
 T: S | ;";
-        let yk = YaccKindResolver::Force(YaccKind::Original(YaccOriginalActionKind::NoAction));
-        let ast_validity = ASTWithValidityInfo::new(yk, src);
+        let mut header = Header::new();
+        header
+            .contents_mut()
+            .set_merge_behavior(&"yacckind".to_string(), MergeBehavior::Ours);
+        header.contents_mut().mark_required(&"yacckind".to_string());
+        header.contents_mut().insert(
+            "yacckind".into(),
+            (
+                Span::new(0, 0),
+                YaccKind::Original(YaccOriginalActionKind::NoAction).into(),
+            ),
+        );
+        let ast_validity = ASTWithValidityInfo::new(header, src);
         let grm = YaccGrammar::<u32>::new_from_ast_with_validity_info(&ast_validity).unwrap();
         let sg = pager_stategraph(&grm);
         match StateTable::new(&grm, &sg) {

--- a/nimbleparse/src/diagnostics.rs
+++ b/nimbleparse/src/diagnostics.rs
@@ -157,10 +157,14 @@ impl<'a> SpannedDiagnosticFormatter<'a> {
                         format!("{} occurrence", Self::ordinal(span_num + 1))
                     }
                     SpansKind::Error => {
-                        unreachable!("Should contain a single span at the site of the error, not more")
+                        unreachable!(
+                            "Should contain a single span at the site of the error, not more"
+                        )
                     }
                     SpansKind::OptionalSpan => {
-                        unreachable!("Should contain 0 or 1 spans at the site of the error, not more")
+                        unreachable!(
+                            "Should contain 0 or 1 spans at the site of the error, not more"
+                        )
                     }
                     _ => "Unrecognized spanskind".to_string(),
                 };

--- a/nimbleparse/src/diagnostics.rs
+++ b/nimbleparse/src/diagnostics.rs
@@ -153,11 +153,14 @@ impl<'a> SpannedDiagnosticFormatter<'a> {
             } else {
                 out.push('\n');
                 let s = match e.spanskind() {
-                    SpansKind::DuplicationError => {
+                    SpansKind::DuplicationError | SpansKind::OptionalDuplicationSpan => {
                         format!("{} occurrence", Self::ordinal(span_num + 1))
                     }
                     SpansKind::Error => {
-                        unreachable!("Should contain a single span at the site of the error")
+                        unreachable!("Should contain a single span at the site of the error, not more")
+                    }
+                    SpansKind::OptionalSpan => {
+                        unreachable!("Should contain 0 or 1 spans at the site of the error, not more")
                     }
                     _ => "Unrecognized spanskind".to_string(),
                 };

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -176,12 +176,14 @@ fn main() {
             ))) => {
                 if let Some((namespace, span)) = namespace {
                     if namespace != "recoverykind" {
-                        formatter.underline_span_with_text(
-                            *span,
-                            "Unknown namespace, expected RecoveryKind".to_string(),
-                            '^',
-                        );
-                        process::exit(1);
+                        let err_str =
+                            format!("Unknown namespace: '{}' expected RecoveryKind", namespace);
+                        if let Some(span) = span {
+                            formatter.underline_span_with_text(*span, err_str, '^');
+                            process::exit(1);
+                        } else {
+                            eprintln!("{}", err_str);
+                        }
                     }
                 }
 
@@ -192,11 +194,15 @@ fn main() {
                 .iter()
                 .find_map(|(rk_str, rk)| (member == rk_str).then_some(*rk));
                 if rk.is_none() {
-                    formatter.underline_span_with_text(
-                        *member_span,
-                        "Invalid RecoveryKind specified in %grmtools section".to_string(),
-                        '^',
+                    let err_str = format!(
+                        "Invalid RecoveryKind: '{}' specified in %grmtools section",
+                        member
                     );
+                    if let Some(member_span) = member_span {
+                        formatter.underline_span_with_text(*member_span, err_str, '^');
+                    } else {
+                        eprintln!("{}", err_str);
+                    }
                 }
                 recoverykind = rk;
             }

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -162,12 +162,10 @@ fn main() {
             .contents_mut()
             .insert("yacckind".into(), (Span::new(0, 0), yacckind.into()))
     });
-    let mut ast_validation = ASTWithValidityInfo::new(header, &yacc_src);
+    let ast_validation = ASTWithValidityInfo::new(&mut header, &yacc_src);
     if recoverykind.is_none() {
         let formatter = SpannedDiagnosticFormatter::new(&yacc_src, &yacc_y_path).unwrap();
-        let recoverer_setting = ast_validation
-            .header_mut()
-            .query("recoverer", SettingQuery::Unitary as u16);
+        let recoverer_setting = header.query("recoverer", SettingQuery::Unitary as u16);
         match recoverer_setting {
             Some(Ok((
                 _,
@@ -211,11 +209,8 @@ fn main() {
         }
     }
     let recoverykind = recoverykind.unwrap_or(RecoveryKind::CPCTPlus);
-    ast_validation
-        .header_mut()
-        .contents_mut()
-        .mark_used(&"recoverer".to_string());
-    let unused: Vec<String> = ast_validation.header().contents().unused();
+    header.contents_mut().mark_used(&"recoverer".to_string());
+    let unused: Vec<String> = header.contents().unused();
     if !unused.is_empty() {
         // Print but don't exit?
         eprintln!("Unused header settings: {}", unused.join(" "));

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -1,11 +1,11 @@
 mod diagnostics;
 use crate::diagnostics::*;
 use cfgrammar::{
+    header::{Namespaced, Setting, SettingQuery, Value},
     yacc::{
         ast::ASTWithValidityInfo, YaccGrammar, YaccKind, YaccKindResolver, YaccOriginalActionKind,
     },
     Span,
-    header::{SettingQuery, Value, Setting, Namespaced}
 };
 use getopts::Options;
 use lrlex::{DefaultLexerTypes, LRNonStreamingLexerDef, LexerDef};
@@ -171,7 +171,11 @@ fn main() {
             ))) => {
                 if let Some((namespace, span)) = namespace {
                     if namespace != "recoverykind" {
-                        formatter.underline_span_with_text(*span, "Unknown namespace, expected RecoveryKind".to_string(), '^');
+                        formatter.underline_span_with_text(
+                            *span,
+                            "Unknown namespace, expected RecoveryKind".to_string(),
+                            '^',
+                        );
                         process::exit(1);
                     }
                 }
@@ -183,7 +187,11 @@ fn main() {
                 .iter()
                 .find_map(|(rk_str, rk)| (member == rk_str).then_some(*rk));
                 if rk.is_none() {
-                    formatter.underline_span_with_text(*member_span, "Invalid RecoveryKind specified in %grmtools section".to_string(), '^');
+                    formatter.underline_span_with_text(
+                        *member_span,
+                        "Invalid RecoveryKind specified in %grmtools section".to_string(),
+                        '^',
+                    );
                 }
                 recoverykind = rk;
             }
@@ -196,12 +204,11 @@ fn main() {
         }
     }
     let recoverykind = recoverykind.unwrap_or(RecoveryKind::CPCTPlus);
-    ast_validation.header_mut().mark_key_used("recoverer");
-    let unused: Vec<String> = ast_validation
-        .header()
-        .unused()
-        .map(|(key, _)| key.clone())
-        .collect::<Vec<_>>();
+    ast_validation
+        .header_mut()
+        .contents_mut()
+        .mark_used(&"recoverer".to_string());
+    let unused: Vec<String> = ast_validation.header().contents().unused();
     if !unused.is_empty() {
         // Print but don't exit?
         eprintln!("Unused header settings: {}", unused.join(" "));


### PR DESCRIPTION
Here is an initial attempt at adding `recoverer` to the grmtools section for yacc.

Things I don't like:

1. It feels to me like quite a bit of boiler plate for adding a single flag (checking all the kinds of value it could be but shouldn't be to throw errors...).
2. Not checking for unused flags `%grmtools{unknown: Foo}`
3. Parsing the section multiple times

I have some thoughts on these last two, for grmtools but lex is perhaps more complicated.

In the same way that ctparserbuilder calls into `self.yacckind = ast_validation.yacc_kind();` we could use a similar path to communicate the key/values that went unused by `YaccParser`.

On the first one, I'll try and think of helper functions, but we have things like YaccKind which can be *either* a `Unitary` or a `Constructor`, so we need to be able to check that it is `oneOf` those.

I'll try and fiddle with it more, but this is at least a naive draft implementation.

Edit: I have some general thoughts on things to attempt,
largely replacing the `HashMap` with something that tracks key consumption,
and a small mechanism for querying values based on a `repr` enum.

```
#[repr(u8)]
enum ValueRepr {
   Flag = 1 << 0,
   Setting = 1 << 1
}
```

```
#[repr(u8)]
enum SettingRepr {
    Num = 1 << 2,
    Unitary = 1 << 3,
    Constructor = 1 << 4,
}
```

Anyhow the feeling I get is that a key query API that checks the value in the hashmap against one of those in bitmask form. That along with, marking keys as "used", doesn't seem to fall into any complexity traps.

I'll elaborate tomorrow in code form...