### PR TITLE
Stop emitting double `to_string()`

### DIFF
--- a/lrlex/src/lib/ctbuilder.rs
+++ b/lrlex/src/lib/ctbuilder.rs
@@ -823,7 +823,7 @@ where
                     // We cannot `impl ToToken for Rule` because `Rule` never stores `lex_flags`,
                     // Thus we reference the local lex_flags variable bound earlier.
                     quote! {
-                        Rule::new(::lrlex::unstable_api::InternalPublicApi, #tok_id, #n, #n_span, #regex.to_string(),
+                        Rule::new(::lrlex::unstable_api::InternalPublicApi, #tok_id, #n, #n_span, #regex,
                                 vec![#(#start_states),*], #target_state, &lex_flags).unwrap()
                     }
                 });


### PR DESCRIPTION

d70b2942 wrapped `regex` in a `QuoteToString` whose `ToTokens` implementation nominally handles the necessary `to_string()` invocation prior to splicing. However, it didn't make the parallel change to drop the call to `to_string` from the splice. This results in a redundant `regex.to_string().to_string()` in the generated code.
A minor tweak, with potentially negligible but positive impact if the compiler isn't clever enough. Mostly motivated on my part because the import model for the generated parsers (`include!`ing them directly in the code) makes it impossible to get Clippy to shut up about this.