### PR TITLE
Fix compile error in generated code.

### DIFF
--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -1179,7 +1179,7 @@ where
                 }
             }
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree) => quote! {
-                (::std::option::Option<crate::Node<<#lexertypest as ::lrpar::LexerTypes>::LexemeT, #storaget>>,
+                (::std::option::Option<Node<<#lexertypest as ::lrpar::LexerTypes>::LexemeT, #storaget>>,
                     ::std::vec::Vec<::lrpar::LexParseError<#storaget, #lexertypest>>)
             },
             YaccKind::Original(YaccOriginalActionKind::NoAction) => quote! {


### PR DESCRIPTION
I was testing out the `master` branch of `grmtools` (because it has an API I need) and noticed that the generated Rust code has a compile error:

```
error[E0412]: cannot find type `Node` in the crate root
     --> /home/<redacted>/target/debug/build/rust-parser-992f753d99ae5fa2/out/rust.y.rs:24154:24
      |
24154 |                 crate::Node<
      |                        ^^^^ not found in the crate root
      |
help: consider importing one of these items
      |
6     +         use crate::rust_y::Node;
      |
6     +         use lrpar::Node;
      |
help: if you import `Node`, refer to it directly
      |
24154 -                 crate::Node<
24154 +                 Node<
      |
```