### PR TITLE
Reserve `test_files` extensions starting with `grm`

### DIFF
--- a/lrlex/src/lib/ctbuilder.rs
+++ b/lrlex/src/lib/ctbuilder.rs
@@ -545,6 +545,13 @@ where
                                 glob(&path_joined.to_string_lossy()).map_err(|e| e.to_string())?
                             {
                                 let path = path?;
+                                if let Some(ext) = path.extension() {
+                                    if let Some(ext) = ext.to_str() {
+                                        if ext.starts_with("grm") {
+                                            Err(ErrorString("test_files extensions beginning with `grm` are reserved.".into()))?
+                                        }
+                                    }
+                                }
                                 let input = fs::read_to_string(&path)?;
                                 let l: LRNonStreamingLexer<LexerTypesT> =
                                     closure_lexerdef.lexer(&input);

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -561,7 +561,18 @@ where
                         }
                         let mut input_paths = Vec::new();
                         for path in paths {
-                            input_paths.push(path?);
+                            let path = path?;
+                            if let Some(ext) = path.extension() {
+                                if let Some(ext) = ext.to_str() {
+                                    if ext.starts_with("grm") {
+                                        Err(NimbleparseError::Other(
+                                            "test_files extensions beginning with `grm` are reserved."
+                                            .into(),
+                                        ))?
+                                    }
+                                }
+                            }
+                            input_paths.push(path);
                         }
                         input_paths
                     } else {


### PR DESCRIPTION
This reserves `test_files` from the `%grmtools` which have a file extension beginning with `.grm`
This is regarding https://github.com/softdevteam/grmtools/issues/595#issuecomment-3220992433

So we can delay #593 to a future release, and not hold this one up on that, but do so compatibly.

I tested this manually by setting the `test_files` section of calc_ast
from `test_files: "input*.txt"` to `test_files: "input*"`, then adding a `calc_ast/src/input.grmfoo` file,
Then manually ran `cargo build` and `nimbleparse src/calc.{l,y}`

This succeeded when the `input.grmfoo` file was gone, and failed with the appropriate error when it was there.