### PR TITLE
Migrate `LexFlags` parsing to GrmtoolsSectionParser

### DIFF
--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -92,12 +92,6 @@ pub enum YaccGrammarErrorKind {
     UnknownEPP(String),
     ExpectedInput(char),
     InvalidYaccKind,
-    InvalidYaccKindNamespace,
-    InvalidActionKind,
-    InvalidActionKindNamespace,
-    InvalidGrmtoolsSectionEntry,
-    DuplicateGrmtoolsSectionEntry,
-    MissingGrmtoolsSection,
 }
 
 /// Any error from the Yacc parser returns an instance of this struct.
@@ -184,17 +178,7 @@ impl fmt::Display for YaccGrammarErrorKind {
                     name
                 )
             }
-            YaccGrammarErrorKind::MissingGrmtoolsSection => "Missing '%grmtools' section",
-            YaccGrammarErrorKind::DuplicateGrmtoolsSectionEntry => {
-                "Duplicate entry in %grmtools section"
-            }
-            YaccGrammarErrorKind::InvalidGrmtoolsSectionEntry => {
-                "Invalid entry in %grmtools section"
-            }
             YaccGrammarErrorKind::InvalidYaccKind => "Invalid yacc kind",
-            YaccGrammarErrorKind::InvalidYaccKindNamespace => "Invalid yacc kind namespace",
-            YaccGrammarErrorKind::InvalidActionKind => "Invalid action kind",
-            YaccGrammarErrorKind::InvalidActionKindNamespace => "Invalid action kind namespace",
         };
         write!(f, "{}", s)
     }
@@ -303,12 +287,7 @@ impl Spanned for YaccGrammarError {
             | YaccGrammarErrorKind::UnknownRuleRef(_)
             | YaccGrammarErrorKind::UnknownToken(_)
             | YaccGrammarErrorKind::NoPrecForToken(_)
-            | YaccGrammarErrorKind::MissingGrmtoolsSection
-            | YaccGrammarErrorKind::InvalidGrmtoolsSectionEntry
             | YaccGrammarErrorKind::InvalidYaccKind
-            | YaccGrammarErrorKind::InvalidYaccKindNamespace
-            | YaccGrammarErrorKind::InvalidActionKind
-            | YaccGrammarErrorKind::InvalidActionKindNamespace
             | YaccGrammarErrorKind::ExpectedInput(_)
             | YaccGrammarErrorKind::UnknownEPP(_) => SpansKind::Error,
             YaccGrammarErrorKind::DuplicatePrecedence
@@ -318,7 +297,6 @@ impl Spanned for YaccGrammarError {
             | YaccGrammarErrorKind::DuplicateImplicitTokensDeclaration
             | YaccGrammarErrorKind::DuplicateStartDeclaration
             | YaccGrammarErrorKind::DuplicateActiontypeDeclaration
-            | YaccGrammarErrorKind::DuplicateGrmtoolsSectionEntry
             | YaccGrammarErrorKind::DuplicateEPP => SpansKind::DuplicationError,
         }
     }

--- a/lrlex/src/lib/parser.rs
+++ b/lrlex/src/lib/parser.rs
@@ -5,14 +5,13 @@ use num_traits::AsPrimitive;
 use proc_macro2::TokenStream;
 use quote::quote;
 use regex::Regex;
-use std::borrow::{Borrow as _, Cow};
-use std::collections::HashMap;
-use std::ops::Not;
 
 use crate::{
-    lexer::{LexFlags, Rule, DEFAULT_LEX_FLAGS, UNSPECIFIED_LEX_FLAGS},
+    lexer::{LexFlags, Rule},
     LexBuildError, LexBuildResult, LexErrorKind,
 };
+use std::borrow::{Borrow as _, Cow};
+use std::ops::Not;
 
 type LexInternalBuildResult<T> = Result<T, LexBuildError>;
 
@@ -34,7 +33,6 @@ lazy_static! {
     static ref RE_LEADING_WS: Regex = Regex::new(r"^[\p{Pattern_White_Space}]*").unwrap();
     static ref RE_WS: Regex = Regex::new(r"\p{Pattern_White_Space}").unwrap();
     static ref RE_LEADING_DIGITS: Regex = Regex::new(r"^[0-9]+").unwrap();
-    static ref RE_NAME: Regex = Regex::new(r"^[a-zA-Z][a-zA-Z]*").unwrap();
 }
 const INITIAL_START_STATE_NAME: &str = "INITIAL";
 
