### PR TITLE
Reorder arguments to indent fn.

### DIFF
--- a/lrlex/src/lib/ctbuilder.rs
+++ b/lrlex/src/lib/ctbuilder.rs
@@ -476,7 +476,7 @@ where
                     lex_diag.file_location_msg(" parsing the `%grmtools` section", None)
                 ));
                 for e in es {
-                    out.push_str(&indent(&lex_diag.format_error(e).to_string(), "     "));
+                    out.push_str(&indent("     ", &lex_diag.format_error(e).to_string()));
                     out.push('\n');
                 }
                 ErrorString(out)
@@ -511,7 +511,7 @@ where
                             lex_diag.file_location_msg("", None)
                         ));
                         for e in errs {
-                            out.push_str(&indent(&lex_diag.format_error(e).to_string(), "     "));
+                            out.push_str(&indent("     ", &lex_diag.format_error(e).to_string()));
                             out.push('\n');
                         }
                         ErrorString(out)
@@ -1168,7 +1168,7 @@ pub fn ct_token_map<StorageT: Display>(
 ///
 /// It is plausible that we should a step 4, but currently do not:
 /// 4. Replace all `\n{indent}\n` with `\n\n`
-fn indent(s: &str, indent: &str) -> String {
+fn indent(indent: &str, s: &str) -> String {
     format!("{indent}{}\n", s.trim_end_matches('\n')).replace('\n', &format!("\n{}", indent))
 }
 

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -566,7 +566,7 @@ where
                 yacc_diag.file_location_msg(" parsing the `%grmtools` section", None)
             ));
             for e in errs {
-                out.push_str(&indent(&yacc_diag.format_error(e).to_string(), "     "));
+                out.push_str(&indent("     ", &yacc_diag.format_error(e).to_string()));
             }
             return Err(ErrorString(out))?;
         }
@@ -606,7 +606,7 @@ where
                 for e in warnings {
                     out.push_str(&format!(
                         "{}\n",
-                        indent(&yacc_diag.format_warning(e).to_string(), "    ")
+                        indent("     ", &yacc_diag.format_warning(e).to_string())
                     ));
                 }
                 return Err(ErrorString(out))?;
@@ -615,7 +615,7 @@ where
                 if !warnings.is_empty() {
                     for w in warnings {
                         let ws_loc = yacc_diag.file_location_msg("", None);
-                        let ws = indent(&yacc_diag.format_warning(w).to_string(), "    ");
+                        let ws = indent("     ", &yacc_diag.format_warning(w).to_string());
                         // Assume if this variable is set we are running under cargo.
                         if std::env::var("OUT_DIR").is_ok() && self.show_warnings {
                             println!("cargo:warning={}", ws_loc);
@@ -635,7 +635,7 @@ where
                     yacc_diag.file_location_msg("", None)
                 ));
                 for e in errs {
-                    out.push_str(&indent(&yacc_diag.format_error(e).to_string(), "     "));
+                    out.push_str(&indent("     ", &yacc_diag.format_error(e).to_string()));
                     out.push('\n');
                 }
 
@@ -1544,7 +1544,7 @@ where
 ///
 /// It is plausible that we should a step 4, but currently do not:
 /// 4. Replace all `\n{indent}\n` with `\n\n`
-fn indent(s: &str, indent: &str) -> String {
+fn indent(indent: &str, s: &str) -> String {
     format!("{indent}{}\n", s.trim_end_matches('\n')).replace('\n', &format!("\n{}", indent))
 }
 

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -63,7 +63,7 @@ fn read_file<P: AsRef<Path>>(path: P) -> String {
 ///
 /// It is plausible that we should a step 4, but currently do not:
 /// 4. Replace all `\n{indent}\n` with `\n\n`
-fn indent(s: &str, indent: &str) -> String {
+fn indent(indent: &str, s: &str) -> String {
     format!("{indent}{}\n", s.trim_end_matches('\n')).replace('\n', &format!("\n{}", indent))
 }
 
@@ -180,7 +180,7 @@ fn main() {
         Err(errs) => {
             eprintln!("{ERROR}{}", lex_diag.file_location_msg("", None));
             for e in errs {
-                eprintln!("{}", indent(&lex_diag.format_error(e).to_string(), "    "));
+                eprintln!("{}", indent("    ", &lex_diag.format_error(e).to_string()));
             }
             process::exit(1);
         }
@@ -204,7 +204,7 @@ fn main() {
                     yacc_diag.file_location_msg(" parsing the `%grmtools` section:", None)
                 );
                 for e in errs {
-                    eprintln!("{}", indent(&yacc_diag.format_error(e).to_string(), "    "));
+                    eprintln!("{}", indent("    ", &yacc_diag.format_error(e).to_string()));
                 }
                 std::process::exit(1);
             }
@@ -238,7 +238,7 @@ fn main() {
                 };
                 eprintln!(
                     "{}",
-                    indent(&yacc_diag.format_error(spanned_e).to_string(), "    ")
+                    indent("    ", &yacc_diag.format_error(spanned_e).to_string())
                 );
                 process::exit(1)
             }
@@ -255,7 +255,7 @@ fn main() {
             if !warnings.is_empty() {
                 eprintln!("{WARNING}{}", yacc_diag.file_location_msg("", None));
                 for w in warnings {
-                    eprintln!("{}", indent(&yacc_diag.format_warning(w), "    "));
+                    eprintln!("{}", indent("    ", &yacc_diag.format_warning(w)));
                 }
             }
             x
@@ -263,11 +263,11 @@ fn main() {
         Err(errs) => {
             eprintln!("{ERROR}{}", yacc_diag.file_location_msg("", None));
             for e in errs {
-                eprintln!("{}", indent(&yacc_diag.format_error(e).to_string(), "    "));
+                eprintln!("{}", indent("    ", &yacc_diag.format_error(e).to_string()));
             }
             eprintln!("{WARNING}{}", yacc_diag.file_location_msg("", None));
             for w in warnings {
-                eprintln!("{}", indent(&yacc_diag.format_warning(w), "    "));
+                eprintln!("{}", indent("    ", &yacc_diag.format_warning(w)));
             }
             process::exit(1);
         }


### PR DESCRIPTION
This is a follow up to PR #567 while doing that I noticed that the indent levels for a few things in lrpar were non-uniform, so this also adds one space to some of the indent calls.