### PR TITLE
Replace `ct_token_map` with `CTTokenMapBuilder`

### DIFF
--- a/doc/src/manuallexer.md
+++ b/doc/src/manuallexer.md
@@ -28,17 +28,17 @@ and the boiler-plate that comes with it unwanted. Fortunately, `lrlex` provides 
      [`lrpar::Lexeme`](https://softdevteam.github.io/grmtools/master/api/lrpar/trait.Lexeme.html)
      trait.
 
-  3. `lrlex` exposes a
-     [`ct_token_map`](https://softdevteam.github.io/grmtools/master/api/lrlex/fn.ct_token_map.html)
-     function to be used from `build.rs` scripts which automatically produces a
-     Rust module with one constant per token ID. `ct_token_map` is explicitly
+  3. `lrlex` exposes
+     [`CTTokenMapBuilder`](https://softdevteam.github.io/grmtools/master/api/lrlex/struct.CTTokenMapBuilder.html)
+     to be used from `build.rs` scripts which automatically produces a
+     Rust module with one constant per token ID. It is explicitly
      designed to be easy to use with `lrpar`'s compile-time building.
 
 Putting these together is then relatively easy. First a `build.rs` file for a
 hand-written lexer will look roughly as follows:
 
 ```rust
-use lrlex::{ct_token_map, DefaultLexerTypes};
+use lrlex::{CTTokenMapBuilder, DefaultLexerTypes};
 use lrpar::CTParserBuilder;
 
 fn main() {
@@ -47,7 +47,7 @@ fn main() {
         .unwrap()
         .build()
         .unwrap();
-    ct_token_map::<u8>("token_map", ctp.token_map(), None).unwrap()
+    CTTokenMapBuilder::<u8>::new("token_map", ctp.token_map()).build().unwrap()
 }
 ```
 
@@ -65,7 +65,7 @@ Expr -> Result<u64, ()>:
 the module will contain `const T_PLUS: u8 = ...;`.
 
 Since Yacc grammars can contain token identifiers which are not valid Rust
-identifiers, `ct_token_map` allows you to provide a map from the token
+identifiers, `CTTokenMapBuilder` allows you to provide a map from the token
 identifier to a "Rust friendly" variant. For example, for the following grammar
 excerpt:
 

--- a/lrlex/examples/calc_manual_lex/build.rs
+++ b/lrlex/examples/calc_manual_lex/build.rs
@@ -1,4 +1,4 @@
-use lrlex::{DefaultLexerTypes, ct_token_map};
+use lrlex::{CTTokenMapBuilder, DefaultLexerTypes};
 use lrpar::CTParserBuilder;
 
 // Some of the token names in the parser do not lead to valid Rust identifiers, so we map them to
@@ -16,10 +16,8 @@ fn main() {
         .unwrap()
         .build()
         .unwrap();
-    ct_token_map::<u8>(
-        "token_map",
-        ctp.token_map(),
-        Some(&TOKENS_MAP.iter().cloned().collect()),
-    )
-    .unwrap();
+    CTTokenMapBuilder::<u8>::new("token_map", ctp.token_map())
+        .rename_map(Some(TOKENS_MAP))
+        .build()
+        .unwrap();
 }

--- a/lrlex/src/lib/mod.rs
+++ b/lrlex/src/lib/mod.rs
@@ -20,8 +20,12 @@ pub mod defaults;
 mod lexer;
 mod parser;
 
+#[allow(deprecated)]
 pub use crate::{
-    ctbuilder::{CTLexer, CTLexerBuilder, LexerKind, RustEdition, Visibility, ct_token_map},
+    ctbuilder::{
+        CTLexer, CTLexerBuilder, CTTokenMapBuilder, LexerKind, RustEdition, Visibility,
+        ct_token_map,
+    },
     defaults::{DefaultLexeme, DefaultLexerTypes},
     lexer::{
         DEFAULT_LEX_FLAGS, LRNonStreamingLexer, LRNonStreamingLexerDef, LexFlags, LexerDef, Rule,


### PR DESCRIPTION
This commit adds `CTTokenMapBuilder` that replaces `ct_token_map`. It provides a few new features:

- generated module is no longer `#[allow(dead_code)]` unless manually enabled. This helps to spot errors in custom lexers where some of the tokens are never emitted;                                

- if generated module contains invalid identifiers, the generation will fail and suggest using `CTTokenMapBuilder::rename_map`;

- `CTTokenMapBuilder::rename_map` accepts any iterable that yields pairs of strings, eliminating the need to convert static arrays of pairs of strings before passing them to builder.

The `ct_token_map` function is deprecated since the next minor release (`0.14`).