@@ -111,11 +109,6 @@ where
     src: String,
     pub(super) rules: Vec<Rule<LexerTypesT::StorageT>>,
     pub(super) start_states: Vec<StartState>,
-    /// Forced flags override those in the `%grmtools` section.
-    pub(super) force_lex_flags: LexFlags,
-    /// Default flags are overriden by those in the `%grmtools` section.
-    pub(super) default_lex_flags: LexFlags,
-    /// The resulting flags after parsing the `%grmtools` and merging defaults and forced flags.
     pub(super) lex_flags: LexFlags,
 }
 
@@ -150,41 +143,20 @@ where
     usize: AsPrimitive<LexerTypesT::StorageT>,
     LexerTypesT::StorageT: TryFrom<usize>,
 {
-    pub(super) fn new(src: String) -> LexBuildResult<LexParser<LexerTypesT>> {
-        let mut p = LexParser {
-            src,
-            rules: Vec::new(),
-            start_states: vec![StartState::new(
-                0,
-                INITIAL_START_STATE_NAME,
-                false,
-                Span::new(0, 0),
-            )],
-            force_lex_flags: UNSPECIFIED_LEX_FLAGS,
-            default_lex_flags: UNSPECIFIED_LEX_FLAGS,
-            lex_flags: DEFAULT_LEX_FLAGS,
-        };
-        p.parse()?;
-        Ok(p)
-    }
-
     pub(super) fn new_with_lex_flags(
         src: String,
-        force_lex_flags: LexFlags,
-        default_lex_flags: LexFlags,
+        lex_flags: LexFlags,
     ) -> LexBuildResult<LexParser<LexerTypesT>> {
         let mut p = LexParser {
             src,
             rules: Vec::new(),
+            lex_flags,
             start_states: vec![StartState::new(
                 0,
                 INITIAL_START_STATE_NAME,
                 false,
                 Span::new(0, 0),
             )],
-            force_lex_flags,
-            default_lex_flags,
-            lex_flags: DEFAULT_LEX_FLAGS,
         };
         p.parse()?;
         Ok(p)
@@ -247,159 +219,12 @@ where
         }
     }
 
