### PR TITLE
Fix warnings from .buildbot.sh

### DIFF
--- a/cfgrammar/src/lib/markmap.rs
+++ b/cfgrammar/src/lib/markmap.rs
@@ -375,7 +375,7 @@ impl<K: Ord + Clone, V> MarkMap<K, V> {
     }
 
     /// Returns an `Entry` for `key`.
-    pub fn entry(&mut self, key: K) -> Entry<K, V> {
+    pub fn entry(&mut self, key: K) -> Entry<'_, K, V> {
         let pos = self.contents.binary_search_by(|(k, _, _)| k.cmp(&key));
         match pos {
             Err(pos) => Entry::Vacant(VacantEntry {

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -739,7 +739,7 @@ where
     /// based on the user-defined `token_cost` function which gives the associated cost for
     /// generating each token (where the cost must be greater than 0). Note that multiple
     /// tokens can have the same score. The simplest cost function is thus `|_| 1`.
-    pub fn sentence_generator<F>(&self, token_cost: F) -> SentenceGenerator<StorageT>
+    pub fn sentence_generator<F>(&self, token_cost: F) -> SentenceGenerator<'_, StorageT>
     where
         F: Fn(TIdx<StorageT>) -> u8,
     {

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -314,7 +314,7 @@ fn add_duplicate_occurrence(
 
 /// The actual parser is intended to be entirely opaque from outside users.
 impl YaccParser<'_> {
-    pub(crate) fn new(yacc_kind: YaccKind, src: &str) -> YaccParser {
+    pub(crate) fn new(yacc_kind: YaccKind, src: &str) -> YaccParser<'_> {
         YaccParser {
             yacc_kind,
             src,

--- a/lrlex/examples/calc_manual_lex/src/main.rs
+++ b/lrlex/examples/calc_manual_lex/src/main.rs
@@ -51,7 +51,7 @@ fn main() {
     }
 }
 
-fn lex(s: &str) -> LRNonStreamingLexer<DefaultLexerTypes<u8>> {
+fn lex(s: &str) -> LRNonStreamingLexer<'_, '_, DefaultLexerTypes<u8>> {
     let mut lexemes = Vec::new();
     let mut i = 0;
     while i < s.len() {

--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -380,10 +380,10 @@ where
     ) -> (Option<HashSet<&'a str>>, Option<HashSet<(&'a str, Span)>>);
 
     /// Returns an iterator over all rules in this AST.
-    fn iter_rules(&self) -> Iter<Rule<LexerTypesT::StorageT>>;
+    fn iter_rules(&self) -> Iter<'_, Rule<LexerTypesT::StorageT>>;
 
     /// Returns an iterator over all start states in this AST.
-    fn iter_start_states(&self) -> Iter<StartState>;
+    fn iter_start_states(&self) -> Iter<'_, StartState>;
 }
 
 /// This struct represents, in essence, a .l file in memory. From it one can produce an
@@ -517,11 +517,11 @@ where
         (missing_from_lexer, missing_from_parser)
     }
 
-    fn iter_rules(&self) -> Iter<Rule<LexerTypesT::StorageT>> {
+    fn iter_rules(&self) -> Iter<'_, Rule<LexerTypesT::StorageT>> {
         self.rules.iter()
     }
 
-    fn iter_start_states(&self) -> Iter<StartState> {
+    fn iter_start_states(&self) -> Iter<'_, StartState> {
         self.start_states.iter()
     }
 }

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -53,6 +53,7 @@ static GENERATED_PATHS: LazyLock<Mutex<HashSet<PathBuf>>> =
 struct CTConflictsError<StorageT: Eq + Hash> {
     conflicts_diagnostic: String,
     #[cfg(test)]
+    #[cfg_attr(test, allow(dead_code))]
     stable: StateTable<StorageT>,
     phantom: PhantomData<StorageT>,
 }

--- a/lrtable/src/lib/statetable.rs
+++ b/lrtable/src/lib/statetable.rs
@@ -433,7 +433,7 @@ where
     }
 
     /// Return an iterator over the indexes of all non-empty actions of `stidx`.
-    pub fn state_actions(&self, stidx: StIdx<StorageT>) -> StateActionsIterator<StorageT> {
+    pub fn state_actions(&self, stidx: StIdx<StorageT>) -> StateActionsIterator<'_, StorageT> {
         let start = usize::from(stidx) * usize::from(self.tokens_len);
         let end = start + usize::from(self.tokens_len);
         StateActionsIterator {
@@ -445,7 +445,7 @@ where
 
     /// Return an iterator over the indexes of all shift actions of `stidx`. By definition this
     /// is a subset of the indexes produced by [`state_actions`](#method.state_actions).
-    pub fn state_shifts(&self, stidx: StIdx<StorageT>) -> StateActionsIterator<StorageT> {
+    pub fn state_shifts(&self, stidx: StIdx<StorageT>) -> StateActionsIterator<'_, StorageT> {
         let start = usize::from(stidx) * usize::from(self.tokens_len);
         let end = start + usize::from(self.tokens_len);
         StateActionsIterator {
@@ -476,7 +476,7 @@ where
     ///   And:    [F -> c., $]
     ///
     /// since the two [E -> ...] items both have the same effects on a parse stack.
-    pub fn core_reduces(&self, stidx: StIdx<StorageT>) -> CoreReducesIterator<StorageT> {
+    pub fn core_reduces(&self, stidx: StIdx<StorageT>) -> CoreReducesIterator<'_, StorageT> {
         let start = usize::from(stidx) * usize::from(self.prods_len);
         let end = start + usize::from(self.prods_len);
         CoreReducesIterator {


### PR DESCRIPTION
I'm still slightly confused about the warnings this fixes,

They don't seem to appear with clippy, or cargo build/test.  But do appear when I run `.buildbot.sh`.
I haven't figured out what the difference between that and the default builds is though.

I'm also not exactly sure what is happening with the `#[cfg_attr(test, allow(dead_code))]`.
This field is used in `#[cfg(test)]`, but I believe that the tests it is used in might be `#[cfg(...)]` out under `wasm`
leading to the dead code warning on some platforms.