### PR TITLE
Update cttest names

### DIFF
--- a/lrpar/cttests/src/calc_actiontype.test
+++ b/lrpar/cttests/src/calc_actiontype.test
@@ -1,4 +1,4 @@
-name: Test basic user actions using the calculator grammar
+name: Test basic user actions using the calculator grammar (Original yacckind)
 yacckind: Original(YaccOriginalActionKind::UserAction)
 recoverer: RecoveryKind::None
 grammar: |

--- a/lrpar/cttests/src/calc_multitypes.test
+++ b/lrpar/cttests/src/calc_multitypes.test
@@ -1,4 +1,4 @@
-name: Test basic user actions using the calculator grammar
+name: Test basic user actions using the calculator grammar (Grmtools yacckind)
 yacckind: Grmtools
 recoverer: RecoveryKind::CPCTPlus
 grammar: |

--- a/lrpar/cttests/src/calc_nodefault_yacckind.test
+++ b/lrpar/cttests/src/calc_nodefault_yacckind.test
@@ -1,4 +1,4 @@
-name: Test basic user actions using the calculator grammar
+name: Test specification of yacckind in %grmtools section
 grammar: |
     %grmtools {yacckind: Original(UserAction)}
     %start Expr

--- a/lrpar/cttests/src/calc_recoverer_cpctplus.test
+++ b/lrpar/cttests/src/calc_recoverer_cpctplus.test
@@ -1,4 +1,4 @@
-name: Test basic user actions using the calculator grammar
+name: Test multiple values in %grmtools section
 grammar: |
     %grmtools {yacckind: Original(UserAction), recoverer: RecoveryKind::CPCTPlus}
     %start Expr

--- a/lrpar/cttests/src/calc_recoverer_none.test
+++ b/lrpar/cttests/src/calc_recoverer_none.test
@@ -1,4 +1,4 @@
-vname: Test basic user actions using the calculator grammar
+vname: Test %grmtools section RecoveryKind::None
 grammar: |
     %grmtools {yacckind: Original(UserAction), recoverer: RecoveryKind::None}
     %start Expr

--- a/lrpar/cttests/src/calc_unsafeaction.test
+++ b/lrpar/cttests/src/calc_unsafeaction.test
@@ -1,4 +1,4 @@
-name: Test basic user actions using the calculator grammar
+name: Test unsafe user actions using the calculator grammar
 yacckind: Original(YaccOriginalActionKind::UserAction)
 grammar: |
     %start Expr


### PR DESCRIPTION
Just a minor thing I noticed when I went to work on cttests, the `name` field was copy/pasted in a few places
where the tests no longer reflected the actual purpose.  It isn't clear to me though when or whether this gets printed.