-    fn parse_grmtools_section_value(
-        &mut self,
-        mut i: usize,
-        span_map: &mut HashMap<&str, Span>,
-        lex_flags: &mut LexFlags,
-    ) -> LexInternalBuildResult<usize> {
-        const OPTIONS: [&str; 13] = [
-            "allow_wholeline_comments",
-            "dot_matches_new_line",
-            "multi_line",
-            "octal",
-            "posix_escapes",
-            "case_insensitive",
-            "swap_greed",
-            "ignore_whitespace",
-            "unicode",
-            "size_limit",
-            "dfa_size_limit",
-            "nest_limit",
-            "lexerkind",
-        ];
-        let start_pos = i;
-        // RegexBuilder isn't uniform regarding whether the default value of an options is true
-        // or false. For instance `unicode` is `true` but `case_insensitive` defaults to false.
-        let flag = if self.src[i..].starts_with("!") {
-            i += 1;
-            false
-        } else {
-            true
-        };
-        for opt in OPTIONS {
-            if self.src[i..].to_lowercase().starts_with(opt) {
-                i += opt.len();
-                let end_pos = i;
-                if let Some(orig_span) = span_map.get(opt) {
-                    return Err(LexBuildError {
-                        kind: LexErrorKind::DuplicateGrmtoolsSectionValue,
-                        spans: vec![*orig_span, Span::new(start_pos, end_pos)],
-                    });
-                }
-                match opt {
-                    "allow_wholeline_comments" => lex_flags.allow_wholeline_comments = Some(flag),
-                    "case_insensitive" => lex_flags.case_insensitive = Some(flag),
-                    "swap_greed" => lex_flags.swap_greed = Some(flag),
-                    "ignore_whitespace" => lex_flags.ignore_whitespace = Some(flag),
-                    "unicode" => lex_flags.unicode = Some(flag),
-                    "dot_matches_new_line" => lex_flags.dot_matches_new_line = Some(flag),
-                    "multi_line" => lex_flags.multi_line = Some(flag),
-                    "octal" => lex_flags.octal = Some(flag),
-                    "posix_escapes" => lex_flags.posix_escapes = Some(flag),
-                    "size_limit" | "dfa_size_limit" | "nest_limit" => {
-                        if !flag {
-                            // We've seen a silly statement like `!size_limit 5``
-                            return Err(LexBuildError {
-                                kind: LexErrorKind::InvalidGrmtoolsSectionValue,
-                                spans: vec![Span::new(start_pos, end_pos)],
-                            });
-                        }
-                        i = self.parse_spaces(i)?;
-                        if let Some(j) = self.lookahead_is(":", i) {
-                            i = j
-                        } else {
-                            return Err(LexBuildError {
-                                kind: LexErrorKind::InvalidGrmtoolsSectionValue,
-                                spans: vec![Span::new(i, i)],
-                            });
-                        }
-                        i = self.parse_spaces(i)?;
-                        let j = self.parse_digits(i)?;
-                        // This checks that the digits are valid numbers, but currently just returns `None`
-                        // when the values are actually out of range for that type. This could be improved.
-                        match opt {
-                            "size_limit" => {
-                                lex_flags.size_limit = str::parse::<usize>(&self.src[i..j]).ok();
-                            }
-                            "dfa_size_limit" => {
-                                lex_flags.dfa_size_limit =
-                                    str::parse::<usize>(&self.src[i..j]).ok();
-                            }
-                            "nest_limit" => {
-                                lex_flags.nest_limit = str::parse::<u32>(&self.src[i..j]).ok();
-                            }
-                            _ => unreachable!(),
-                        }
-                        i = j;
-                    }
-                    "lexerkind" => {
-                        // We just want to skip this, we already know we're `LRNonStreamingLexer`
-                        i = self.parse_ws(i)?;
-                        if let Some(j) = self.lookahead_is(":", i) {
-                            i = j
-                        } else {
-                            return Err(LexBuildError {
-                                kind: LexErrorKind::InvalidGrmtoolsSectionValue,
-                                spans: vec![Span::new(i, i)],
-                            });
-                        }
-                        i = self.parse_ws(i)?;
-                        let (j, _) = self.parse_name(i)?;
-                        i = self.parse_ws(j)?;
-                        if let Some(j) = self.lookahead_is("::", j) {
-                            i = self.parse_ws(j)?;
-                            let (j, _) = self.parse_name(i)?;
-                            i = j;
-                        }
-                    }
-                    _ => unreachable!(),
-                }
-                span_map.insert(opt, Span::new(start_pos, end_pos));
-                return self.parse_ws(i);
-            }
-        }
-        Err(self.mk_error(LexErrorKind::InvalidGrmtoolsSectionValue, i))
-    }
-
     fn parse_declarations(
         &mut self,
         mut i: usize,
         errs: &mut Vec<LexBuildError>,
     ) -> LexInternalBuildResult<usize> {
         i = self.parse_ws(i)?;
-        let mut grmtools_section_span_map = HashMap::new();
-        let mut grmtools_section_lex_flags = UNSPECIFIED_LEX_FLAGS;
-        if let Some(j) = self.lookahead_is("%grmtools", i) {
-            i = self.parse_ws(j)?;
-            if let Some(j) = self.lookahead_is("{", i) {
-                i = self.parse_ws(j)?;
-            }
-
-            while self.lookahead_is("}", i).is_none() {
-                i = self.parse_grmtools_section_value(
-                    i,
-                    &mut grmtools_section_span_map,
-                    &mut grmtools_section_lex_flags,
-                )?;
-                if let Some(j) = self.lookahead_is(",", i) {
-                    i = self.parse_ws(j)?;
-                    continue;
-                } else {
-                    break;
-                }
-            }
-            if let Some(j) = self.lookahead_is("}", i) {
-                i = j
-            } else {
-                return Err(self.mk_error(LexErrorKind::PrematureEnd, i));
-            }
-            i = self.parse_ws(i)?;
-        }
-        grmtools_section_lex_flags.merge_from(&self.force_lex_flags);
-        self.default_lex_flags
-            .merge_from(&grmtools_section_lex_flags);
-        self.lex_flags.merge_from(&self.default_lex_flags);
         loop {
             i = self.parse_ws(i)?;
             if self.lex_flags.allow_wholeline_comments.unwrap_or(false)
@@ -778,7 +603,6 @@ where
                 }
                 Cow::from(unescaped)
             }
-
             Ok((vec![], unescape(Cow::from(re_str), &self.lex_flags)))
         } else {
             match re_str.find('>') {
@@ -821,29 +645,6 @@ where
             .unwrap_or(i))
     }
 
