### PR TITLE
Print source snippet for lookahead value of rr-conflicts

### DIFF
--- a/lrpar/src/lib/diagnostics.rs
+++ b/lrpar/src/lib/diagnostics.rs
@@ -267,7 +267,14 @@ impl<'a> SpannedDiagnosticFormatter<'a> {
             let (_r1_prod_names, _r1_prod_spans) = pidx_prods_data(ast, *r1_prod_idx);
             let (_r2_prod_names, _r2_prod_spans) = pidx_prods_data(ast, *r2_prod_idx);
 
-            let t_name = grm.token_name(*t_idx).unwrap_or("$");
+            let (t_name, t_span) = if let Some(name) = grm.token_name(*t_idx) {
+                (name, grm.token_span(*t_idx))
+            } else {
+                (
+                    "$",
+                    grm.token_idx("$").and_then(|t_idx| grm.token_span(t_idx)),
+                )
+            };
             let r1_rule_idx = grm.prod_to_rule(*r1_prod_idx);
             let r2_rule_idx = grm.prod_to_rule(*r2_prod_idx);
             let r1_span = grm.rule_name_span(r1_rule_idx);
@@ -287,6 +294,9 @@ impl<'a> SpannedDiagnosticFormatter<'a> {
             );
             out.pushln(self.underline_span_with_text(r1_span, "First reduce".to_string(), '^'));
             out.pushln(self.underline_span_with_text(r2_span, "Second reduce".to_string(), '-'));
+            if let Some(t_span) = t_span {
+                out.pushln(self.underline_span_with_text(t_span, "Lookahead".to_string(), '+'));
+            }
             out.push('\n');
         }
         for (s_tok_idx, r_prod_idx, _st_idx) in c.sr_conflicts() {


### PR DESCRIPTION
This adds printing using spans for the lookahead information that was added in #506
using the example from that PR

```
%start S
%%
S: A X | B X | A Y;
A: '0' ; B: '0' ; C: '0' ;
X: '1' ; Y: '2' ;
```

Adds the last line to this conflict printing output:
```console
Reduce/Reduce conflict, can reduce 'A' or 'B' with lookahead '1' at rr.y:5:1
5| A: '0' ; B: '0' ; C: '0' ;
   ^ First reduce
5| A: '0' ; B: '0' ; C: '0' ;
            - Second reduce
6| X: '1' ; Y: '2' ;
       + Lookahead
```

Not certain we need to be using different underline characters for each thing here, but it was currently doing that so I kept the tradition?