### PR TITLE
Add more test cases for unbalanced curly brackets.

### DIFF
--- a/cfgrammar/src/lib/header.rs
+++ b/cfgrammar/src/lib/header.rs
@@ -682,11 +682,27 @@ mod test {
 
     #[test]
     fn test_header_missing_curly_bracket() {
-        let src = "%grmtools { a, b";
-        for flag in [true, false] {
-            let parser = GrmtoolsSectionParser::new(src, flag);
-            let res = parser.parse();
-            assert!(res.is_err());
+        let srcs = [
+            "%grmtools { a",
+            "%grmtools { a, b",
+            "%grmtools { a, b,",
+            "%grmtools { yacckind",
+            "%grmtools { yacckind:",
+            "%grmtools { yacckind: GrmTools",
+            "%grmtools { yacckind: GrmTools,",
+            r#"%grmtools { test_files: ""#,
+            r#"%grmtools { test_files: "test"#,
+            r#"%grmtools { test_files: "test""#,
+            r#"%grmtools { test_files: "test","#,
+            "%grmtools { !flag",
+            "%grmtools { !flag,",
+        ];
+        for src in srcs {
+            for flag in [true, false] {
+                let parser = GrmtoolsSectionParser::new(src, flag);
+                let res = parser.parse();
+                assert!(res.is_err());
+            }
         }
     }
 


### PR DESCRIPTION
This just adds more tests for incomplete input regarding unbalanced curly brackets, ensuring we get errors and don't panic.
