### PR TITLE
Improve error message for issue #618

### DIFF
--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -1459,7 +1459,20 @@ where
             for i in 0..grm.prod(pidx).len() {
                 let argt = match grm.prod(pidx)[i] {
                     Symbol::Rule(ref_ridx) => {
-                        str::parse::<TokenStream>(grm.actiontype(ref_ridx).as_ref().unwrap())?
+                        if let Some(action_type) = grm.actiontype(ref_ridx).as_ref() {
+                            str::parse::<TokenStream>(action_type)?
+                        } else {
+                            let mut s = String::from("\n");
+                            let rule_span = grm.rule_name_span(ref_ridx);
+                            s.push_str(&diag.file_location_msg("Error", Some(rule_span)));
+                            s.push_str("\n");
+                            s.push_str(&diag.underline_span_with_text(
+                                rule_span,
+                                "Rule missing action type".to_string(),
+                                '^',
+                            ));
+                            return Err(ErrorString(s).into());
+                        }
                     }
                     Symbol::Token(_) => {
                         let lexemet =
@@ -1530,6 +1543,8 @@ where
                             let inner_span =
                                 Span::new(span.start() + last + off + "$".len(), span.end());
                             let mut s = String::from("\n");
+                            s.push_str(&diag.file_location_msg("Error", Some(inner_span)));
+                            s.push_str("\n");
                             s.push_str(&diag.underline_span_with_text(
                                 inner_span,
                                 "Unknown text following '$'".to_string(),


### PR DESCRIPTION
This should fix #618 which is a similar CTParserBuilder error that lacked span information (or a good error).

Tested with the `calc_parsetree` example with the following diff applied

```
diff --git a/lrpar/examples/calc_parsetree/src/calc.y b/lrpar/examples/calc_parsetree/src/calc.y
index b8a1f34d..25b165ec 100644
--- a/lrpar/examples/calc_parsetree/src/calc.y
+++ b/lrpar/examples/calc_parsetree/src/calc.y
@@ -1,5 +1,5 @@
 %grmtools{
-    yacckind: Original(GenericParseTree),
+    yacckind: Original(UserAction),
     test_files: ["input*.txt"],
 }
 %start Expr
```

```console  
--- stderr
  thread 'main' (2467488) panicked at lrpar/examples/calc_parsetree/build.rs:16:10:
  called `Result::unwrap()` on an `Err` value:
  8| Expr: Expr '+' Term
     ^^^^ Rule missing action type
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```