### PR TITLE
Note unreachable error

### DIFF
--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -1359,8 +1359,8 @@ where
             } else if pidx == grm.start_prod() {
                 wrapper_fn_body.extend(quote!(unreachable!()));
             } else {
-                panic!(
-                    "Production in rule '{}' must have an action body.",
+                unreachable!(
+                    "Production in rule '{}' must have an action body, which should have been handled by gen_user_actions.",
                     grm.rule_name_str(grm.prod_to_rule(pidx))
                 );
             };


### PR DESCRIPTION
I believe that the following error is unreachable, with the error in my last pr (#625) occurring before this error is reached.
It looks like this check was unreachable as far back as #456 because an `unwrap()` call would panic before this was printed.

Both appear to take the forms roughly:
```
for pidx in pidxs {
   match grm.actions(pidx) {
      Some(action_code) => ...,
      None if pidx == grm.start_prod() => ...,
      _ => error
   }
}
```

I'm not exactly convinced what I've done here (changing the panic to unreachable, and adding a note) is the right thing, but I struggled to find a better option, none of the existing combinators seemed to help clean it up either.

So curious if there are better ideas/preferences on how we should handle it, this seems kind of fragile.