-    fn parse_digits(&mut self, i: usize) -> LexInternalBuildResult<usize> {
-        RE_LEADING_DIGITS
-            .find(&self.src[i..])
-            .map(|m| m.end() + i)
-            .ok_or(LexBuildError {
-                kind: LexErrorKind::InvalidNumber,
-                spans: vec![Span::new(i, i)],
-            })
-    }
-
-    fn parse_name(&self, i: usize) -> Result<(usize, String), LexBuildError> {
-        match RE_NAME.find(&self.src[i..]) {
-            Some(m) => {
-                assert_eq!(m.start(), 0);
-                Ok((i + m.end(), self.src[i..i + m.end()].to_string()))
-            }
-            None => Err(LexBuildError {
-                kind: LexErrorKind::InvalidGrmtoolsSectionValue,
-                spans: vec![Span::new(i, i)],
-            }),
-        }
-    }
-
     fn parse_spaces(&mut self, i: usize) -> LexInternalBuildResult<usize> {
         Ok(RE_LEADING_SPACE_SEPS
             .find(&self.src[i..])
@@ -865,7 +666,7 @@ mod test {
     use super::*;
     use crate::{
         lexer::{LRNonStreamingLexerDef, LexerDef},
-        DefaultLexerTypes,
+        DefaultLexerTypes, LexBuildHeaderError,
     };
     use cfgrammar::Spanned as _;
     use std::collections::HashMap;
@@ -896,7 +697,9 @@ mod test {
         );
     }
 
-    impl ErrorsHelper for Result<LRNonStreamingLexerDef<DefaultLexerTypes<u8>>, Vec<LexBuildError>> {
+    impl ErrorsHelper
+        for Result<LRNonStreamingLexerDef<DefaultLexerTypes<u8>>, Vec<LexBuildHeaderError>>
+    {
         #[track_caller]
         fn expect_error_at_line_col(self, src: &str, kind: LexErrorKind, line: usize, col: usize) {
             self.expect_error_at_lines_cols(src, kind, &mut std::iter::once((line, col)))
@@ -915,19 +718,26 @@ mod test {
                 .expect_err("Parsed ok while expecting error");
             assert_eq!(errs.len(), 1);
             let e = &errs[0];
-            if !e.kind.is_same_kind(&kind) {
-                panic!("expected {:?}.is_same_kind({:?})", &e.kind, &kind);
-            }
-            assert_eq!(
-                e.spans()
-                    .iter()
-                    .map(|span| line_col!(src, span))
-                    .collect::<Vec<(usize, usize)>>(),
-                lines_cols.collect::<Vec<(usize, usize)>>()
-            );
-            // Check that it is valid to slice.
-            for span in e.spans() {
-                let _ = &src[span.start()..span.end()];
+            match e {
+                LexBuildHeaderError::Build(e) => {
+                    if !e.kind.is_same_kind(&kind) {
+                        panic!("expected {:?}.is_same_kind({:?})", &e.kind, &kind);
+                    }
+                    assert_eq!(
+                        e.spans()
+                            .iter()
+                            .map(|span| line_col!(src, span))
+                            .collect::<Vec<(usize, usize)>>(),
+                        lines_cols.collect::<Vec<(usize, usize)>>()
+                    );
+                    // Check that it is valid to slice.
+                    for span in e.spans() {
+                        let _ = &src[span.start()..span.end()];
+                    }
+                }
+                _ => {
+                    panic!("Testsuite helper expects a valid header");
+                }
             }
         }
 
@@ -939,27 +749,37 @@ mod test {
         ) {
             let errs = self.expect_err("Parsed ok while expecting error");
             for e in &errs {
-                // Check that it is valid to slice the source with the spans.
-                for span in e.spans() {
-                    let _ = &src[span.start()..span.end()];
-                }
-            }
+                match e {
+                    LexBuildHeaderError::Build(e) => {
+                        // Check that it is valid to slice the source with the spans.
+                        for span in e.spans() {
+                            let _ = &src[span.start()..span.end()];
+                        }
 
-            for ((ek1, es1), (ek2, es2)) in errs
-                .iter()
-                .map(|e| {
-                    (
-                        e.kind.clone(),
-                        e.spans()
+                        for ((ek1, es1), (ek2, es2)) in errs
                             .iter()
-                            .map(|span| line_col!(src, span))
-                            .collect::<Vec<_>>(),
-                    )
-                })
-                .zip(expected)
-            {
-                assert!(ek1.is_same_kind(&ek2));
-                assert_eq!(es1, es2);
+                            .map(|e| match e {
+                                LexBuildHeaderError::Build(e) => (
+                                    e.kind.clone(),
+                                    e.spans()
+                                        .iter()
+                                        .map(|span| line_col!(src, span))
+                                        .collect::<Vec<_>>(),
+                                ),
+                                _ => {
+                                    panic!("Testsuite helper expects a valid header");
+                                }
+                            })
+                            .zip(&mut *expected)
+                        {
+                            assert!(ek1.is_same_kind(&ek2));
+                            assert_eq!(es1, es2);
+                        }
+                    }
+                    _ => {
+                        panic!("Testsuite helper expects valid header");
+                    }
+                }
             }
         }
     }
@@ -1924,11 +1744,7 @@ b "A"
 . "dot";
 \n+ ;
 "#;
-        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(src).expect_error_at_lines_cols(
-            src,
-            LexErrorKind::DuplicateGrmtoolsSectionValue,
-            &mut [(3, 3), (4, 3)].into_iter(),
-        );
+        assert!(LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(src).is_err());
 
         let src = r#"
 %grmtools {
@@ -1939,11 +1755,7 @@ b "A"
 . "dot";
 \n+ ;
 "#;
-        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(src).expect_error_at_lines_cols(
-            src,
-            LexErrorKind::DuplicateGrmtoolsSectionValue,
-            &mut [(3, 3), (4, 3)].into_iter(),
-        );
+        assert!(LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(src).is_err());
 
         let src = r#"
 %grmtools {
@@ -1953,12 +1765,7 @@ b "A"
 . "dot"
 \n+ ;
 "#;
-        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(src).expect_error_at_line_col(
-            src,
-            LexErrorKind::InvalidGrmtoolsSectionValue,
-            3,
-            3,
-        );
+        assert!(LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(src).is_err());
         // The following is missing comma separators for more than 2 elements
         // This is to avoid parsing it as "key value" number of elements.
         // However we actually error after the first element since the parser
@@ -1969,12 +1776,7 @@ b "A"
 . "dot"
 \n+ ;
 "#;
-        LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(src).expect_error_at_line_col(
-            src,
-            LexErrorKind::PrematureEnd,
-            2,
-            38,
-        );
+        assert!(LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(src).is_err());
     }
 
     #[test]

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -7,7 +7,7 @@ use cfgrammar::{
     Location, Span,
 };
 use getopts::Options;
-use lrlex::{DefaultLexerTypes, LRNonStreamingLexerDef, LexerDef};
+use lrlex::{DefaultLexerTypes, LRNonStreamingLexerDef, LexBuildHeaderError, LexerDef};
 use lrpar::{
     parser::{RTParserBuilder, RecoveryKind},
     LexerTypes,
@@ -168,7 +168,14 @@ fn main() {
             let formatter = SpannedDiagnosticFormatter::new(&lex_src, &lex_l_path).unwrap();
             eprintln!("{ERROR}{}", formatter.file_location_msg("", None));
             for e in errs {
-                eprintln!("{}", indent(&formatter.format_error(e).to_string(), "    "));
+                match e {
+                    LexBuildHeaderError::Build(e) => {
+                        eprintln!("{}", indent(&formatter.format_error(e).to_string(), "    "));
+                    }
+                    LexBuildHeaderError::Header(e) => {
+                        eprintln!("{}", indent(&format!("{}", e), "    "))
+                    }
+                }
             }
             process::exit(1);
         }


### PR DESCRIPTION
So here is what I've managed to come up with for migrating the `LexFlags` parsing code in the `%grmtools` section to use the `GrmtoolsSectionParser`, with this patch we parse the `%grmtools` section twice.

1. The first in `CTParserBuilder`, to pull out `LexerKind`,
2. Then again in one of the `LRNonStreamingLexerDef` constructors to get and merge the `LexFlags`.
3. As a consequence by the time `LexParser` has run `Header` has been lowered to a `LexFlags`, 
    and the whole `%grmtools` section has been stripped off, so we don't need to parse it a third time to find the beginning 
    of the lex file's contents.
 
We do all the merging in step 2, partially because `LexFlags` lacks a notion of `MergeBehavior` and that is the point where we still have enough information to merge without introducing multiple parameters like `forcing` and `default`.
This also kindly isolates the `LexBuildHeaderError` (for lack of any good name) out of `LexParser`.
This allows us to keep around the `new_with_lex_flags` constructor but simplified a little bit with fewer arguments.

One very important thing to note is that this changes the return type of the trait method `from_str`.
A second thing to note is that I noticed that `from_rules` doesn't have any method to change the `LexFlags`, it is still relying on the defaults.
A third thing to note is that this may not produce the nicest of errors, but I think we should be able to improve them without breaking semver now.