### PR TITLE
Disable two tests which require filesystem under wasm32-wasip2

### DIFF
--- a/lrlex/src/lib/ctbuilder.rs
+++ b/lrlex/src/lib/ctbuilder.rs
@@ -1444,7 +1444,10 @@ fn indent(indent: &str, s: &str) -> String {
     format!("{indent}{}\n", s.trim_end_matches('\n')).replace('\n', &format!("\n{}", indent))
 }
 
-#[cfg(test)]
+// It isn't clear to me why this test isn't working on wasm32,
+// as the `workspace_runner` should allow access to `OUT_DIR`
+// perhaps it is related to absolute paths
+#[cfg(all(not(target_arch = "wasm32"), test))]
 mod test {
     use std::fs::File;
     use std::io::Write;

--- a/lrpar/cttests/src/lib.rs
+++ b/lrpar/cttests/src/lib.rs
@@ -352,6 +352,7 @@ fn test_expect() {
 // various files from across the project workspace.
 //
 // Wasi's filesystem access is sandboxed by default.
+#[cfg(all(not(target_arch = "wasm32"), test))]
 #[test]
 fn test_grmtools_section_files() {
     use glob::glob;


### PR DESCRIPTION
I noticed an oddity in the ci build logs, where a testsuite failure wasn't causing a ci failure.

I've filed this PR to the `workspace_runner` to fix that, and will give some time for comment period before merging)

https://github.com/ratmice/workspace_runner/pull/3

This PR disables the tests that were failing.

One of these tests requires filesystem access to `../../lrpar/examples` which isn't going to work with the sandbox
Where the workspace runner allows access to everything between the source directory, and the `$OUT_DIR`.
But doesn't try to enumerate every path within the workspace.

There is a pre-existing comment that this test should be disabled under wasm32, but it seems like it didn't get disabled.

The other one appears like it *should* work, as in it seems like it should only require access to the `$OUT_DIR` directory.
So it isn't clear to me exactly why it is failing.