### PR TITLE
Fix multi line cargo warnings

### DIFF
--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -618,8 +618,9 @@ where
                         let ws = indent("     ", &yacc_diag.format_warning(w).to_string());
                         // Assume if this variable is set we are running under cargo.
                         if std::env::var("OUT_DIR").is_ok() && self.show_warnings {
-                            println!("cargo:warning={}", ws_loc);
-                            println!("cargo:warning={}", ws);
+                            for line in ws_loc.lines().chain(ws.lines()) {
+                                println!("cargo:warning={}", line);
+                            }
                         } else if self.show_warnings {
                             eprintln!("{}", ws_loc);
                             eprintln!("{WARNING} {}", ws);


### PR DESCRIPTION
When I added the warning printing code, I failed to account for the fact that the formatted warning output
can contain multiple lines, and thus we need to prefix each line with `cargo:warning`.