### PR TITLE
Replace a misuse prone internal API with a better one.

### DIFF
--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -522,7 +522,7 @@ where
 
         match header.entry("yacckind".to_string()) {
             Entry::Occupied(_) => unreachable!(),
-            Entry::Vacant(v) => match self.yacckind {
+            Entry::Vacant(mut v) => match self.yacckind {
                 Some(YaccKind::Eco) => panic!("Eco compile-time grammar generation not supported."),
                 Some(yk) => {
                     let yk_value = Value::try_from(yk)?;
@@ -533,7 +533,7 @@ where
                     o.set_merge_behavior(MergeBehavior::Ours);
                 }
                 None => {
-                    v.occupied_entry().mark_required();
+                    v.mark_required();
                 }
             },
         }


### PR DESCRIPTION
`occupied_entry` was documented as not being useful for `insert`, but ok for setting various marks. This is because `OccupiedEntry` combines insertion with lookup by returning the previous value. In doing so it assumes that the previous value exists, where in the case of the `occupied_entry` function called from a `VacantEntry` there was no previous value.

Instead this patch just adds the various marking functions to `VacantEntry` avoiding the problematic assumptions.

I didn't add `mark_used`, because it seems out of place and sequence, marking as used is typically done late after lookup, not early before insertion.  Oddly the tests do `mark_used` early, but only because they needed an extra mark to cover all the internal states of the `VacantEntry` field `pos` I did add `set_merge_behavior` even though it isn't used, because at least with that I can think of uses for it.