### PR TITLE
Update nimbleparse help text regarding default values

### DIFF
--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -108,13 +108,13 @@ fn main() {
         .optopt(
             "r",
             "recoverer",
-            "Recoverer to be used (default: cpctplus)",
+            "Recoverer to be used (default: cpctplus unless specified in grammar)",
             "cpctplus|none",
         )
         .optopt(
             "y",
             "yaccvariant",
-            "Yacc variant to be parsed (default: original)",
+            "Yacc variant to be parsed (default: None unless specified in grammar)",
             "eco|original|grmtools",
         )
         .parse(&args[1..])


### PR DESCRIPTION
I had missed/failed to notice that in nimbleparse there is some help text regarding default values.
This missed getting updated when the default values were changed with the `%grmtools` section changes.
I'm not actually certain how to get this text to print from nimbleparse, as things like`-y list`, etc didn't seem to work.

But I also didn't dig at all into the getopt crate, and the changes seemed straightforward enough.