### PR TITLE
Make lrpar RustEdition `#[non_exhaustive]`

### DIFF
--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -170,6 +170,7 @@ pub enum Visibility {
 ///
 /// [Rust Edition]: https://doc.rust-lang.org/edition-guide/rust-2021/index.html
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[non_exhaustive]
 pub enum RustEdition {
     Rust2015,
     Rust2018,


### PR DESCRIPTION
I was looking through the output of `cargo semver-checks` from the `cargo-semver-checks` tool.
In order to make a list of semver changes in doing so I noticed that `RustEdition` had been `#[non_exhaustive]` in `lrlex` but not `lrpar`.