### PR TITLE
Fix copy/paste error in setting up DEFAULT_LEX_FLAGS.case_insensitive.

### DIFF
--- a/lrlex/src/lib/parser.rs
+++ b/lrlex/src/lib/parser.rs
@@ -172,7 +172,7 @@ where
         *posix_escapes = posix_escapes.or(DEFAULT_LEX_FLAGS.posix_escapes);
         *allow_wholeline_comments =
             allow_wholeline_comments.or(DEFAULT_LEX_FLAGS.allow_wholeline_comments);
-        *case_insensitive = case_insensitive.or(DEFAULT_LEX_FLAGS.allow_wholeline_comments);
+        *case_insensitive = case_insensitive.or(DEFAULT_LEX_FLAGS.case_insensitive);
         *ignore_whitespace = ignore_whitespace.or(DEFAULT_LEX_FLAGS.ignore_whitespace);
         *swap_greed = swap_greed.or(DEFAULT_LEX_FLAGS.swap_greed);
         *unicode = unicode.or(DEFAULT_LEX_FLAGS.unicode);


### PR DESCRIPTION
This was accidentally defaulting to the default value for `allow_wholeline_comments`. This shouldn't have any effect, because `DEFAULT_LEX_FLAGS.allow_wholeline_comments` defaults to a different value `Some(false)` vs `None`.

The `None` value sets it use the regex default value which is `false`.