### PR TITLE
Consistently underline error spans with '^'

### DIFF
--- a/lrpar/src/lib/diagnostics.rs
+++ b/lrpar/src/lib/diagnostics.rs
@@ -185,7 +185,7 @@ impl<'a> SpannedDiagnosticFormatter<'a> {
                     }
                     _ => "Unrecognized spanskind".to_string(),
                 };
-                out.push_str(&self.prefixed_underline_span_with_text(dots, *span, s, '-'));
+                out.push_str(&self.prefixed_underline_span_with_text(dots, *span, s, '^'));
             }
         }
         out
@@ -293,9 +293,9 @@ impl<'a> SpannedDiagnosticFormatter<'a> {
                 ),
             );
             out.pushln(self.underline_span_with_text(r1_span, "First reduce".to_string(), '^'));
-            out.pushln(self.underline_span_with_text(r2_span, "Second reduce".to_string(), '-'));
+            out.pushln(self.underline_span_with_text(r2_span, "Second reduce".to_string(), '^'));
             if let Some(t_span) = t_span {
-                out.pushln(self.underline_span_with_text(t_span, "Lookahead".to_string(), '+'));
+                out.pushln(self.underline_span_with_text(t_span, "Lookahead".to_string(), '^'));
             }
             out.push('\n');
         }
@@ -319,7 +319,7 @@ impl<'a> SpannedDiagnosticFormatter<'a> {
             );
 
             out.pushln(self.underline_span_with_text(s_tok_span, "Shift".to_string(), '^'));
-            out.pushln(self.underline_span_with_text(r_rule_span, "Reduced rule".to_string(), '+'));
+            out.pushln(self.underline_span_with_text(r_rule_span, "Reduced rule".to_string(), '^'));
 
             if r_prod_spans.is_empty() {
                 r_prod_spans.push(fallback_span);


### PR DESCRIPTION
This makes error messages consistently underline with the '^' character, 

As discussed in #578, using different underline characters was intended for a more footnote style, 
where we would avoid emitting duplicate source lines, by coalescing spans and use multiple underlines
on a single source line, then emitting error text as footnotes.  But I never actually implemented that,
and it seems like it would probably be more difficult to read/follow.