### PR TITLE
Add grmtools book documentation for new header fields

### DIFF
--- a/doc/src/errorrecovery.md
+++ b/doc/src/errorrecovery.md
@@ -560,3 +560,11 @@ Unable to evaluate expression.
 Unless you have a good reason to do so (e.g. quickly hacking together a grammar
 where you would prefer not to think about error recovery at all), we do not
 recommend turning off error recovery.
+
+## RecoveryKinds
+
+The complete list of `RecoveryKind` values are:
+
+* `CPCTPlus` Error recovery using the `CPCT+` algorithm (the default).
+
+* `None` Error recovery disabled.

--- a/doc/src/lexcompatibility.md
+++ b/doc/src/lexcompatibility.md
@@ -61,3 +61,9 @@ There are several major differences between Lex and grmtools:
 
 * Lex treats lines in the rules section beginning with whitespace as code to be copied verbatim
   into the generated lexer source.  Grmtools lex does not support these and produces an error. 
+
+## LexerKinds
+
+### LRNonStreamingLexerKind
+
+Currently lrlex only supports a single `LexKind::LRNonStreamingLexerKind` which is the default if unspecified.

--- a/doc/src/lexextensions.md
+++ b/doc/src/lexextensions.md
@@ -26,20 +26,21 @@ other flags should specify their value immediately after the flag name.
 
 ## List of flags:
 
-| Flag                          | Value | Required | Regex[^regex] |
-|-------------------------------|-------|----------|---------------|
-| `posix_escapes`[^†]           | bool  | &cross;  | &cross;       |
-| `allow_wholeline_comment`[^‡] | bool  | &cross;  | &cross;       |
-| `case_insensitive`            | bool  | &cross;  | &checkmark;   |
-| `dot_matches_new_line`        | bool  | &cross;  | &checkmark;   |
-| `multi_line`                  | bool  | &cross;  | &checkmark;   |
-| `octal`                       | bool  | &cross;  | &checkmark;   |
-| `swap_greed`                  | bool  | &cross;  | &checkmark;   |
-| `ignore_whitespace`           | bool  | &cross;  | &checkmark;   |
-| `unicode`                     | bool  | &cross;  | &checkmark;   |
-| `size_limit`                  | usize | &cross;  | &checkmark;   |
-| `dfa_size_limit`              | usize | &cross;  | &checkmark;   |
-| `nest_limit`                  | u32   | &cross;  | &checkmark;   |
+| Flag                          | Value     | Required | Regex[^regex] |
+|-------------------------------|-----------|----------|---------------|
+| `lexerkind`                   | [LexerKind](lexcompatibility.md#lexerkinds) | &cross;  | &cross; |
+| `posix_escapes`[^†]           | bool      | &cross;  | &cross;       |
+| `allow_wholeline_comment`[^‡] | bool      | &cross;  | &cross;       |
+| `case_insensitive`            | bool      | &cross;  | &checkmark;   |
+| `dot_matches_new_line`        | bool      | &cross;  | &checkmark;   |
+| `multi_line`                  | bool      | &cross;  | &checkmark;   |
+| `octal`                       | bool      | &cross;  | &checkmark;   |
+| `swap_greed`                  | bool      | &cross;  | &checkmark;   |
+| `ignore_whitespace`           | bool      | &cross;  | &checkmark;   |
+| `unicode`                     | bool      | &cross;  | &checkmark;   |
+| `size_limit`                  | usize     | &cross;  | &checkmark;   |
+| `dfa_size_limit`              | usize     | &cross;  | &checkmark;   |
+| `nest_limit`                  | u32       | &cross;  | &checkmark;   |
 
 [^†]: Enable compatibility with posix escape sequences.
 [^‡]: Enables rust style `// comments` at the start of lines.

--- a/doc/src/yaccextensions.md
+++ b/doc/src/yaccextensions.md
@@ -3,10 +3,13 @@
 At the beginning of a `.y` file is a `%grmtools{}` section, by default this section is required.
 But a default can be set or forced by using a `YaccKindResolver`.
 
-| Flag       | Value                                       | Required     |
-|------------|---------------------------------------------|--------------|
-| `yacckind` |  [YaccKind](yacccompatibility.md#yacckinds) | &checkmark;  |
+| Flag             | Value                                           | Required     |
+|------------------|-------------------------------------------------|--------------|
+| `yacckind`       |  [YaccKind](yacccompatibility.md#yacckinds)     | &checkmark;  |
+| `recoverykind`   |  [RecoveryKind](errorrecovery.md#recoverykinds) | &cross;      |
+| `test_files`[^†] | String                                          | &cross;      |
 
+[^†]: String containing a glob relative to the yacc `.y` source file, experimental.
 
 ## Example
 


### PR DESCRIPTION
It occurred to me I should probably do a pass over the docs, this documents the new lex and yacc header fields that were added: `test_files` `recoverykind` and `lexerkind`.