### PR TITLE
Add source snippets to missing_from_lexer/parser errors

### DIFF
--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -644,6 +644,16 @@ where
         m
     }
 
+    pub fn tokens_map_iter(&self) -> impl Iterator<Item = (&str, TIdx<StorageT>)> {
+        self.iter_tidxs().filter_map(|tidx| {
+            if let Some((_, name)) = self.token_names[usize::from(tidx)].as_ref() {
+                Some((name.as_str(), tidx))
+            } else {
+                None
+            }
+        })
+    }
+
     /// Return the index of the token named `n` or `None` if it doesn't exist.
     pub fn token_idx(&self, n: &str) -> Option<TIdx<StorageT>> {
         self.token_names

--- a/lrlex/examples/calc_manual_lex/build.rs
+++ b/lrlex/examples/calc_manual_lex/build.rs
@@ -18,7 +18,7 @@ fn main() {
         .unwrap();
     ct_token_map::<u8>(
         "token_map",
-        ctp.token_map().as_ref(),
+        ctp.token_map(),
         Some(&TOKENS_MAP.iter().cloned().collect()),
     )
     .unwrap();

--- a/lrlex/examples/calc_manual_lex/build.rs
+++ b/lrlex/examples/calc_manual_lex/build.rs
@@ -18,7 +18,7 @@ fn main() {
         .unwrap();
     ct_token_map::<u8>(
         "token_map",
-        ctp.token_map(),
+        ctp.token_map().as_ref(),
         Some(&TOKENS_MAP.iter().cloned().collect()),
     )
     .unwrap();


### PR DESCRIPTION
Here is an initial attempt at `missing_from_lexer` and `missing_from_parser` for `CTLexerBuilder` including source snippets
I'm marking this as draft, because this patch is pretty awful.

For instance, it calls `set_rule_ids` and `set_rule_ids_spanned` when the `lrpar_config` callback is used.
but just `set_rule_ids` otherwise.  One thing to note is that the `cttests` tests don't use the `lrpar_config` callback, but build `CTParserBuilder` and `CTLexerBuilder` separately via the older method, and tying the gordian knot via `set_rule_ids`.

It is only when `lrpar_config` is used that we have the span info to produce these nice errors.
The other thing to note is that values like `token_map` and `rules_id_map` of `CTParser` and `CTLexerBuilder` are now kind of superfluous with the inclusion of `YaccGrammar` in the return value.

So while this functions, it really seems like it needs some design work to reduce all these separate but related code paths and slightly different duplicates of values.

As I started trying out options, it all seemed to snowball so it seemed best to just stop here before going too far down any one path.