### PR TITLE
Pass `LexerKind` by reference.

### DIFF
--- a/lrlex/src/lib/ctbuilder.rs
+++ b/lrlex/src/lib/ctbuilder.rs
@@ -248,7 +248,7 @@ where
     show_warnings: bool,
     header: Header<Location>,
     #[cfg(test)]
-    inspect_lexerkind_cb: Option<Box<dyn Fn(LexerKind) -> Result<(), Box<dyn Error>>>>,
+    inspect_lexerkind_cb: Option<Box<dyn Fn(&LexerKind) -> Result<(), Box<dyn Error>>>>,
 }
 
 impl CTLexerBuilder<'_, DefaultLexerTypes<u32>> {
@@ -509,7 +509,7 @@ where
         };
         #[cfg(test)]
         if let Some(inspect_lexerkind_cb) = self.inspect_lexerkind_cb {
-            inspect_lexerkind_cb(lexerkind)?
+            inspect_lexerkind_cb(&lexerkind)?
         }
         let (lexerdef, lex_flags): (LRNonStreamingLexerDef<LexerTypesT>, LexFlags) =
             match lexerkind {
@@ -1211,7 +1211,7 @@ where
     #[cfg(test)]
     pub fn inspect_lexerkind(
         mut self,
-        cb: Box<dyn Fn(LexerKind) -> Result<(), Box<dyn Error>>>,
+        cb: Box<dyn Fn(&LexerKind) -> Result<(), Box<dyn Error>>>,
     ) -> Self {
         self.inspect_lexerkind_cb = Some(cb);
         self
@@ -1481,7 +1481,7 @@ mod test {
                 .output_path(format!("{}.rs", lex_path.clone()))
                 .lexer_path(lex_path.clone())
                 .inspect_lexerkind(Box::new(move |lexerkind| {
-                    assert!(matches!(lexerkind, LexerKind::LRNonStreamingLexer));
+                    assert!(matches!(lexerkind, &LexerKind::LRNonStreamingLexer));
                     Ok(())
                 }))
                 .build()


### PR DESCRIPTION
At the moment the code happens to work only because of an oversight in rustc: that oversight is likely to be fixed soon (https://github.com/rust-lang/rust/pull/150681).

@meithecatte If you're able to do so, I'd be grateful if you can confirm this addresses the rustc issue properly. If so, I will then make a new release shortly after so that we're not blocking the rustc PR.