### PR TITLE
Fix typo, and test in cttests

### DIFF
--- a/lrpar/cttests/src/calc_actiontype.test
+++ b/lrpar/cttests/src/calc_actiontype.test
@@ -1,6 +1,6 @@
 name: Test basic user actions using the calculator grammar (Original yacckind)
 yacckind: Original(YaccOriginalActionKind::UserAction)
-recoverer: RecoveryKind::None
+recoverer: RecoveryKind::CPCTPlus
 grammar: |
     %start Expr
     %actiontype Result<u64, ()>

--- a/lrpar/cttests/src/cgen_helper.rs
+++ b/lrpar/cttests/src/cgen_helper.rs
@@ -31,9 +31,10 @@ pub(crate) fn run_test_path<P: AsRef<Path>>(path: P) -> Result<(), Box<dyn std::
             Some(s) => panic!("YaccKind '{}' not supported", s),
             None => None,
         };
-        let recoverer = match docs[0]["revoverer"].as_str() {
+        let recoverer = match docs[0]["recoverer"].as_str() {
             Some("RecoveryKind::CPCTPlus") => Some(RecoveryKind::CPCTPlus),
             Some("RecoveryKind::None") => Some(RecoveryKind::None),
+            Some(kind) => panic!("Unknown RecoveryKind '{kind}'"),
             _ => None,
         };
         let (negative_lex_flags, positive_lex_flags) = &docs[0]["lex_flags"]


### PR DESCRIPTION
This test was expecting to run with a recoverer. So fixing the typo, broke the test.
Because of the typo it was falling back to the default (CPCTPlus).
