### PR TITLE
Use \p{Pattern_White_Space} rather than hard coded ws characters.

### DIFF
--- a/lrpar/cttests/src/grmtools_section.test
+++ b/lrpar/cttests/src/grmtools_section.test
@@ -148,4 +148,4 @@ lexer: |
     :: '::'
     : ':'
     \"(\\.|[^"\\])*\" 'STRING'
-    [\n\t\ ] ;
+    \p{Pattern_White_Space} ;


### PR DESCRIPTION
This is just a small patch which shouldn't change much,
in lrlex's parsing code, https://github.com/softdevteam/grmtools/blob/master/lrlex/src/lib/parser.rs#L38-L40
the parse_ws function uses a different regex for parsing whitespace, than the one that was in use for the cttest version of the grmtools section parser.

So this makes the grmtools_section.test lexer match the lrlex code.