### PR TITLE
Previously cargo-deny accepted 'check license' now it only seems to accept 'check licenses'

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -100,7 +100,7 @@ RUSTDOCFLAGS="-Dwarnings" cargo doc --no-deps
 
 # Check licenses.
 wait "${cargo_deny_mdbook_pid}" || ( cat "${cargo_deny_mdbook_tmp}" && exit 1 )
-cargo-deny check license
+cargo-deny check licenses
 
 # Build the docs
 cd $root/doc


### PR DESCRIPTION
This should fix the CI license check with newer versions of cargo-deny.
I couldn't find a ChangeLog entry/bug report/PR in cargo-deny that indicated this change though.