### PR TITLE
Relax ct_token_map signature to allow `Borrow` refs.

### DIFF
--- a/lrlex/src/lib/ctbuilder.rs
+++ b/lrlex/src/lib/ctbuilder.rs
@@ -2,6 +2,7 @@
 
 use std::{
     any::type_name,
+    borrow::Borrow,
     collections::{HashMap, HashSet},
     env::{current_dir, var},
     error::Error,
@@ -1105,7 +1106,7 @@ impl CTLexer {
 /// ```
 pub fn ct_token_map<StorageT: Display>(
     mod_name: &str,
-    token_map: &HashMap<String, StorageT>,
+    token_map: impl Borrow<HashMap<String, StorageT>>,
     rename_map: Option<&HashMap<&str, &str>>,
 ) -> Result<(), Box<dyn Error>> {
     // Record the time that this version of lrlex was built. If the source code changes and rustc
@@ -1122,6 +1123,7 @@ pub fn ct_token_map<StorageT: Display>(
     .ok();
     outs.push_str(
         &token_map
+            .borrow()
             .iter()
             .map(|(k, v)| {
                 let k = match rename_map {


### PR DESCRIPTION
I believe that changing the signature for the `ct_token_map` function should be fully backwards compatible,

1. it adds no additional generic types so turbofish should still work the same.  
2. Because of the following blanket trait impl it should still accept all `&HashMap<String, Storaget>` instances.
    https://doc.rust-lang.org/stable/std/borrow/trait.Borrow.html#impl-Borrow%3CT%3E-for-%26T


Thus my belief is that this just relaxes the type signature to allow additional parameters like `Box` or `Rc` without having to first convert it to a reference type.