### PR TITLE
Migrate `LexFlags` parsing to `GrmtoolsSectionParser` and `Header`.

### DIFF
--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -64,12 +64,6 @@ pub enum YaccGrammarErrorKind {
     UnknownEPP(String),
     ExpectedInput(char),
     InvalidYaccKind,
-    InvalidYaccKindNamespace,
-    InvalidActionKind,
-    InvalidActionKindNamespace,
-    InvalidGrmtoolsSectionEntry,
-    DuplicateGrmtoolsSectionEntry,
-    MissingGrmtoolsSection,
     Header(HeaderErrorKind, SpansKind),
 }
 
@@ -157,17 +151,7 @@ impl fmt::Display for YaccGrammarErrorKind {
                     name
                 )
             }
-            YaccGrammarErrorKind::MissingGrmtoolsSection => "Missing '%grmtools' section",
-            YaccGrammarErrorKind::DuplicateGrmtoolsSectionEntry => {
-                "Duplicate entry in %grmtools section"
-            }
-            YaccGrammarErrorKind::InvalidGrmtoolsSectionEntry => {
-                "Invalid entry in %grmtools section"
-            }
             YaccGrammarErrorKind::InvalidYaccKind => "Invalid yacc kind",
-            YaccGrammarErrorKind::InvalidYaccKindNamespace => "Invalid yacc kind namespace",
-            YaccGrammarErrorKind::InvalidActionKind => "Invalid action kind",
-            YaccGrammarErrorKind::InvalidActionKindNamespace => "Invalid action kind namespace",
             YaccGrammarErrorKind::Header(hk, _) => &format!("Error in '%grmtools' {}", hk),
         };
         write!(f, "{}", s)
@@ -278,12 +262,7 @@ impl Spanned for YaccGrammarError {
             | YaccGrammarErrorKind::UnknownRuleRef(_)
             | YaccGrammarErrorKind::UnknownToken(_)
             | YaccGrammarErrorKind::NoPrecForToken(_)
-            | YaccGrammarErrorKind::MissingGrmtoolsSection
-            | YaccGrammarErrorKind::InvalidGrmtoolsSectionEntry
             | YaccGrammarErrorKind::InvalidYaccKind
-            | YaccGrammarErrorKind::InvalidYaccKindNamespace
-            | YaccGrammarErrorKind::InvalidActionKind
-            | YaccGrammarErrorKind::InvalidActionKindNamespace
             | YaccGrammarErrorKind::ExpectedInput(_)
             | YaccGrammarErrorKind::UnknownEPP(_) => SpansKind::Error,
             YaccGrammarErrorKind::DuplicatePrecedence
@@ -293,7 +272,6 @@ impl Spanned for YaccGrammarError {
             | YaccGrammarErrorKind::DuplicateImplicitTokensDeclaration
             | YaccGrammarErrorKind::DuplicateStartDeclaration
             | YaccGrammarErrorKind::DuplicateActiontypeDeclaration
-            | YaccGrammarErrorKind::DuplicateGrmtoolsSectionEntry
             | YaccGrammarErrorKind::DuplicateEPP => SpansKind::DuplicationError,
             YaccGrammarErrorKind::Header(_, spanskind) => spanskind,
         }


### PR DESCRIPTION
This rebuilds my previous PR #553 on top of the current master branch.
I didn't manage to avoid *all* problems associated with Span/Location conversion.

In particular, because we need to synthesize a `LexFlags` for default values, and merge those in with the `%grmtools` section in the `.l` file, we have to synthesize a made up span for said default values.

It isn't to difficult to see though that when the `LexFlags::try_from` in `from_str` encounters a default value with a synthesized span, the hard coded values in the default shouldn't cause an error, and therefore the span should go unused. After which the header parameter to try_from gets dropped. So as much as I dislike just making up spans, in this case it doesn't really seem like it can materialize into a problem where the user could see the synthesized span.