### PR TITLE
Limit `GrammarAST::new()` to only being `pub(crate)`

### DIFF
--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -232,7 +232,7 @@ impl fmt::Display for Symbol {
 }
 
 impl GrammarAST {
-    pub fn new() -> GrammarAST {
+    pub(crate) fn new() -> GrammarAST {
         GrammarAST {
             start: None,
             rules: IndexMap::new(), // Using an IndexMap means that we retain the order


### PR DESCRIPTION
I'm not sure if we want this change, Previously/historically `GrammarAST::new()` has been `pub`.

However, there is nothing pub really takes a `GrammarAST` as a parameter and returns a `YaccGrammar`.  Another possible use would be if they were (at least) `PartialEq` or `PartialOrd`, but it doesn't derive anything but debug.

Everything else is basically a self parameter.

My recent changes adding the unstable `grammar_ast()` function to `CTParserBuilder` don't actually change this,
because that takes a `ASTWithValidityInfo`, and there is no way to go from a `GrammarAST` to that.

Anyways, it might be a good time to reevaluate whether we still want this `pub` or not.