### PR TITLE
Lrpar codegen

### DIFF
--- a/lrpar/src/lib/codegen.rs
+++ b/lrpar/src/lib/codegen.rs
@@ -1,11 +1,11 @@
 #![deny(unfulfilled_lint_expectations)]
 #![expect(dead_code)]
 
-use std::{error::Error, fmt, marker::PhantomData, path::Path};
+use std::{error::Error, fmt, hash::Hash, marker::PhantomData, path::Path};
 
 use crate::{
     LexerTypes, RecoveryKind, RustEdition, SerialisationFormat, Visibility,
-    ctbuilder::{ERROR, indent},
+    ctbuilder::{CTConflictsError, ERROR, FixIntConfig, VarIntConfig, indent},
     diagnostics::{DiagnosticFormatter, SpannedDiagnosticFormatter},
 };
 
@@ -14,7 +14,9 @@ use cfgrammar::{
     header::{GrmtoolsSectionParser, Header, HeaderValue},
     yacc::{YaccGrammar, YaccKind, ast::ASTWithValidityInfo},
 };
-use lrtable::{StateGraph, StateTable};
+
+use lrtable::{Minimiser, StateGraph, StateTable, from_yacc};
+use wincode::SchemaWrite;
 
 pub(crate) struct ParserSrcEnv<'a> {
     src: &'a str,
@@ -328,6 +330,103 @@ where
 
     pub(crate) fn yacc_kind(&self) -> YaccKind {
         self.ast_with_validity_info.yacc_kind()
+    }
+
+    pub(crate) fn code_generator(
+        &self,
+        src_env: &ParserSrcEnv,
+        timestamp: &str,
+    ) -> Result<ParserCodegen<LexerTypesT>, Box<dyn Error>> {
+        let grm = match YaccGrammar::<LexerTypesT::StorageT>::new_from_ast_with_validity_info(
+            &self.ast_with_validity_info,
+        ) {
+            Ok(grm) => grm,
+            Err(errs) => {
+                let mut out = String::new();
+                out.push_str(&format!(
+                    "\n{ERROR}{}\n",
+                    src_env.yacc_diag().file_location_msg("", None)
+                ));
+                for e in errs {
+                    out.push_str(&indent(
+                        "     ",
+                        &src_env.yacc_diag().format_error(e).to_string(),
+                    ));
+                    out.push('\n');
+                }
+                return Err(ErrorString(out).into());
+            }
+        };
+
+        let (sgraph, stable) = from_yacc(&grm, Minimiser::Pager)?;
+        if self.cache_args.error_on_conflicts
+            && let Some(c) = stable.conflicts()
+        {
+            match (grm.expect(), grm.expectrr()) {
+                (Some(i), Some(j)) if i == c.sr_len() && j == c.rr_len() => (),
+                (Some(i), None) if i == c.sr_len() && 0 == c.rr_len() => (),
+                (None, Some(j)) if 0 == c.sr_len() && j == c.rr_len() => (),
+                (None, None) if 0 == c.rr_len() && 0 == c.sr_len() => (),
+                _ => {
+                    let conflicts_diagnostic = src_env.yacc_diag().format_conflicts::<LexerTypesT>(
+                        &grm,
+                        self.ast_with_validity_info.ast(),
+                        c,
+                        &sgraph,
+                        &stable,
+                    );
+                    return Err(Box::new(CTConflictsError {
+                        conflicts_diagnostic,
+                        phantom: PhantomData,
+                        #[cfg(test)]
+                        stable,
+                    }));
+                }
+            }
+        }
+
+        Ok(ParserCodegen {
+            grm,
+            stable,
+            sgraph,
+            timestamp: timestamp.to_string(),
+        })
+    }
+}
+
+impl<LexerTypesT> ParserCodegen<LexerTypesT>
+where
+    LexerTypesT: LexerTypes,
+    usize: num_traits::AsPrimitive<LexerTypesT::StorageT>,
+    LexerTypesT::StorageT: 'static
+        + fmt::Debug
+        + Hash
+        + num_traits::PrimInt
+        + SchemaWrite<FixIntConfig, Src = LexerTypesT::StorageT>
+        + SchemaWrite<VarIntConfig, Src = LexerTypesT::StorageT>
+        + num_traits::Unsigned,
+    LexerTypesT: LexerTypes,
+{
+    pub(crate) fn grm(&self) -> &YaccGrammar<LexerTypesT::StorageT> {
+        &self.grm
+    }
+
+    pub(crate) fn stable(&self) -> &StateTable<LexerTypesT::StorageT> {
+        &self.stable
+    }
+
+    pub(crate) fn sgraph(&self) -> &StateGraph<LexerTypesT::StorageT> {
+        &self.sgraph
+    }
+
+    pub(crate) fn finish(
+        self,
+    ) -> (
+        YaccGrammar<LexerTypesT::StorageT>,
+        StateGraph<LexerTypesT::StorageT>,
+        StateTable<LexerTypesT::StorageT>,
+    ) {
+        (self.grm, self.sgraph, self.stable)
     }
 }
 

--- a/lrpar/src/lib/codegen.rs
+++ b/lrpar/src/lib/codegen.rs
@@ -1,23 +1,32 @@
 #![deny(unfulfilled_lint_expectations)]
 #![expect(dead_code)]
 
-use std::{error::Error, fmt, hash::Hash, marker::PhantomData, path::Path};
+use std::{
+    any::type_name,
+    error::Error,
+    fmt::{self, Write},
+    hash::Hash,
+    marker::PhantomData,
+    path::Path,
+};
 
 use crate::{
     LexerTypes, RecoveryKind, RustEdition, SerialisationFormat, Visibility,
-    ctbuilder::{CTConflictsError, ERROR, FixIntConfig, VarIntConfig, indent},
+    ctbuilder::{
+        ACTION_PREFIX, CTConflictsError, ERROR, FixIntConfig, VarIntConfig, indent, make_generics,
+    },
     diagnostics::{DiagnosticFormatter, SpannedDiagnosticFormatter},
 };
 
 use cfgrammar::{
-    Location, Span,
+    Location, Span, Symbol,
     header::{GrmtoolsSectionParser, Header, HeaderValue},
     yacc::{YaccGrammar, YaccKind, ast::ASTWithValidityInfo},
 };
 
 use lrtable::{Minimiser, StateGraph, StateTable, from_yacc};
 use proc_macro2::TokenStream;
-use quote::{ToTokens, TokenStreamExt, quote};
+use quote::{ToTokens, TokenStreamExt, format_ident, quote};
 use wincode::SchemaWrite;
 
 pub(crate) struct ParserSrcEnv<'a> {
@@ -493,6 +502,176 @@ where
         build_env: &ParserBuildEnv<LexerTypesT>,
     ) -> String {
         self.gen_cache(src_env, build_env).to_string()
+    }
+
+    /// Generate the user action functions (if any).
+    pub(crate) fn gen_user_actions(
+        &self,
+        src_env: &ParserSrcEnv,
+    ) -> Result<TokenStream, Box<dyn Error>> {
+        let grm = self.grm();
+        let diag = src_env.yacc_diag();
+        let programs = grm
+            .programs()
+            .as_ref()
+            .map(|s| str::parse::<TokenStream>(s))
+            .transpose()?;
+        let mut action_fns = TokenStream::new();
+        // Convert actions to functions
+        let parsed_parse_generics = make_generics(grm.parse_generics().as_deref())?;
+        let (generics, _, where_clause) = parsed_parse_generics.split_for_impl();
+        let (parse_paramname, parse_paramdef, parse_param_unit);
+        match grm.parse_param() {
+            Some((name, tyname)) => {
+                parse_param_unit = tyname.trim() == "()";
+                parse_paramname = str::parse::<TokenStream>(name)?;
+                let ty = str::parse::<TokenStream>(tyname)?;
+                parse_paramdef = quote!(#parse_paramname: #ty);
+            }
+            None => {
+                parse_param_unit = true;
+                parse_paramname = quote!(());
+                parse_paramdef = quote! {_: ()};
+            }
+        };
+        for pidx in grm.iter_pidxs() {
+            if pidx == grm.start_prod() {
+                continue;
+            }
+
+            // Work out the right type for each argument
+            let mut args = Vec::with_capacity(grm.prod(pidx).len());
+            for i in 0..grm.prod(pidx).len() {
+                let argt = match grm.prod(pidx)[i] {
+                    Symbol::Rule(ref_ridx) => {
+                        if let Some(action_type) = grm.actiontype(ref_ridx).as_ref() {
+                            str::parse::<TokenStream>(action_type)?
+                        } else {
+                            let mut s = String::from("\n");
+                            let rule_span = grm.rule_name_span(ref_ridx);
+                            s.push_str(&diag.file_location_msg("Error", Some(rule_span)));
+                            s.push('\n');
+                            s.push_str(&diag.underline_span_with_text(
+                                rule_span,
+                                "Rule missing action type".to_string(),
+                                '^',
+                            ));
+                            return Err(ErrorString(s).into());
+                        }
+                    }
+                    Symbol::Token(_) => {
+                        let lexemet =
+                            str::parse::<TokenStream>(type_name::<LexerTypesT::LexemeT>())?;
+                        quote!(::std::result::Result<#lexemet, #lexemet>)
+                    }
+                };
+                let arg = format_ident!("{}arg_{}", ACTION_PREFIX, i + 1);
+                args.push(quote!(mut #arg: #argt));
+            }
+
+            // If this rule's `actiont` is `()` then Clippy will warn that the return type `-> ()`
+            // is pointless (which is true). We therefore avoid outputting a return type if actiont
+            // is the unit type.
+            let returnt = {
+                let actiont = grm.actiontype(grm.prod_to_rule(pidx)).as_ref().unwrap();
+                if actiont == "()" {
+                    None
+                } else {
+                    let actiont = str::parse::<TokenStream>(actiont)?;
+                    Some(quote!( -> #actiont))
+                }
+            };
+            let action_fn = format_ident!("{}action_{}", ACTION_PREFIX, usize::from(pidx));
+            let lexer_var = format_ident!("{}lexer", ACTION_PREFIX);
+            let span_var = format_ident!("{}span", ACTION_PREFIX);
+            let ridx_var = format_ident!("{}ridx", ACTION_PREFIX);
+            let storaget = str::parse::<TokenStream>(type_name::<LexerTypesT::StorageT>())?;
+            let lexertypest = str::parse::<TokenStream>(type_name::<LexerTypesT>())?;
+            let bind_parse_param = if !parse_param_unit {
+                Some(quote! {let _ = #parse_paramname;})
+            } else {
+                None
+            };
+
+            // Iterate over all $-arguments and replace them with their respective
+            // element from the argument vector (e.g. $1 is replaced by args[0]).
+            let pre_action = grm.action(pidx).as_ref().ok_or_else(|| {
+                let mut s = String::from("\n");
+                let span = grm.prod_span(pidx);
+                s.push_str(&diag.file_location_msg("Error", Some(span)));
+                s.push('\n');
+                s.push_str(&diag.underline_span_with_text(
+                    span,
+                    "Production is missing action code".to_string(),
+                    '^',
+                ));
+                ErrorString(s)
+            })?;
+            let mut last = 0;
+            let mut outs = String::new();
+            loop {
+                match pre_action[last..].find('$') {
+                    Some(off) => {
+                        if pre_action[last + off..].starts_with("$$") {
+                            outs.push_str(&pre_action[last..last + off + "$".len()]);
+                            last = last + off + "$$".len();
+                        } else if pre_action[last + off..].starts_with("$lexer") {
+                            outs.push_str(&pre_action[last..last + off]);
+                            write!(outs, "{prefix}lexer", prefix = ACTION_PREFIX).ok();
+                            last = last + off + "$lexer".len();
+                        } else if pre_action[last + off..].starts_with("$span") {
+                            outs.push_str(&pre_action[last..last + off]);
+                            write!(outs, "{prefix}span", prefix = ACTION_PREFIX).ok();
+                            last = last + off + "$span".len();
+                        } else if last + off + 1 < pre_action.len()
+                            && pre_action[last + off + 1..].starts_with(|c: char| c.is_numeric())
+                        {
+                            outs.push_str(&pre_action[last..last + off]);
+                            write!(outs, "{prefix}arg_", prefix = ACTION_PREFIX).ok();
+                            last = last + off + "$".len();
+                        } else {
+                            let span = grm.action_span(pidx).unwrap();
+                            let inner_span =
+                                Span::new(span.start() + last + off + "$".len(), span.end());
+                            let mut s = String::from("\n");
+                            s.push_str(&diag.file_location_msg("Error", Some(inner_span)));
+                            s.push('\n');
+                            s.push_str(&diag.underline_span_with_text(
+                                inner_span,
+                                "Unknown text following '$'".to_string(),
+                                '^',
+                            ));
+                            return Err(ErrorString(s).into());
+                        }
+                    }
+                    None => {
+                        outs.push_str(&pre_action[last..]);
+                        break;
+                    }
+                }
+            }
+
+            let action_body = str::parse::<TokenStream>(&outs)?;
+            action_fns.extend(quote! {
+                #[allow(clippy::too_many_arguments)]
+                fn #action_fn #generics (
+                    #ridx_var: ::cfgrammar::RIdx<#storaget>,
+                    #lexer_var: &'lexer dyn ::lrpar::NonStreamingLexer<'input, #lexertypest>,
+                    #span_var: ::cfgrammar::Span,
+                    #parse_paramdef,
+                    #(#args,)*
+                ) #returnt
+                #where_clause
+                {
+                    #bind_parse_param
+                    #action_body
+                }
+            })
+        }
+        Ok(quote! {
+            #programs
+            #action_fns
+        })
     }
 }
 

--- a/lrpar/src/lib/codegen.rs
+++ b/lrpar/src/lib/codegen.rs
@@ -13,7 +13,8 @@ use std::{
 use crate::{
     LexerTypes, RecoveryKind, RustEdition, SerialisationFormat, Visibility,
     ctbuilder::{
-        ACTION_PREFIX, CTConflictsError, ERROR, FixIntConfig, VarIntConfig, indent, make_generics,
+        ACTION_PREFIX, CTConflictsError, ERROR, FixIntConfig, GLOBAL_PREFIX, VarIntConfig, indent,
+        make_generics,
     },
     diagnostics::{DiagnosticFormatter, SpannedDiagnosticFormatter},
 };
@@ -690,6 +691,28 @@ where
         }
         Ok(toks)
     }
+
+    pub(crate) fn gen_token_epp(&self) -> Result<TokenStream, proc_macro2::LexError> {
+        let grm = self.grm();
+        let mut tidxs = Vec::new();
+        for tidx in grm.iter_tidxs() {
+            tidxs.push(QuoteOption(grm.token_epp(tidx)));
+        }
+        let const_epp_ident = format_ident!("{}EPP", GLOBAL_PREFIX);
+        let storage_ty = str::parse::<TokenStream>(type_name::<LexerTypesT::StorageT>())?;
+        Ok(quote! {
+            const #const_epp_ident: &[::std::option::Option<&str>] = &[
+                #(#tidxs,)*
+            ];
+
+            /// Return the %epp entry for token `tidx` (where `None` indicates \"the token has no
+            /// pretty-printed value\"). Panics if `tidx` doesn't exist.
+            #[allow(dead_code)]
+            pub fn token_epp<'a>(tidx: ::cfgrammar::TIdx<#storage_ty>) -> ::std::option::Option<&'a str> {
+                #const_epp_ident[usize::from(tidx)]
+            }
+        })
+    }
 }
 
 /// A string which uses `Display` for it's `Debug` impl.
@@ -713,8 +736,7 @@ impl Error for ErrorString {}
 ///
 /// This wrapper instead emits both `Some` and `None` variants.
 /// See: [quote #20](https://github.com/dtolnay/quote/issues/20)
-// Temporarily pub(crate)
-pub(crate) struct QuoteOption<T>(pub(crate) Option<T>);
+struct QuoteOption<T>(Option<T>);
 
 impl<T: ToTokens> ToTokens for QuoteOption<T> {
     fn to_tokens(&self, tokens: &mut TokenStream) {

--- a/lrpar/src/lib/codegen.rs
+++ b/lrpar/src/lib/codegen.rs
@@ -453,6 +453,83 @@ where
         (self.grm, self.sgraph, self.stable)
     }
 
+    pub(crate) fn generate(
+        &self,
+        src_env: &ParserSrcEnv,
+        build_env: &ParserBuildEnv<LexerTypesT>,
+    ) -> Result<String, Box<dyn Error>> {
+        let mod_name = build_env.derived_mod_name();
+        let visibility = build_env.visibility();
+        let user_actions = if let YaccKind::Original(YaccOriginalActionKind::UserAction)
+        | YaccKind::Grmtools = build_env.yacc_kind()
+        {
+            Some(self.gen_user_actions(src_env)?)
+        } else {
+            None
+        };
+        let rule_consts = self.gen_rule_consts()?;
+        let token_epp = self.gen_token_epp()?;
+        let parse_function = self.gen_parse_function(build_env)?;
+        let action_wrappers = match build_env.yacc_kind() {
+            YaccKind::Original(YaccOriginalActionKind::UserAction) | YaccKind::Grmtools => {
+                Some(self.gen_wrappers(build_env)?)
+            }
+            YaccKind::Original(YaccOriginalActionKind::NoAction)
+            | YaccKind::Original(YaccOriginalActionKind::GenericParseTree) => None,
+            _ => unreachable!(),
+        };
+
+        let additional_decls = if let YaccKind::Original(YaccOriginalActionKind::GenericParseTree) =
+            build_env.yacc_kind()
+        {
+            // `lrpar::Node`` is deprecated within the lrpar crate, but not from within this module,
+            // Once it is removed from `lrpar`, we should move the declaration here entirely.
+            Some(quote! {
+                #[allow(unused_imports)]
+                pub use ::lrpar::parser::_deprecated_moved_::Node;
+            })
+        } else {
+            None
+        };
+
+        let mod_name =
+            match syn::parse_str::<proc_macro2::Ident>(mod_name) {
+                Ok(s) => s,
+                Err(e) => return Err(format!(
+                    "CTParserBuilder::mod_name(\"{}\") is not a valid rust identifier due to '{}'",
+                    mod_name, e
+                )
+                .into()),
+            };
+        let out_tokens = quote! {
+            #visibility mod #mod_name {
+                // At the top so that `user_actions` may contain #![inner_attribute]
+                #user_actions
+                mod _parser_ {
+                    #![allow(clippy::type_complexity)]
+                    #![allow(clippy::unnecessary_wraps)]
+                    #![deny(unsafe_code)]
+                    #[allow(unused_imports)]
+                    use super::*;
+                    #additional_decls
+                    #parse_function
+                    #rule_consts
+                    #token_epp
+                    #action_wrappers
+                } // End of `mod _parser_`
+                #[allow(unused_imports)]
+                pub use _parser_::*;
+                #[allow(unused_imports)]
+                use ::lrpar::Lexeme;
+            } // End of `mod #mod_name`
+        };
+        // Try and run a code formatter on the generated code.
+        let unformatted = out_tokens.to_string();
+        Ok(syn::parse_str(&unformatted)
+            .map(|syntax_tree| prettyplease::unparse(&syntax_tree))
+            .unwrap_or(unformatted))
+    }
+
     /// Generate the cache, which determines if anything's changed enough that we need to
     /// regenerate outputs and force rustc to recompile.
     fn gen_cache(

--- a/lrpar/src/lib/codegen.rs
+++ b/lrpar/src/lib/codegen.rs
@@ -12,10 +12,7 @@ use std::{
 
 use crate::{
     LexerTypes, RecoveryKind, RustEdition, SerialisationFormat, Visibility,
-    ctbuilder::{
-        ACTION_PREFIX, ACTIONS_KIND, ACTIONS_KIND_PREFIX, CTConflictsError, ERROR, FixIntConfig,
-        GLOBAL_PREFIX, VarIntConfig, indent, make_generics,
-    },
+    ctbuilder::{CTConflictsError, ERROR, FixIntConfig, VarIntConfig, indent, make_generics},
     diagnostics::{DiagnosticFormatter, SpannedDiagnosticFormatter},
 };
 
@@ -30,6 +27,12 @@ use proc_macro2::{Literal, TokenStream};
 use quote::{ToTokens, TokenStreamExt, format_ident, quote};
 use syn::Generics;
 use wincode::SchemaWrite;
+
+const ACTION_PREFIX: &str = "__gt_";
+const GLOBAL_PREFIX: &str = "__GT_";
+const ACTIONS_KIND: &str = "__GtActionsKind";
+const ACTIONS_KIND_PREFIX: &str = "Ak";
+const ACTIONS_KIND_HIDDEN: &str = "__GtActionsKindHidden";
 
 pub(crate) struct ParserSrcEnv<'a> {
     src: &'a str,
@@ -891,6 +894,169 @@ where
                 #run_parser
             }
         })
+    }
+
+    /// Generate the wrappers that call user actions
+    pub(crate) fn gen_wrappers(
+        &self,
+        build_env: &ParserBuildEnv<LexerTypesT>,
+    ) -> Result<TokenStream, Box<dyn Error>> {
+        let grm = self.grm();
+        let parsed_parse_generics = make_generics(grm.parse_generics().as_deref())?;
+        let (generics, type_generics, where_clause) = parsed_parse_generics.split_for_impl();
+
+        let (parse_paramname, parse_paramdef);
+        match grm.parse_param() {
+            Some((name, tyname)) => {
+                parse_paramname = str::parse::<TokenStream>(name)?;
+                let ty = str::parse::<TokenStream>(tyname)?;
+                parse_paramdef = quote!(#parse_paramname: #ty);
+            }
+            None => {
+                parse_paramname = quote!(());
+                parse_paramdef = quote! {_: ()};
+            }
+        };
+
+        let mut wrappers = TokenStream::new();
+        for pidx in grm.iter_pidxs() {
+            let ridx = grm.prod_to_rule(pidx);
+
+            // Iterate over all $-arguments and replace them with their respective
+            // element from the argument vector (e.g. $1 is replaced by args[0]). At
+            // the same time extract &str from tokens and actiontype from nonterminals.
+            let wrapper_fn = format_ident!("{}wrapper_{}", ACTION_PREFIX, usize::from(pidx));
+            let ridx_var = format_ident!("{}ridx", ACTION_PREFIX);
+            let lexer_var = format_ident!("{}lexer", ACTION_PREFIX);
+            let span_var = format_ident!("{}span", ACTION_PREFIX);
+            let args_var = format_ident!("{}args", ACTION_PREFIX);
+            let storaget = str::parse::<TokenStream>(type_name::<LexerTypesT::StorageT>())?;
+            let lexertypest = str::parse::<TokenStream>(type_name::<LexerTypesT>())?;
+            let actionskind = str::parse::<TokenStream>(ACTIONS_KIND)?;
+            let edition_lifetime = if build_env.rust_edition() != RustEdition::Rust2015 {
+                Some(quote!('_,))
+            } else {
+                None
+            };
+            let mut wrapper_fn_body = TokenStream::new();
+            if grm.action(pidx).is_some() {
+                // Unpack the arguments passed to us by the drain
+                for i in 0..grm.prod(pidx).len() {
+                    let arg = format_ident!("{}arg_{}", ACTION_PREFIX, i + 1);
+                    wrapper_fn_body.extend(match grm.prod(pidx)[i] {
+                        Symbol::Rule(ref_ridx) => {
+                            let ref_ridx = usize::from(ref_ridx);
+                            let actionvariant = format_ident!("{}{}", ACTIONS_KIND_PREFIX, ref_ridx);
+                            quote! {
+                                #[allow(clippy::let_unit_value)]
+                                let #arg = match #args_var.next().unwrap() {
+                                    ::lrpar::parser::AStackType::ActionType(#actionskind::#type_generics::#actionvariant(x)) => x,
+                                    _ => unreachable!()
+                                };
+                            }
+                        }
+                        Symbol::Token(_) => {
+                            quote! {
+                                let #arg = match #args_var.next().unwrap() {
+                                    ::lrpar::parser::AStackType::Lexeme(l) => {
+                                        if l.faulty() {
+                                            Err(l)
+                                        } else {
+                                            Ok(l)
+                                        }
+                                    },
+                                    ::lrpar::parser::AStackType::ActionType(_) => unreachable!()
+                                };
+                            }
+                        }
+                    })
+                }
+
+                // Call the user code
+                let args = (0..grm.prod(pidx).len())
+                    .map(|i| format_ident!("{}arg_{}", ACTION_PREFIX, i + 1))
+                    .collect::<Vec<_>>();
+                let action_fn = format_ident!("{}action_{}", ACTION_PREFIX, usize::from(pidx));
+                let actionsvariant = format_ident!("{}{}", ACTIONS_KIND_PREFIX, usize::from(ridx));
+
+                wrapper_fn_body.extend(match grm.actiontype(ridx) {
+                    Some(s) if s == "()" => {
+                        // If the rule `r` that we're calling has the unit type then Clippy will warn that
+                        // `enum::A(wrapper_r())` is pointless. We thus have to split it into two:
+                        // `wrapper_r(); enum::A(())`.
+                        quote! {
+                            #action_fn(#ridx_var, #lexer_var, #span_var, #parse_paramname, #(#args,)*);
+                            #actionskind::#type_generics::#actionsvariant(())
+                        }
+                    }
+                    _ => {
+                        quote! {
+                            #actionskind::#type_generics::#actionsvariant(#action_fn(#ridx_var, #lexer_var, #span_var, #parse_paramname, #(#args,)*))
+                        }
+                    }
+                })
+            } else if pidx == grm.start_prod() {
+                wrapper_fn_body.extend(quote!(unreachable!()));
+            } else {
+                unreachable!(
+                    "Production in rule '{}' must have an action body, which should have been handled by gen_user_actions.",
+                    grm.rule_name_str(grm.prod_to_rule(pidx))
+                );
+            };
+
+            let attrib = if pidx == grm.start_prod() {
+                // The start prod has an unreachable body so it doesn't use it's variables.
+                Some(quote!(#[allow(unused_variables)]))
+            } else {
+                None
+            };
+            wrappers.extend(quote! {
+                #attrib
+                fn #wrapper_fn #generics (
+                    #ridx_var: ::cfgrammar::RIdx<#storaget>,
+                    #lexer_var: &'lexer dyn ::lrpar::NonStreamingLexer<'input, #lexertypest>,
+                    #span_var: ::cfgrammar::Span,
+                    mut #args_var: ::std::vec::Drain<#edition_lifetime ::lrpar::parser::AStackType<<#lexertypest as ::lrpar::LexerTypes>::LexemeT, #actionskind #type_generics>>,
+                    #parse_paramdef
+                ) -> #actionskind #type_generics
+                #where_clause
+                {
+                    #wrapper_fn_body
+                }
+             })
+        }
+        let mut actionskindvariants = Vec::new();
+        let actionskindhidden = format_ident!("_{}", ACTIONS_KIND_HIDDEN);
+        let actionskind = str::parse::<TokenStream>(ACTIONS_KIND).unwrap();
+        let mut phantom_data_type = Vec::new();
+        for ridx in grm.iter_rules() {
+            if let Some(actiont) = grm.actiontype(ridx) {
+                let actionskindvariant =
+                    format_ident!("{}{}", ACTIONS_KIND_PREFIX, usize::from(ridx));
+                let actiont = str::parse::<TokenStream>(actiont).unwrap();
+                actionskindvariants.push(quote! {
+                    #actionskindvariant(#actiont)
+                })
+            }
+        }
+        for lifetime in parsed_parse_generics.lifetimes() {
+            let lifetime = &lifetime.lifetime;
+            phantom_data_type.push(quote! { &#lifetime () });
+        }
+        for type_param in parsed_parse_generics.type_params() {
+            let ident = &type_param.ident;
+            phantom_data_type.push(quote! { #ident });
+        }
+        actionskindvariants.push(quote! {
+            #actionskindhidden(::std::marker::PhantomData<(#(#phantom_data_type,)*)>)
+        });
+        wrappers.extend(quote! {
+            #[allow(dead_code)]
+            enum #actionskind #generics #where_clause {
+                #(#actionskindvariants,)*
+            }
+        });
+        Ok(wrappers)
     }
 
     /// Return the `RIdx` of the %start rule in the grammar (which will not be the same as

--- a/lrpar/src/lib/codegen.rs
+++ b/lrpar/src/lib/codegen.rs
@@ -13,21 +13,22 @@ use std::{
 use crate::{
     LexerTypes, RecoveryKind, RustEdition, SerialisationFormat, Visibility,
     ctbuilder::{
-        ACTION_PREFIX, CTConflictsError, ERROR, FixIntConfig, GLOBAL_PREFIX, VarIntConfig, indent,
-        make_generics,
+        ACTION_PREFIX, ACTIONS_KIND, ACTIONS_KIND_PREFIX, CTConflictsError, ERROR, FixIntConfig,
+        GLOBAL_PREFIX, VarIntConfig, indent, make_generics,
     },
     diagnostics::{DiagnosticFormatter, SpannedDiagnosticFormatter},
 };
 
 use cfgrammar::{
-    Location, Span, Symbol,
+    Location, RIdx, Span, Symbol,
     header::{GrmtoolsSectionParser, Header, HeaderValue},
-    yacc::{YaccGrammar, YaccKind, ast::ASTWithValidityInfo},
+    yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind, ast::ASTWithValidityInfo},
 };
 
 use lrtable::{Minimiser, StateGraph, StateTable, from_yacc};
 use proc_macro2::{Literal, TokenStream};
 use quote::{ToTokens, TokenStreamExt, format_ident, quote};
+use syn::Generics;
 use wincode::SchemaWrite;
 
 pub(crate) struct ParserSrcEnv<'a> {
@@ -712,6 +713,196 @@ where
                 #const_epp_ident[usize::from(tidx)]
             }
         })
+    }
+
+    /// Generate the main parse() function for the output file.
+    pub(crate) fn gen_parse_function(
+        &self,
+        build_env: &ParserBuildEnv<LexerTypesT>,
+    ) -> Result<TokenStream, Box<dyn Error>> {
+        let stable = self.stable();
+        let grm = self.grm();
+        let storaget = str::parse::<TokenStream>(type_name::<LexerTypesT::StorageT>())?;
+        let lexertypest = str::parse::<TokenStream>(type_name::<LexerTypesT>())?;
+        let recoverer = build_env.recoverer();
+        let run_parser = match build_env.yacc_kind() {
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree) => {
+                quote! {
+                    ::lrpar::RTParserBuilder::new(grm, stable)
+                        .recoverer(#recoverer)
+                        .parse_map(
+                            lexer,
+                            &|lexeme| Node::Term{lexeme},
+                            &|ridx, nodes| Node::Nonterm{ridx, nodes}
+                        )
+                }
+            }
+            YaccKind::Original(YaccOriginalActionKind::NoAction) => {
+                quote! {
+                    ::lrpar::RTParserBuilder::new(grm, stable)
+                        .recoverer(#recoverer)
+                        .parse_map(lexer, &|_| (), &|_, _| ()).1
+                }
+            }
+            YaccKind::Original(YaccOriginalActionKind::UserAction) | YaccKind::Grmtools => {
+                let actionskind = str::parse::<TokenStream>(ACTIONS_KIND)?;
+                let parsed_parse_generics = make_generics(grm.parse_generics().as_deref())?;
+                let (_, type_generics, _) = parsed_parse_generics.split_for_impl();
+                // actions always have a parse_param argument, and when the `parse` function lacks one
+                // that parameter will be unit.
+                let (action_fn_parse_param, action_fn_parse_param_ty) = match grm.parse_param() {
+                    Some((name, ty)) => {
+                        let name = str::parse::<TokenStream>(name)?;
+                        let ty = str::parse::<TokenStream>(ty)?;
+                        (quote!(#name), quote!(#ty))
+                    }
+                    None => (quote!(()), quote!(())),
+                };
+                let wrappers = grm.iter_pidxs().map(|pidx| {
+                    let pidx = usize::from(pidx);
+                    format_ident!("{}wrapper_{}", ACTION_PREFIX, pidx)
+                });
+                let edition_lifetime = if build_env.rust_edition() != RustEdition::Rust2015 {
+                    quote!('_,)
+                } else {
+                    quote!()
+                };
+                let ridx = usize::from(self.user_start_ridx());
+                let action_ident = format_ident!("{}{}", ACTIONS_KIND_PREFIX, ridx);
+
+                quote! {
+                    let actions: ::std::vec::Vec<
+                            &dyn Fn(
+                                    ::cfgrammar::RIdx<#storaget>,
+                                    &'lexer dyn ::lrpar::NonStreamingLexer<'input, #lexertypest>,
+                                    ::cfgrammar::Span,
+                                    ::std::vec::Drain<#edition_lifetime ::lrpar::parser::AStackType<<#lexertypest as ::lrpar::LexerTypes>::LexemeT, #actionskind #type_generics>>,
+                                    #action_fn_parse_param_ty
+                            ) -> #actionskind #type_generics
+                        > = ::std::vec![#(&#wrappers,)*];
+                    match ::lrpar::RTParserBuilder::new(grm, stable)
+                        .recoverer(#recoverer)
+                        .parse_actions(lexer, &actions, #action_fn_parse_param) {
+                            (Some(#actionskind::#action_ident(x)), y) => (Some(x), y),
+                            (None, y) => (None, y),
+                            _ => unreachable!()
+                    }
+                }
+            }
+            kind => panic!("YaccKind {:?} not supported", kind),
+        };
+
+        let parsed_parse_generics: Generics = match build_env.yacc_kind() {
+            YaccKind::Original(YaccOriginalActionKind::UserAction) | YaccKind::Grmtools => {
+                make_generics(grm.parse_generics().as_deref())?
+            }
+            _ => make_generics(None)?,
+        };
+        let (generics, _, where_clause) = parsed_parse_generics.split_for_impl();
+
+        // `parse()` may or may not have an argument for `%parseparam`.
+        let parse_fn_parse_param = match build_env.yacc_kind() {
+            YaccKind::Original(YaccOriginalActionKind::UserAction) | YaccKind::Grmtools => {
+                if let Some((name, tyname)) = grm.parse_param() {
+                    let name = str::parse::<TokenStream>(name)?;
+                    let tyname = str::parse::<TokenStream>(tyname)?;
+                    Some(quote! {#name: #tyname})
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        };
+        let parse_fn_return_ty = match build_env.yacc_kind() {
+            YaccKind::Original(YaccOriginalActionKind::UserAction) | YaccKind::Grmtools => {
+                let actiont = grm
+                    .actiontype(self.user_start_ridx())
+                    .as_ref()
+                    .map(|at| str::parse::<TokenStream>(at))
+                    .transpose()?;
+                quote! {
+                    (::std::option::Option<#actiont>, ::std::vec::Vec<::lrpar::LexParseError<#storaget, #lexertypest>>)
+                }
+            }
+            YaccKind::Original(YaccOriginalActionKind::GenericParseTree) => quote! {
+                (::std::option::Option<Node<<#lexertypest as ::lrpar::LexerTypes>::LexemeT, #storaget>>,
+                    ::std::vec::Vec<::lrpar::LexParseError<#storaget, #lexertypest>>)
+            },
+            YaccKind::Original(YaccOriginalActionKind::NoAction) => quote! {
+                ::std::vec::Vec<::lrpar::LexParseError<#storaget, #lexertypest>>
+            },
+            _ => unreachable!(),
+        };
+
+        let serialisation_format = build_env.serialisation_format();
+        // Note that the configuration types use associated consts, and thus these configurations represent distinct types.
+        let (grm_data, stable_data): (Vec<u8>, Vec<u8>) = match serialisation_format {
+            SerialisationFormat::FixedSizeInteger => {
+                let config = wincode::config::Configuration::default().with_fixint_encoding();
+                let grm = wincode::config::serialize(grm, config)?;
+                let stable = wincode::config::serialize(stable, config)?;
+                (grm, stable)
+            }
+            SerialisationFormat::VariableSizedInteger => {
+                let config = wincode::config::Configuration::default().with_varint_encoding();
+                let grm = wincode::config::serialize(grm, config)?;
+                let stable = wincode::config::serialize(stable, config)?;
+                (grm, stable)
+            }
+        };
+        let serialisation_format_str = quote!(serialisation_format).to_string();
+        Ok(quote! {
+            const __GRM_DATA: &[u8] = &[#(#grm_data,)*];
+            const __STABLE_DATA: &[u8] = &[#(#stable_data,)*];
+            const __SERIALISATION_FORMAT: ::lrpar::ctbuilder::SerialisationFormat = #serialisation_format;
+
+            fn __lrpar_parser_data() -> &'static ::lrpar::ParserData<#storaget> {
+                static DATA: ::std::sync::OnceLock<::lrpar::ParserData<#storaget>>
+                    = ::std::sync::OnceLock::new();
+                DATA.get_or_init(
+                    || {
+                        // We have to call reconstitute like this because the config parameter takes a trait
+                        // which uses const generics. Thus the two config parameters here are not actually of the same type.
+                        match __SERIALISATION_FORMAT {
+                            ::lrpar::ctbuilder::SerialisationFormat::FixedSizeInteger => {
+                                ::lrpar::ctbuilder::_reconstitute(__GRM_DATA, __STABLE_DATA, ::lrpar::ctbuilder::wincode::config::Configuration::default().with_fixint_encoding())
+                            }
+                            ::lrpar::ctbuilder::SerialisationFormat::VariableSizedInteger => {
+                                ::lrpar::ctbuilder::_reconstitute(__GRM_DATA, __STABLE_DATA, ::lrpar::ctbuilder::wincode::config::Configuration::default().with_varint_encoding())
+                            }
+                            _ => {
+                                panic!("Parser source was generated using unknown `SerialisationFormat`: {:?}", #serialisation_format_str)
+                            }
+                        }
+                    }
+                )
+            }
+
+            #[allow(dead_code)]
+            pub fn parse #generics (
+                 lexer: &'lexer dyn ::lrpar::NonStreamingLexer<'input, #lexertypest>,
+                 #parse_fn_parse_param
+            ) -> #parse_fn_return_ty
+            #where_clause
+            {
+                let __data = __lrpar_parser_data();
+                let grm = __data.grm();
+                let stable = __data.stable();
+                #run_parser
+            }
+        })
+    }
+
+    /// Return the `RIdx` of the %start rule in the grammar (which will not be the same as
+    /// grm.start_rule_idx because the latter has an additional rule insert by cfgrammar
+    /// which then calls the user's %start rule).
+    fn user_start_ridx(&self) -> RIdx<LexerTypesT::StorageT> {
+        let grm = self.grm();
+        debug_assert_eq!(grm.prod(grm.start_prod()).len(), 1);
+        match grm.prod(grm.start_prod())[0] {
+            Symbol::Rule(ridx) => ridx,
+            _ => unreachable!(),
+        }
     }
 }
 

--- a/lrpar/src/lib/codegen.rs
+++ b/lrpar/src/lib/codegen.rs
@@ -12,7 +12,7 @@ use std::{
 
 use crate::{
     LexerTypes, RecoveryKind, RustEdition, SerialisationFormat, Visibility,
-    ctbuilder::{CTConflictsError, ERROR, FixIntConfig, VarIntConfig, indent, make_generics},
+    ctbuilder::{CTConflictsError, ERROR, FixIntConfig, VarIntConfig, indent},
     diagnostics::{DiagnosticFormatter, SpannedDiagnosticFormatter},
 };
 
@@ -25,7 +25,7 @@ use cfgrammar::{
 use lrtable::{Minimiser, StateGraph, StateTable, from_yacc};
 use proc_macro2::{Literal, TokenStream};
 use quote::{ToTokens, TokenStreamExt, format_ident, quote};
-use syn::Generics;
+use syn::{Generics, parse_quote};
 use wincode::SchemaWrite;
 
 const ACTION_PREFIX: &str = "__gt_";
@@ -1253,5 +1253,30 @@ impl Visibility {
                 quote!(::lrpar::Visibility::PublicIn(#data))
             }
         }
+    }
+}
+
+impl ToTokens for SerialisationFormat {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.extend(match self {
+            SerialisationFormat::FixedSizeInteger => {
+                quote! {::lrpar::ctbuilder::SerialisationFormat::FixedSizeInteger}
+            }
+            SerialisationFormat::VariableSizedInteger => {
+                quote! {::lrpar::ctbuilder::SerialisationFormat::VariableSizedInteger}
+            }
+        })
+    }
+}
+
+pub(crate) fn make_generics(parse_generics: Option<&str>) -> Result<Generics, Box<dyn Error>> {
+    if let Some(parse_generics) = parse_generics {
+        let tokens = str::parse::<TokenStream>(parse_generics)?;
+        match syn::parse2(quote!(<'lexer, 'input: 'lexer, #tokens>)) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(format!("unable to parse %parse-generics: {}", err).into()),
+        }
+    } else {
+        Ok(parse_quote!(<'lexer, 'input: 'lexer>))
     }
 }

--- a/lrpar/src/lib/codegen.rs
+++ b/lrpar/src/lib/codegen.rs
@@ -125,6 +125,10 @@ impl<'a> ParserSrcEnv<'a> {
         }
     }
 
+    pub(crate) fn path(&self) -> &Path {
+        self.path
+    }
+
     pub(crate) fn yacc_diag(&self) -> &SpannedDiagnosticFormatter<'a> {
         &self.diagnostics
     }
@@ -302,6 +306,10 @@ where
 
     pub(crate) fn derived_mod_name(&self) -> &str {
         &self.mod_name
+    }
+
+    pub(crate) fn specified_mod_name(&self) -> Option<&str> {
+        self.cache_args.mod_name.as_deref()
     }
 
     pub(crate) fn recoverer(&self) -> RecoveryKind {

--- a/lrpar/src/lib/codegen.rs
+++ b/lrpar/src/lib/codegen.rs
@@ -3,7 +3,6 @@
 
 use std::{
     any::type_name,
-    error::Error,
     fmt::{self, Write},
     hash::Hash,
     marker::PhantomData,
@@ -12,17 +11,19 @@ use std::{
 
 use crate::{
     LexerTypes, RecoveryKind, RustEdition, SerialisationFormat, Visibility,
-    ctbuilder::{CTConflictsError, ERROR, FixIntConfig, VarIntConfig, indent},
-    diagnostics::{DiagnosticFormatter, SpannedDiagnosticFormatter},
+    ctbuilder::{FixIntConfig, VarIntConfig},
 };
 
 use cfgrammar::{
     Location, RIdx, Span, Symbol,
-    header::{GrmtoolsSectionParser, Header, HeaderValue},
-    yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind, ast::ASTWithValidityInfo},
+    header::{GrmtoolsSectionParser, Header, HeaderError, HeaderValue},
+    markmap::MergeError,
+    yacc::{
+        YaccGrammar, YaccGrammarError, YaccKind, YaccOriginalActionKind, ast::ASTWithValidityInfo,
+    },
 };
 
-use lrtable::{Minimiser, StateGraph, StateTable, from_yacc};
+use lrtable::{Minimiser, StateGraph, StateTable, StateTableError, from_yacc};
 use proc_macro2::{Literal, TokenStream};
 use quote::{ToTokens, TokenStreamExt, format_ident, quote};
 use syn::{Generics, parse_quote};
@@ -34,13 +35,145 @@ const ACTIONS_KIND: &str = "__GtActionsKind";
 const ACTIONS_KIND_PREFIX: &str = "Ak";
 const ACTIONS_KIND_HIDDEN: &str = "__GtActionsKindHidden";
 
-pub(crate) struct ParserSrcEnv<'a> {
+pub(crate) enum ParserSrcEnvError {
+    GrmtoolsSectionParseError(Vec<HeaderError<Span>>),
+    GrmtoolsSectionMergeError(MergeError<String, Box<HeaderValue<Location>>>),
+    GrmtoolsSectionLookupError(HeaderError<Location>),
+    MissingYaccKind,
+    MissingModName,
+}
+
+pub(crate) enum ParserBuildEnvError<LexerTypesT>
+where
+    LexerTypesT: LexerTypes,
+    usize: num_traits::AsPrimitive<LexerTypesT::StorageT>,
+{
+    StateTableError(StateTableError<LexerTypesT::StorageT>),
+    YaccGrammarErrors(Vec<YaccGrammarError>),
+    GrmtoolsSectionUnusedKeys(Vec<String>),
+    GrmtoolsSectionMissingRequiredKeys(Vec<String>),
+}
+
+pub(crate) enum CodegenError {
+    ProcMacro2Error(proc_macro2::LexError),
+    InvalidRustIdentifierModName(syn::Error, String),
+    InvalidParseGenerics(syn::Error),
+    WincodeError(wincode::WriteError),
+}
+
+impl From<Vec<HeaderError<Span>>> for ParserSrcEnvError {
+    fn from(it: Vec<HeaderError<Span>>) -> Self {
+        ParserSrcEnvError::GrmtoolsSectionParseError(it)
+    }
+}
+
+impl From<MergeError<String, Box<HeaderValue<Location>>>> for ParserSrcEnvError {
+    fn from(it: MergeError<String, Box<HeaderValue<Location>>>) -> Self {
+        ParserSrcEnvError::GrmtoolsSectionMergeError(it)
+    }
+}
+
+impl From<HeaderError<Location>> for ParserSrcEnvError {
+    fn from(it: HeaderError<Location>) -> Self {
+        ParserSrcEnvError::GrmtoolsSectionLookupError(it)
+    }
+}
+
+impl<LexerTypesT> From<Vec<YaccGrammarError>> for ParserBuildEnvError<LexerTypesT>
+where
+    LexerTypesT: LexerTypes,
+    usize: num_traits::AsPrimitive<LexerTypesT::StorageT>,
+{
+    fn from(it: Vec<YaccGrammarError>) -> Self {
+        ParserBuildEnvError::YaccGrammarErrors(it)
+    }
+}
+
+impl<LexerTypesT> From<StateTableError<LexerTypesT::StorageT>> for ParserBuildEnvError<LexerTypesT>
+where
+    LexerTypesT: LexerTypes,
+    usize: num_traits::AsPrimitive<LexerTypesT::StorageT>,
+{
+    fn from(it: StateTableError<LexerTypesT::StorageT>) -> Self {
+        ParserBuildEnvError::StateTableError(it)
+    }
+}
+
+impl From<proc_macro2::LexError> for CodegenError {
+    fn from(it: proc_macro2::LexError) -> Self {
+        CodegenError::ProcMacro2Error(it)
+    }
+}
+
+impl From<wincode::WriteError> for CodegenError {
+    fn from(it: wincode::WriteError) -> Self {
+        CodegenError::WincodeError(it)
+    }
+}
+
+impl fmt::Display for ParserSrcEnvError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&match self {
+            Self::GrmtoolsSectionParseError(errs) => errs
+                .iter()
+                .map(|e| e.to_string())
+                .collect::<Vec<_>>()
+                .join("\n"),
+            Self::GrmtoolsSectionMergeError(e) => e.to_string(),
+            Self::GrmtoolsSectionLookupError(e) => e.to_string(),
+            Self::MissingYaccKind => "Code generator cannot resolve yacc kind".to_string(),
+            Self::MissingModName => "Code generator requires a mod name".to_string(),
+        })
+    }
+}
+
+impl<LexerTypesT> fmt::Display for ParserBuildEnvError<LexerTypesT>
+where
+    LexerTypesT: LexerTypes,
+    usize: num_traits::AsPrimitive<LexerTypesT::StorageT>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&match self {
+            Self::StateTableError(e) => format!("{}", e).to_string(),
+            Self::YaccGrammarErrors(errs) => errs
+                .iter()
+                .map(|e| e.to_string())
+                .collect::<Vec<_>>()
+                .join("\n"),
+            Self::GrmtoolsSectionUnusedKeys(keys) => {
+                format!("Unused keys in %grmtools section: {}", keys.join(", "))
+            }
+            Self::GrmtoolsSectionMissingRequiredKeys(keys) => format!(
+                "Required keys are missing from %grmtools section: {}",
+                keys.join(", ")
+            ),
+        })
+    }
+}
+impl fmt::Display for CodegenError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&match self {
+            Self::ProcMacro2Error(e) => e.to_string(),
+            Self::InvalidRustIdentifierModName(e, s) => format!(
+                "mod_name '{}' is not a valid rust identifier due to '{}'",
+                s, e
+            ),
+            Self::InvalidParseGenerics(e) => format!("Unable to parse %parse-generics '{e}'"),
+            Self::WincodeError(e) => format!("Unable to serialize parser {e}"),
+        })
+    }
+}
+
+pub(crate) struct ParserSrcEnv<'a, LexerTypesT>
+where
+    LexerTypesT: LexerTypes,
+    usize: num_traits::AsPrimitive<LexerTypesT::StorageT>,
+{
     src: &'a str,
-    // We store the path here so we can generate a module name from it if needed.
-    // But should never use it for filesystem interaction within this module.
-    path: &'a Path,
-    diagnostics: SpannedDiagnosticFormatter<'a>,
+    fallback_modname: Option<String>,
+    grammar_path_cache_entry: Option<String>,
     header: Header<Location>,
+    phantom: PhantomData<LexerTypesT::StorageT>,
 }
 
 pub(crate) struct ParserBuildEnvArgs<'a> {
@@ -66,6 +199,8 @@ where
     cache_args: ParserBuildEnvArgs<'a>,
     phantom_storaget: PhantomData<LexerTypesT::StorageT>,
     mod_name: String,
+    grammar_path: Option<String>,
+    header: Header<Location>,
 }
 
 pub(crate) struct ParserCodegen<LexerTypesT>
@@ -126,27 +261,41 @@ impl<'a> ParserBuildEnvArgs<'a> {
     }
 }
 
-impl<'a> ParserSrcEnv<'a> {
+impl<'a, LexerTypesT> ParserSrcEnv<'a, LexerTypesT>
+where
+    LexerTypesT: LexerTypes,
+    usize: num_traits::AsPrimitive<LexerTypesT::StorageT>,
+{
     pub(crate) fn new_with_header(
         src: &'a str,
-        path: &'a Path,
+        path: Option<&Path>,
         header: Header<Location>,
-    ) -> ParserSrcEnv<'a> {
-        let diagnostics = SpannedDiagnosticFormatter::new(src, path);
+    ) -> ParserSrcEnv<'a, LexerTypesT> {
+        let fallback_modname = if let Some(path) = path {
+            // When the user hasn't specified a module name, so we create one automatically: what we
+            // do is strip off all the filename extensions (note that it's likely that inp ends
+            // with `y.rs`, so we potentially have to strip off more than one extension) and
+            // then add `_y` to the end.
+            let mut stem = path.to_str().unwrap();
+            loop {
+                let new_stem = Path::new(stem).file_stem().unwrap().to_str().unwrap();
+                if stem == new_stem {
+                    break;
+                }
+                stem = new_stem;
+            }
+            Some(format!("{}_y", stem))
+        } else {
+            None
+        };
+        let grammar_path_cache_entry = path.map(|s| s.to_string_lossy().to_string());
         ParserSrcEnv {
             src,
-            path,
+            fallback_modname,
+            grammar_path_cache_entry,
             header,
-            diagnostics,
+            phantom: PhantomData,
         }
-    }
-
-    pub(crate) fn path(&self) -> &Path {
-        self.path
-    }
-
-    pub(crate) fn yacc_diag(&self) -> &SpannedDiagnosticFormatter<'a> {
-        &self.diagnostics
     }
 
     pub(crate) fn header_mut(&mut self) -> &mut Header<Location> {
@@ -157,52 +306,13 @@ impl<'a> ParserSrcEnv<'a> {
         &self.header
     }
 
-    fn merge_headers(&mut self) -> Result<(), Box<dyn Error>> {
+    fn merge_headers(&mut self) -> Result<(), ParserSrcEnvError> {
         let (parsed_header, _) = self.parse_header()?;
         Ok(self.header.merge_from(parsed_header)?)
     }
 
-    fn parse_header(&self) -> Result<(Header<Span>, usize), Box<dyn Error>> {
-        GrmtoolsSectionParser::new(self.src, false)
-            .parse()
-            .map_err(|es| {
-                let mut out = String::new();
-                out.push_str(&format!(
-                    "\n{ERROR}{}\n",
-                    self.yacc_diag()
-                        .file_location_msg(" parsing the `%grmtools` section", None)
-                ));
-                for e in es {
-                    out.push_str(&indent(
-                        "     ",
-                        &self.yacc_diag().format_error(e).to_string(),
-                    ));
-                    out.push('\n');
-                }
-                ErrorString(out).into()
-            })
-    }
-
-    pub(crate) fn check_unused_header_keys(&self) -> Result<(), Box<dyn Error>> {
-        let unused_keys = self.header.unused();
-        if !unused_keys.is_empty() {
-            return Err(format!("Unused keys in header: {}", unused_keys.join(", ")).into());
-        }
-        let missing_keys = self
-            .header
-            .missing()
-            .iter()
-            .map(|s| s.as_str())
-            .collect::<Vec<_>>();
-        if !missing_keys.is_empty() {
-            Err(format!(
-                "Required values were missing from the header: {}",
-                missing_keys.join(", ")
-            )
-            .into())
-        } else {
-            Ok(())
-        }
+    fn parse_header(&self) -> Result<(Header<Span>, usize), Vec<HeaderError<Span>>> {
+        GrmtoolsSectionParser::new(self.src, false).parse()
     }
 
     /// Looks up the `yacckind` field from the header, marks the field
@@ -210,7 +320,7 @@ impl<'a> ParserSrcEnv<'a> {
     fn resolve_ast_with_validity_info(
         &mut self,
         from_ast: Option<&ASTWithValidityInfo>,
-    ) -> Result<ASTWithValidityInfo, Box<dyn Error>> {
+    ) -> Result<ASTWithValidityInfo, ParserSrcEnvError> {
         self.header.mark_used(&"yacckind".to_string());
         if let Some(ast) = from_ast {
             Ok(ast.clone())
@@ -223,13 +333,13 @@ impl<'a> ParserSrcEnv<'a> {
         {
             Ok(ASTWithValidityInfo::new(yk, self.src))
         } else {
-            Err("Missing 'yacckind'".to_string())?
+            Err(ParserSrcEnvError::MissingYaccKind)?
         }
     }
 
     /// Looks up the `recoverer` field in the header, marks the field
     /// as used, and defaulting to `CPCTPlus` if unfound.
-    fn resolve_recoverer(&mut self) -> Result<RecoveryKind, Box<dyn Error>> {
+    fn resolve_recoverer(&mut self) -> Result<RecoveryKind, ParserSrcEnvError> {
         self.header.mark_used(&"recoverer".to_string());
         let rk_val = self
             .header
@@ -245,7 +355,7 @@ impl<'a> ParserSrcEnv<'a> {
 
     /// Looks up the `serialisation_format` field in the header, marks the field
     /// as used, and defaults to `VariableSizedInteger` if unfound.
-    fn resolve_serialisation_format(&mut self) -> Result<SerialisationFormat, Box<dyn Error>> {
+    fn resolve_serialisation_format(&mut self) -> Result<SerialisationFormat, ParserSrcEnvError> {
         self.header.mark_used(&"serialisation_format".to_string());
         if let Some(ec_val) = self
             .header
@@ -260,31 +370,21 @@ impl<'a> ParserSrcEnv<'a> {
 
     /// Looks up the `mod_name` from the `args`, and defaults to
     /// the `{filename}_y` with any file extenstion stripped off.
-    fn resolve_mod_name(&self, args: &ParserBuildEnvArgs) -> String {
+    fn resolve_mod_name(&self, args: &ParserBuildEnvArgs) -> Result<String, ParserSrcEnvError> {
         match &args.mod_name {
-            Some(s) => s.to_owned(),
-            None => {
-                // The user hasn't specified a module name, so we create one automatically: what we
-                // do is strip off all the filename extensions (note that it's likely that inp ends
-                // with `y.rs`, so we potentially have to strip off more than one extension) and
-                // then add `_y` to the end.
-                let mut stem = self.path.to_str().unwrap();
-                loop {
-                    let new_stem = Path::new(stem).file_stem().unwrap().to_str().unwrap();
-                    if stem == new_stem {
-                        break;
-                    }
-                    stem = new_stem;
-                }
-                format!("{}_y", stem)
-            }
+            Some(s) => Ok(s.to_owned()),
+            None => self
+                .fallback_modname
+                .as_ref()
+                .ok_or(ParserSrcEnvError::MissingModName)
+                .map(|s| s.to_string()),
         }
     }
 
-    pub(crate) fn build_env<LexerTypesT>(
-        &mut self,
+    pub(crate) fn build_env(
+        mut self,
         args: ParserBuildEnvArgs<'a>,
-    ) -> Result<ParserBuildEnv<'a, LexerTypesT>, Box<dyn Error>>
+    ) -> Result<ParserBuildEnv<'a, LexerTypesT>, ParserSrcEnvError>
     where
         LexerTypesT: LexerTypes,
         usize: num_traits::AsPrimitive<LexerTypesT::StorageT>,
@@ -294,7 +394,8 @@ impl<'a> ParserSrcEnv<'a> {
             self.resolve_ast_with_validity_info(args.ast_with_validity_info)?;
         let recoverer = self.resolve_recoverer()?;
         let serialisation_format = self.resolve_serialisation_format()?;
-        let mod_name = self.resolve_mod_name(&args);
+        let mod_name = self.resolve_mod_name(&args)?;
+        let grammar_path = self.grammar_path_cache_entry;
 
         Ok(ParserBuildEnv {
             ast_with_validity_info,
@@ -302,6 +403,8 @@ impl<'a> ParserSrcEnv<'a> {
             recoverer,
             serialisation_format,
             mod_name,
+            grammar_path,
+            header: self.header,
             phantom_storaget: PhantomData,
         })
     }
@@ -314,6 +417,10 @@ where
 {
     pub(crate) fn ast_with_validity_info(&self) -> &ASTWithValidityInfo {
         &self.ast_with_validity_info
+    }
+
+    pub(crate) fn header_mut(&mut self) -> &mut Header<Location> {
+        &mut self.header
     }
 
     pub(crate) fn serialisation_format(&self) -> &SerialisationFormat {
@@ -356,59 +463,34 @@ where
         self.ast_with_validity_info.yacc_kind()
     }
 
+    pub(crate) fn check_unused_header_keys(&self) -> Result<(), ParserBuildEnvError<LexerTypesT>> {
+        let unused_keys = self.header.unused();
+        if !unused_keys.is_empty() {
+            return Err(ParserBuildEnvError::GrmtoolsSectionUnusedKeys(unused_keys));
+        }
+        let missing_keys = self
+            .header
+            .missing()
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>();
+        if !missing_keys.is_empty() {
+            Err(ParserBuildEnvError::GrmtoolsSectionMissingRequiredKeys(
+                missing_keys,
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
     pub(crate) fn code_generator(
         &self,
-        src_env: &ParserSrcEnv,
         timestamp: &str,
-    ) -> Result<ParserCodegen<LexerTypesT>, Box<dyn Error>> {
-        let grm = match YaccGrammar::<LexerTypesT::StorageT>::new_from_ast_with_validity_info(
+    ) -> Result<ParserCodegen<LexerTypesT>, ParserBuildEnvError<LexerTypesT>> {
+        let grm = YaccGrammar::<LexerTypesT::StorageT>::new_from_ast_with_validity_info(
             &self.ast_with_validity_info,
-        ) {
-            Ok(grm) => grm,
-            Err(errs) => {
-                let mut out = String::new();
-                out.push_str(&format!(
-                    "\n{ERROR}{}\n",
-                    src_env.yacc_diag().file_location_msg("", None)
-                ));
-                for e in errs {
-                    out.push_str(&indent(
-                        "     ",
-                        &src_env.yacc_diag().format_error(e).to_string(),
-                    ));
-                    out.push('\n');
-                }
-                return Err(ErrorString(out).into());
-            }
-        };
-
+        )?;
         let (sgraph, stable) = from_yacc(&grm, Minimiser::Pager)?;
-        if self.cache_args.error_on_conflicts
-            && let Some(c) = stable.conflicts()
-        {
-            match (grm.expect(), grm.expectrr()) {
-                (Some(i), Some(j)) if i == c.sr_len() && j == c.rr_len() => (),
-                (Some(i), None) if i == c.sr_len() && 0 == c.rr_len() => (),
-                (None, Some(j)) if 0 == c.sr_len() && j == c.rr_len() => (),
-                (None, None) if 0 == c.rr_len() && 0 == c.sr_len() => (),
-                _ => {
-                    let conflicts_diagnostic = src_env.yacc_diag().format_conflicts::<LexerTypesT>(
-                        &grm,
-                        self.ast_with_validity_info.ast(),
-                        c,
-                        &sgraph,
-                        &stable,
-                    );
-                    return Err(Box::new(CTConflictsError {
-                        conflicts_diagnostic,
-                        phantom: PhantomData,
-                        #[cfg(test)]
-                        stable,
-                    }));
-                }
-            }
-        }
-
         Ok(ParserCodegen {
             grm,
             stable,
@@ -455,15 +537,14 @@ where
 
     pub(crate) fn generate(
         &self,
-        src_env: &ParserSrcEnv,
         build_env: &ParserBuildEnv<LexerTypesT>,
-    ) -> Result<String, Box<dyn Error>> {
+    ) -> Result<String, CodegenError> {
         let mod_name = build_env.derived_mod_name();
         let visibility = build_env.visibility();
         let user_actions = if let YaccKind::Original(YaccOriginalActionKind::UserAction)
         | YaccKind::Grmtools = build_env.yacc_kind()
         {
-            Some(self.gen_user_actions(src_env)?)
+            Some(self.gen_user_actions()?)
         } else {
             None
         };
@@ -492,15 +573,15 @@ where
             None
         };
 
-        let mod_name =
-            match syn::parse_str::<proc_macro2::Ident>(mod_name) {
-                Ok(s) => s,
-                Err(e) => return Err(format!(
-                    "CTParserBuilder::mod_name(\"{}\") is not a valid rust identifier due to '{}'",
-                    mod_name, e
-                )
-                .into()),
-            };
+        let mod_name = match syn::parse_str::<proc_macro2::Ident>(mod_name) {
+            Ok(s) => s,
+            Err(e) => {
+                return Err(CodegenError::InvalidRustIdentifierModName(
+                    e,
+                    mod_name.to_string(),
+                ));
+            }
+        };
         let out_tokens = quote! {
             #visibility mod #mod_name {
                 // At the top so that `user_actions` may contain #![inner_attribute]
@@ -532,14 +613,10 @@ where
 
     /// Generate the cache, which determines if anything's changed enough that we need to
     /// regenerate outputs and force rustc to recompile.
-    fn gen_cache(
-        &self,
-        src_env: &ParserSrcEnv,
-        build_env: &ParserBuildEnv<LexerTypesT>,
-    ) -> TokenStream {
+    fn gen_cache(&self, build_env: &ParserBuildEnv<LexerTypesT>) -> TokenStream {
         let grm = self.grm();
-        let build_time = env!("VERGEN_BUILD_TIMESTAMP");
-        let grammar_path = src_env.path().to_string_lossy();
+        let build_time = &self.timestamp;
+        let grammar_path = &build_env.grammar_path;
         let mod_name = QuoteOption(build_env.specified_mod_name());
         let visibility = build_env.visibility().to_variant_tokens();
         let rust_edition = build_env.rust_edition().to_variant_tokens();
@@ -578,18 +655,13 @@ where
         quote!(#cache_info_str)
     }
 
-    pub(crate) fn cache_str(
-        &self,
-        src_env: &ParserSrcEnv,
-        build_env: &ParserBuildEnv<LexerTypesT>,
-    ) -> String {
-        self.gen_cache(src_env, build_env).to_string()
+    pub(crate) fn cache_str(&self, build_env: &ParserBuildEnv<LexerTypesT>) -> String {
+        self.gen_cache(build_env).to_string()
     }
 
     /// Generate the user action functions (if any).
-    fn gen_user_actions(&self, src_env: &ParserSrcEnv) -> Result<TokenStream, Box<dyn Error>> {
+    fn gen_user_actions(&self) -> Result<TokenStream, CodegenError> {
         let grm = self.grm();
-        let diag = src_env.yacc_diag();
         let programs = grm
             .programs()
             .as_ref()
@@ -623,20 +695,10 @@ where
             for i in 0..grm.prod(pidx).len() {
                 let argt = match grm.prod(pidx)[i] {
                     Symbol::Rule(ref_ridx) => {
-                        if let Some(action_type) = grm.actiontype(ref_ridx).as_ref() {
-                            str::parse::<TokenStream>(action_type)?
-                        } else {
-                            let mut s = String::from("\n");
-                            let rule_span = grm.rule_name_span(ref_ridx);
-                            s.push_str(&diag.file_location_msg("Error", Some(rule_span)));
-                            s.push('\n');
-                            s.push_str(&diag.underline_span_with_text(
-                                rule_span,
-                                "Rule missing action type".to_string(),
-                                '^',
-                            ));
-                            return Err(ErrorString(s).into());
-                        }
+                        let action_type = grm.actiontype(ref_ridx)
+                           .as_ref()
+                           .expect("actiontype should have been checked during complete_and_validate for this YaccKind");
+                        str::parse::<TokenStream>(action_type)?
                     }
                     Symbol::Token(_) => {
                         let lexemet =
@@ -674,18 +736,7 @@ where
 
             // Iterate over all $-arguments and replace them with their respective
             // element from the argument vector (e.g. $1 is replaced by args[0]).
-            let pre_action = grm.action(pidx).as_ref().ok_or_else(|| {
-                let mut s = String::from("\n");
-                let span = grm.prod_span(pidx);
-                s.push_str(&diag.file_location_msg("Error", Some(span)));
-                s.push('\n');
-                s.push_str(&diag.underline_span_with_text(
-                    span,
-                    "Production is missing action code".to_string(),
-                    '^',
-                ));
-                ErrorString(s)
-            })?;
+            let pre_action = grm.action(pidx).as_ref().expect("action code should have been checked during complete_and_validate for this YaccKind");
             let mut last = 0;
             let mut outs = String::new();
             loop {
@@ -709,18 +760,7 @@ where
                             write!(outs, "{prefix}arg_", prefix = ACTION_PREFIX).ok();
                             last = last + off + "$".len();
                         } else {
-                            let span = grm.action_span(pidx).unwrap();
-                            let inner_span =
-                                Span::new(span.start() + last + off + "$".len(), span.end());
-                            let mut s = String::from("\n");
-                            s.push_str(&diag.file_location_msg("Error", Some(inner_span)));
-                            s.push('\n');
-                            s.push_str(&diag.underline_span_with_text(
-                                inner_span,
-                                "Unknown text following '$'".to_string(),
-                                '^',
-                            ));
-                            return Err(ErrorString(s).into());
+                            unreachable!("action variables checked during complete_and_validate");
                         }
                     }
                     None => {
@@ -796,7 +836,7 @@ where
     fn gen_parse_function(
         &self,
         build_env: &ParserBuildEnv<LexerTypesT>,
-    ) -> Result<TokenStream, Box<dyn Error>> {
+    ) -> Result<TokenStream, CodegenError> {
         let stable = self.stable();
         let grm = self.grm();
         let storaget = str::parse::<TokenStream>(type_name::<LexerTypesT::StorageT>())?;
@@ -974,7 +1014,7 @@ where
     fn gen_wrappers(
         &self,
         build_env: &ParserBuildEnv<LexerTypesT>,
-    ) -> Result<TokenStream, Box<dyn Error>> {
+    ) -> Result<TokenStream, CodegenError> {
         let grm = self.grm();
         let parsed_parse_generics = make_generics(grm.parse_generics().as_deref())?;
         let (generics, type_generics, where_clause) = parsed_parse_generics.split_for_impl();
@@ -1146,22 +1186,6 @@ where
     }
 }
 
-/// A string which uses `Display` for it's `Debug` impl.
-struct ErrorString(String);
-impl fmt::Display for ErrorString {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let ErrorString(s) = self;
-        write!(f, "{}", s)
-    }
-}
-impl fmt::Debug for ErrorString {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let ErrorString(s) = self;
-        write!(f, "{}", s)
-    }
-}
-impl Error for ErrorString {}
-
 /// The quote impl of `ToTokens` for `Option` prints an empty string for `None`
 /// and the inner value for `Some(inner_value)`.
 ///
@@ -1266,12 +1290,12 @@ impl ToTokens for SerialisationFormat {
     }
 }
 
-pub(crate) fn make_generics(parse_generics: Option<&str>) -> Result<Generics, Box<dyn Error>> {
+pub(crate) fn make_generics(parse_generics: Option<&str>) -> Result<Generics, CodegenError> {
     if let Some(parse_generics) = parse_generics {
         let tokens = str::parse::<TokenStream>(parse_generics)?;
         match syn::parse2(quote!(<'lexer, 'input: 'lexer, #tokens>)) {
             Ok(res) => Ok(res),
-            Err(err) => Err(format!("unable to parse %parse-generics: {}", err).into()),
+            Err(err) => Err(CodegenError::InvalidParseGenerics(err)),
         }
     } else {
         Ok(parse_quote!(<'lexer, 'input: 'lexer>))

--- a/lrpar/src/lib/codegen.rs
+++ b/lrpar/src/lib/codegen.rs
@@ -1,0 +1,348 @@
+#![deny(unfulfilled_lint_expectations)]
+#![expect(dead_code)]
+
+use std::{error::Error, fmt, marker::PhantomData, path::Path};
+
+use crate::{
+    LexerTypes, RecoveryKind, RustEdition, SerialisationFormat, Visibility,
+    ctbuilder::{ERROR, indent},
+    diagnostics::{DiagnosticFormatter, SpannedDiagnosticFormatter},
+};
+
+use cfgrammar::{
+    Location, Span,
+    header::{GrmtoolsSectionParser, Header, HeaderValue},
+    yacc::{YaccGrammar, YaccKind, ast::ASTWithValidityInfo},
+};
+use lrtable::{StateGraph, StateTable};
+
+pub(crate) struct ParserSrcEnv<'a> {
+    src: &'a str,
+    // We store the path here so we can generate a module name from it if needed.
+    // But should never use it for filesystem interaction within this module.
+    path: &'a Path,
+    diagnostics: SpannedDiagnosticFormatter<'a>,
+    header: Header<Location>,
+}
+
+pub(crate) struct ParserBuildEnvArgs<'a> {
+    /// If the input came from a preparsed AST, this will be Some
+    ast_with_validity_info: Option<&'a ASTWithValidityInfo>,
+    mod_name: Option<String>,
+    rust_edition: RustEdition,
+    visibility: Visibility,
+    error_on_conflicts: bool,
+    show_warnings: bool,
+    warnings_are_errors: bool,
+}
+
+pub(crate) struct ParserBuildEnv<'a, LexerTypesT>
+where
+    LexerTypesT: LexerTypes,
+    usize: num_traits::AsPrimitive<LexerTypesT::StorageT>,
+{
+    ast_with_validity_info: ASTWithValidityInfo,
+    recoverer: RecoveryKind,
+    serialisation_format: SerialisationFormat,
+    // Preserve the args for generating the cache.
+    cache_args: ParserBuildEnvArgs<'a>,
+    phantom_storaget: PhantomData<LexerTypesT::StorageT>,
+    mod_name: String,
+}
+
+pub(crate) struct ParserCodegen<LexerTypesT>
+where
+    LexerTypesT: LexerTypes,
+    usize: num_traits::AsPrimitive<LexerTypesT::StorageT>,
+{
+    grm: YaccGrammar<LexerTypesT::StorageT>,
+    stable: StateTable<LexerTypesT::StorageT>,
+    sgraph: StateGraph<LexerTypesT::StorageT>,
+    timestamp: String,
+}
+
+impl<'a> ParserBuildEnvArgs<'a> {
+    pub(crate) fn new() -> Self {
+        ParserBuildEnvArgs {
+            ast_with_validity_info: None,
+            mod_name: None,
+            visibility: Visibility::Private,
+            rust_edition: RustEdition::Rust2021,
+            error_on_conflicts: true,
+            show_warnings: true,
+            warnings_are_errors: true,
+        }
+    }
+
+    /// Set this to `Some(ast)` if the the parser should be built from a pre-parsed AST
+    /// instead of from parsing a source string.
+    pub(crate) fn ast_with_validity_info(mut self, ast: Option<&'a ASTWithValidityInfo>) -> Self {
+        self.ast_with_validity_info = ast;
+        self
+    }
+
+    pub(crate) fn mod_name(mut self, mod_name: Option<&str>) -> Self {
+        self.mod_name = mod_name.map(|s| s.to_string());
+        self
+    }
+
+    pub(crate) fn rust_edition(mut self, rust_edition: RustEdition) -> Self {
+        self.rust_edition = rust_edition;
+        self
+    }
+    pub(crate) fn visibility(mut self, visibility: Visibility) -> Self {
+        self.visibility = visibility;
+        self
+    }
+    pub(crate) fn error_on_conflicts(mut self, error_on_conflicts: bool) -> Self {
+        self.error_on_conflicts = error_on_conflicts;
+        self
+    }
+    pub(crate) fn show_warnings(mut self, show_warnings: bool) -> Self {
+        self.show_warnings = show_warnings;
+        self
+    }
+    pub(crate) fn warnings_are_errors(mut self, warnings_are_errors: bool) -> Self {
+        self.warnings_are_errors = warnings_are_errors;
+        self
+    }
+}
+
+impl<'a> ParserSrcEnv<'a> {
+    pub(crate) fn new_with_header(
+        src: &'a str,
+        path: &'a Path,
+        header: Header<Location>,
+    ) -> ParserSrcEnv<'a> {
+        let diagnostics = SpannedDiagnosticFormatter::new(src, path);
+        ParserSrcEnv {
+            src,
+            path,
+            header,
+            diagnostics,
+        }
+    }
+
+    pub(crate) fn yacc_diag(&self) -> &SpannedDiagnosticFormatter<'a> {
+        &self.diagnostics
+    }
+
+    pub(crate) fn header_mut(&mut self) -> &mut Header<Location> {
+        &mut self.header
+    }
+
+    pub(crate) fn header(&self) -> &Header<Location> {
+        &self.header
+    }
+
+    fn merge_headers(&mut self) -> Result<(), Box<dyn Error>> {
+        let (parsed_header, _) = self.parse_header()?;
+        Ok(self.header.merge_from(parsed_header)?)
+    }
+
+    fn parse_header(&self) -> Result<(Header<Span>, usize), Box<dyn Error>> {
+        GrmtoolsSectionParser::new(self.src, false)
+            .parse()
+            .map_err(|es| {
+                let mut out = String::new();
+                out.push_str(&format!(
+                    "\n{ERROR}{}\n",
+                    self.yacc_diag()
+                        .file_location_msg(" parsing the `%grmtools` section", None)
+                ));
+                for e in es {
+                    out.push_str(&indent(
+                        "     ",
+                        &self.yacc_diag().format_error(e).to_string(),
+                    ));
+                    out.push('\n');
+                }
+                ErrorString(out).into()
+            })
+    }
+
+    pub(crate) fn check_unused_header_keys(&self) -> Result<(), Box<dyn Error>> {
+        let unused_keys = self.header.unused();
+        if !unused_keys.is_empty() {
+            return Err(format!("Unused keys in header: {}", unused_keys.join(", ")).into());
+        }
+        let missing_keys = self
+            .header
+            .missing()
+            .iter()
+            .map(|s| s.as_str())
+            .collect::<Vec<_>>();
+        if !missing_keys.is_empty() {
+            Err(format!(
+                "Required values were missing from the header: {}",
+                missing_keys.join(", ")
+            )
+            .into())
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Looks up the `yacckind` field from the header, marks the field
+    /// as used then constructs AST of that kind.
+    fn resolve_ast_with_validity_info(
+        &mut self,
+        from_ast: Option<&ASTWithValidityInfo>,
+    ) -> Result<ASTWithValidityInfo, Box<dyn Error>> {
+        self.header.mark_used(&"yacckind".to_string());
+        if let Some(ast) = from_ast {
+            Ok(ast.clone())
+        } else if let Some(yk) = self
+            .header
+            .get("yacckind")
+            .map(|HeaderValue(_, val)| val)
+            .map(YaccKind::try_from)
+            .transpose()?
+        {
+            Ok(ASTWithValidityInfo::new(yk, self.src))
+        } else {
+            Err("Missing 'yacckind'".to_string())?
+        }
+    }
+
+    /// Looks up the `recoverer` field in the header, marks the field
+    /// as used, and defaulting to `CPCTPlus` if unfound.
+    fn resolve_recoverer(&mut self) -> Result<RecoveryKind, Box<dyn Error>> {
+        self.header.mark_used(&"recoverer".to_string());
+        let rk_val = self
+            .header
+            .get("recoverer")
+            .map(|HeaderValue(_, rk_val)| rk_val);
+        if let Some(rk_val) = rk_val {
+            Ok(RecoveryKind::try_from(rk_val)?)
+        } else {
+            // Fallback to the default recoverykind.
+            Ok(RecoveryKind::CPCTPlus)
+        }
+    }
+
+    /// Looks up the `serialisation_format` field in the header, marks the field
+    /// as used, and defaults to `VariableSizedInteger` if unfound.
+    fn resolve_serialisation_format(&mut self) -> Result<SerialisationFormat, Box<dyn Error>> {
+        self.header.mark_used(&"serialisation_format".to_string());
+        if let Some(ec_val) = self
+            .header
+            .get("serialisation_format")
+            .map(|HeaderValue(_, ec_val)| ec_val)
+        {
+            Ok(SerialisationFormat::try_from(ec_val)?)
+        } else {
+            Ok(SerialisationFormat::VariableSizedInteger)
+        }
+    }
+
+    /// Looks up the `mod_name` from the `args`, and defaults to
+    /// the `{filename}_y` with any file extenstion stripped off.
+    fn resolve_mod_name(&self, args: &ParserBuildEnvArgs) -> String {
+        match &args.mod_name {
+            Some(s) => s.to_owned(),
+            None => {
+                // The user hasn't specified a module name, so we create one automatically: what we
+                // do is strip off all the filename extensions (note that it's likely that inp ends
+                // with `y.rs`, so we potentially have to strip off more than one extension) and
+                // then add `_y` to the end.
+                let mut stem = self.path.to_str().unwrap();
+                loop {
+                    let new_stem = Path::new(stem).file_stem().unwrap().to_str().unwrap();
+                    if stem == new_stem {
+                        break;
+                    }
+                    stem = new_stem;
+                }
+                format!("{}_y", stem)
+            }
+        }
+    }
+
+    pub(crate) fn build_env<LexerTypesT>(
+        &mut self,
+        args: ParserBuildEnvArgs<'a>,
+    ) -> Result<ParserBuildEnv<'a, LexerTypesT>, Box<dyn Error>>
+    where
+        LexerTypesT: LexerTypes,
+        usize: num_traits::AsPrimitive<LexerTypesT::StorageT>,
+    {
+        self.merge_headers()?;
+        let ast_with_validity_info =
+            self.resolve_ast_with_validity_info(args.ast_with_validity_info)?;
+        let recoverer = self.resolve_recoverer()?;
+        let serialisation_format = self.resolve_serialisation_format()?;
+        let mod_name = self.resolve_mod_name(&args);
+
+        Ok(ParserBuildEnv {
+            ast_with_validity_info,
+            cache_args: args,
+            recoverer,
+            serialisation_format,
+            mod_name,
+            phantom_storaget: PhantomData,
+        })
+    }
+}
+
+impl<'a, LexerTypesT> ParserBuildEnv<'a, LexerTypesT>
+where
+    LexerTypesT: LexerTypes,
+    usize: num_traits::AsPrimitive<LexerTypesT::StorageT>,
+{
+    pub(crate) fn ast_with_validity_info(&self) -> &ASTWithValidityInfo {
+        &self.ast_with_validity_info
+    }
+
+    pub(crate) fn serialisation_format(&self) -> &SerialisationFormat {
+        &self.serialisation_format
+    }
+
+    pub(crate) fn derived_mod_name(&self) -> &str {
+        &self.mod_name
+    }
+
+    pub(crate) fn recoverer(&self) -> RecoveryKind {
+        self.recoverer
+    }
+
+    pub(crate) fn rust_edition(&self) -> RustEdition {
+        self.cache_args.rust_edition
+    }
+
+    pub(crate) fn visibility(&self) -> &Visibility {
+        &self.cache_args.visibility
+    }
+
+    pub(crate) fn show_warnings(&self) -> bool {
+        self.cache_args.show_warnings
+    }
+
+    pub(crate) fn warnings_are_errors(&self) -> bool {
+        self.cache_args.warnings_are_errors
+    }
+
+    pub(crate) fn error_on_conflicts(&self) -> bool {
+        self.cache_args.error_on_conflicts
+    }
+
+    pub(crate) fn yacc_kind(&self) -> YaccKind {
+        self.ast_with_validity_info.yacc_kind()
+    }
+}
+
+/// A string which uses `Display` for it's `Debug` impl.
+struct ErrorString(String);
+impl fmt::Display for ErrorString {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let ErrorString(s) = self;
+        write!(f, "{}", s)
+    }
+}
+impl fmt::Debug for ErrorString {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let ErrorString(s) = self;
+        write!(f, "{}", s)
+    }
+}
+impl Error for ErrorString {}

--- a/lrpar/src/lib/codegen.rs
+++ b/lrpar/src/lib/codegen.rs
@@ -16,6 +16,8 @@ use cfgrammar::{
 };
 
 use lrtable::{Minimiser, StateGraph, StateTable, from_yacc};
+use proc_macro2::TokenStream;
+use quote::{ToTokens, TokenStreamExt, quote};
 use wincode::SchemaWrite;
 
 pub(crate) struct ParserSrcEnv<'a> {
@@ -436,6 +438,62 @@ where
     ) {
         (self.grm, self.sgraph, self.stable)
     }
+
+    /// Generate the cache, which determines if anything's changed enough that we need to
+    /// regenerate outputs and force rustc to recompile.
+    fn gen_cache(
+        &self,
+        src_env: &ParserSrcEnv,
+        build_env: &ParserBuildEnv<LexerTypesT>,
+    ) -> TokenStream {
+        let grm = self.grm();
+        let build_time = env!("VERGEN_BUILD_TIMESTAMP");
+        let grammar_path = src_env.path().to_string_lossy();
+        let mod_name = QuoteOption(build_env.specified_mod_name());
+        let visibility = build_env.visibility().to_variant_tokens();
+        let rust_edition = build_env.rust_edition().to_variant_tokens();
+        let yacckind = build_env.yacc_kind();
+        let rule_map = grm
+            .iter_tidxs()
+            .map(|tidx| {
+                QuoteTuple((
+                    usize::from(tidx),
+                    grm.token_name(tidx).unwrap_or("<unknown>"),
+                ))
+            })
+            .collect::<Vec<_>>();
+        let derived_mod_name = build_env.derived_mod_name();
+        let serialisation_format = build_env.serialisation_format();
+        let recoverer = build_env.recoverer();
+        let error_on_conflicts = build_env.error_on_conflicts();
+        let show_warnings = build_env.show_warnings();
+        let warnings_are_errors = build_env.warnings_are_errors();
+        let cache_info = quote! {
+            BUILD_TIME = #build_time
+            DERIVED_MOD_NAME = #derived_mod_name
+            ENCODING_CONFIG = #serialisation_format
+            GRAMMAR_PATH = #grammar_path
+            MOD_NAME = #mod_name
+            RECOVERER = #recoverer
+            YACC_KIND = #yacckind
+            ERROR_ON_CONFLICTS = #error_on_conflicts
+            SHOW_WARNINGS = #show_warnings
+            WARNINGS_ARE_ERRORS = #warnings_are_errors
+            RUST_EDITION = #rust_edition
+            RULE_IDS_MAP = [#(#rule_map,)*]
+            VISIBILITY = #visibility
+        };
+        let cache_info_str = cache_info.to_string();
+        quote!(#cache_info_str)
+    }
+
+    pub(crate) fn cache_str(
+        &self,
+        src_env: &ParserSrcEnv,
+        build_env: &ParserBuildEnv<LexerTypesT>,
+    ) -> String {
+        self.gen_cache(src_env, build_env).to_string()
+    }
 }
 
 /// A string which uses `Display` for it's `Debug` impl.
@@ -453,3 +511,83 @@ impl fmt::Debug for ErrorString {
     }
 }
 impl Error for ErrorString {}
+
+/// The quote impl of `ToTokens` for `Option` prints an empty string for `None`
+/// and the inner value for `Some(inner_value)`.
+///
+/// This wrapper instead emits both `Some` and `None` variants.
+/// See: [quote #20](https://github.com/dtolnay/quote/issues/20)
+// Temporarily pub(crate)
+pub(crate) struct QuoteOption<T>(pub(crate) Option<T>);
+
+impl<T: ToTokens> ToTokens for QuoteOption<T> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.append_all(match self.0 {
+            Some(ref t) => quote! { ::std::option::Option::Some(#t) },
+            None => quote! { ::std::option::Option::None },
+        });
+    }
+}
+
+/// This wrapper adds a missing impl of `ToTokens` for tuples.
+/// For a tuple `(a, b)` emits `(a.to_tokens(), b.to_tokens())`
+struct QuoteTuple<T>(T);
+
+impl<A: ToTokens, B: ToTokens> ToTokens for QuoteTuple<(A, B)> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let (a, b) = &self.0;
+        tokens.append_all(quote!((#a, #b)));
+    }
+}
+
+/// The wrapped `&str` value will be emitted with a call to `to_string()`
+struct QuoteToString<'a>(&'a str);
+
+impl ToTokens for QuoteToString<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let x = &self.0;
+        tokens.append_all(quote! { #x.to_string() });
+    }
+}
+
+impl RustEdition {
+    fn to_variant_tokens(self) -> TokenStream {
+        match self {
+            RustEdition::Rust2015 => quote!(::lrpar::RustEdition::Rust2015),
+            RustEdition::Rust2018 => quote!(::lrpar::RustEdition::Rust2018),
+            RustEdition::Rust2021 => quote!(::lrpar::RustEdition::Rust2021),
+        }
+    }
+}
+
+impl ToTokens for Visibility {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.extend(match self {
+            Visibility::Private => quote!(),
+            Visibility::Public => quote! {pub},
+            Visibility::PublicSuper => quote! {pub(super)},
+            Visibility::PublicSelf => quote! {pub(self)},
+            Visibility::PublicCrate => quote! {pub(crate)},
+            Visibility::PublicIn(data) => {
+                let other = str::parse::<TokenStream>(data).unwrap();
+                quote! {pub(in #other)}
+            }
+        })
+    }
+}
+
+impl Visibility {
+    fn to_variant_tokens(&self) -> TokenStream {
+        match self {
+            Visibility::Private => quote!(::lrpar::Visibility::Private),
+            Visibility::Public => quote!(::lrpar::Visibility::Public),
+            Visibility::PublicSuper => quote!(::lrpar::Visibility::PublicSuper),
+            Visibility::PublicSelf => quote!(::lrpar::Visibility::PublicSelf),
+            Visibility::PublicCrate => quote!(::lrpar::Visibility::PublicCrate),
+            Visibility::PublicIn(data) => {
+                let data = QuoteToString(data);
+                quote!(::lrpar::Visibility::PublicIn(#data))
+            }
+        }
+    }
+}

--- a/lrpar/src/lib/codegen.rs
+++ b/lrpar/src/lib/codegen.rs
@@ -587,10 +587,7 @@ where
     }
 
     /// Generate the user action functions (if any).
-    pub(crate) fn gen_user_actions(
-        &self,
-        src_env: &ParserSrcEnv,
-    ) -> Result<TokenStream, Box<dyn Error>> {
+    fn gen_user_actions(&self, src_env: &ParserSrcEnv) -> Result<TokenStream, Box<dyn Error>> {
         let grm = self.grm();
         let diag = src_env.yacc_diag();
         let programs = grm
@@ -756,7 +753,7 @@ where
         })
     }
 
-    pub(crate) fn gen_rule_consts(&self) -> Result<TokenStream, proc_macro2::LexError> {
+    fn gen_rule_consts(&self) -> Result<TokenStream, proc_macro2::LexError> {
         let grm = self.grm();
         let mut toks = TokenStream::new();
         for ridx in grm.iter_rules() {
@@ -773,7 +770,7 @@ where
         Ok(toks)
     }
 
-    pub(crate) fn gen_token_epp(&self) -> Result<TokenStream, proc_macro2::LexError> {
+    fn gen_token_epp(&self) -> Result<TokenStream, proc_macro2::LexError> {
         let grm = self.grm();
         let mut tidxs = Vec::new();
         for tidx in grm.iter_tidxs() {
@@ -796,7 +793,7 @@ where
     }
 
     /// Generate the main parse() function for the output file.
-    pub(crate) fn gen_parse_function(
+    fn gen_parse_function(
         &self,
         build_env: &ParserBuildEnv<LexerTypesT>,
     ) -> Result<TokenStream, Box<dyn Error>> {
@@ -974,7 +971,7 @@ where
     }
 
     /// Generate the wrappers that call user actions
-    pub(crate) fn gen_wrappers(
+    fn gen_wrappers(
         &self,
         build_env: &ParserBuildEnv<LexerTypesT>,
     ) -> Result<TokenStream, Box<dyn Error>> {

--- a/lrpar/src/lib/codegen.rs
+++ b/lrpar/src/lib/codegen.rs
@@ -25,7 +25,7 @@ use cfgrammar::{
 };
 
 use lrtable::{Minimiser, StateGraph, StateTable, from_yacc};
-use proc_macro2::TokenStream;
+use proc_macro2::{Literal, TokenStream};
 use quote::{ToTokens, TokenStreamExt, format_ident, quote};
 use wincode::SchemaWrite;
 
@@ -673,6 +673,23 @@ where
             #action_fns
         })
     }
+
+    pub(crate) fn gen_rule_consts(&self) -> Result<TokenStream, proc_macro2::LexError> {
+        let grm = self.grm();
+        let mut toks = TokenStream::new();
+        for ridx in grm.iter_rules() {
+            if !grm.rule_to_prods(ridx).contains(&grm.start_prod()) {
+                let r_const = format_ident!("R_{}", grm.rule_name_str(ridx).to_ascii_uppercase());
+                let storage_ty = str::parse::<TokenStream>(type_name::<LexerTypesT::StorageT>())?;
+                let ridx = UnsuffixedUsize(usize::from(ridx));
+                toks.extend(quote! {
+                    #[allow(dead_code)]
+                    pub const #r_const: #storage_ty = #ridx;
+                });
+            }
+        }
+        Ok(toks)
+    }
 }
 
 /// A string which uses `Display` for it's `Debug` impl.
@@ -726,6 +743,18 @@ impl ToTokens for QuoteToString<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let x = &self.0;
         tokens.append_all(quote! { #x.to_string() });
+    }
+}
+
+/// The quote impl of `ToTokens` for `usize` prints literal values
+/// including a type suffix for example `0usize`.
+///
+/// This wrapper omits the type suffix emitting `0` instead.
+struct UnsuffixedUsize(usize);
+
+impl ToTokens for UnsuffixedUsize {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.append(Literal::usize_unsuffixed(self.0))
     }
 }
 

--- a/lrpar/src/lib/codegen.rs
+++ b/lrpar/src/lib/codegen.rs
@@ -1,6 +1,3 @@
-#![deny(unfulfilled_lint_expectations)]
-#![expect(dead_code)]
-
 use std::{
     any::type_name,
     fmt::{self, Write},
@@ -296,14 +293,6 @@ where
             header,
             phantom: PhantomData,
         }
-    }
-
-    pub(crate) fn header_mut(&mut self) -> &mut Header<Location> {
-        &mut self.header
-    }
-
-    pub(crate) fn header(&self) -> &Header<Location> {
-        &self.header
     }
 
     fn merge_headers(&mut self) -> Result<(), ParserSrcEnvError> {

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -16,7 +16,7 @@ use std::{
 
 use crate::{
     LexerTypes, RTParserBuilder, RecoveryKind,
-    codegen::{ParserBuildEnv, ParserBuildEnvArgs, ParserSrcEnv},
+    codegen::{ParserBuildEnv, ParserBuildEnvArgs, ParserCodegen, ParserSrcEnv},
     diagnostics::{DiagnosticFormatter, SpannedDiagnosticFormatter},
 };
 
@@ -785,7 +785,7 @@ where
             .map(|(&n, &i)| (n.to_owned(), i.as_storaget()))
             .collect::<HashMap<_, _>>();
 
-        let cache = self.rebuild_cache(build_env.derived_mod_name(), grm);
+        let cache = self.rebuild_cache(&code_gen, &src_env, &build_env);
 
         // We don't need to go through the full rigmarole of generating an output file if all of
         // the following are true: the output file exists; it is newer than the input file; and the
@@ -1062,42 +1062,19 @@ where
 
     /// Generate the cache, which determines if anything's changed enough that we need to
     /// regenerate outputs and force rustc to recompile.
-    fn rebuild_cache(&self, derived_mod_name: &'_ str, grm: &YaccGrammar<StorageT>) -> TokenStream {
-        // We don't need to be particularly clever here: we just need to record the various things
-        // that could change between builds.
-        //
-        // Record the time that this version of lrpar was built. If the source code changes and
-        // rustc forces a recompile, this will change this value, causing anything which depends on
-        // this build of lrpar to be recompiled too.
-        let Self {
-            // All variables except for `output_path`, `inspect_callback` and `phantom` should
-            // be written into the cache.
-            grammar_path,
-            // I struggle to imagine the correct thing for `grammar_src`.
-            grammar_src: _,
-            // I struggle to imagine the correct thing for `from_ast`.
-            from_ast: _,
-            mod_name,
-            recoverer,
-            yacckind,
-            output_path: _,
-            error_on_conflicts,
-            warnings_are_errors,
-            show_warnings,
-            visibility,
-            rust_edition,
-            serialisation_format,
-            inspect_rt: _,
-            #[cfg(test)]
-                inspect_callback: _,
-            phantom: _,
-        } = self;
+    fn rebuild_cache(
+        &self,
+        code_gen: &ParserCodegen<LexerTypesT>,
+        src_env: &ParserSrcEnv,
+        build_env: &ParserBuildEnv<LexerTypesT>,
+    ) -> TokenStream {
+        let grm = code_gen.grm();
         let build_time = env!("VERGEN_BUILD_TIMESTAMP");
-        let grammar_path = grammar_path.as_ref().unwrap().to_string_lossy();
-        let mod_name = QuoteOption(mod_name.as_deref());
-        let visibility = visibility.to_variant_tokens();
-        let rust_edition = rust_edition.to_variant_tokens();
-        let yacckind = yacckind.expect("is_some() by this point");
+        let grammar_path = src_env.path().to_string_lossy();
+        let mod_name = QuoteOption(build_env.specified_mod_name());
+        let visibility = build_env.visibility().to_variant_tokens();
+        let rust_edition = build_env.rust_edition().to_variant_tokens();
+        let yacckind = build_env.yacc_kind();
         let rule_map = grm
             .iter_tidxs()
             .map(|tidx| {
@@ -1107,6 +1084,12 @@ where
                 ))
             })
             .collect::<Vec<_>>();
+        let derived_mod_name = build_env.derived_mod_name();
+        let serialisation_format = build_env.serialisation_format();
+        let recoverer = build_env.recoverer();
+        let error_on_conflicts = build_env.error_on_conflicts();
+        let show_warnings = build_env.show_warnings();
+        let warnings_are_errors = build_env.warnings_are_errors();
         let cache_info = quote! {
             BUILD_TIME = #build_time
             DERIVED_MOD_NAME = #derived_mod_name
@@ -1121,7 +1104,6 @@ where
             RUST_EDITION = #rust_edition
             RULE_IDS_MAP = [#(#rule_map,)*]
             VISIBILITY = #visibility
-
         };
         let cache_info_str = cache_info.to_string();
         quote!(#cache_info_str)

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -32,8 +32,8 @@ use cfgrammar::{
 use filetime::FileTime;
 use lrtable::{StateGraph, StateTable, statetable::Conflicts};
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
-use proc_macro2::{Literal, TokenStream};
-use quote::{ToTokens, TokenStreamExt, format_ident, quote};
+use proc_macro2::TokenStream;
+use quote::{ToTokens, format_ident, quote};
 use syn::{Generics, parse_quote};
 use wincode::{SchemaRead, SchemaReadOwned, SchemaWrite};
 
@@ -57,18 +57,6 @@ pub(crate) struct CTConflictsError<StorageT: Eq + Hash> {
     #[cfg_attr(test, allow(dead_code))]
     pub(crate) stable: StateTable<StorageT>,
     pub(crate) phantom: PhantomData<StorageT>,
-}
-
-/// The quote impl of `ToTokens` for `usize` prints literal values
-/// including a type suffix for example `0usize`.
-///
-/// This wrapper omits the type suffix emitting `0` instead.
-struct UnsuffixedUsize(usize);
-
-impl ToTokens for UnsuffixedUsize {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        tokens.append(Literal::usize_unsuffixed(self.0))
-    }
 }
 
 impl<StorageT> fmt::Display for CTConflictsError<StorageT>
@@ -909,7 +897,7 @@ where
             None
         };
 
-        let rule_consts = self.gen_rule_consts(code_gen)?;
+        let rule_consts = code_gen.gen_rule_consts()?;
         let token_epp = self.gen_token_epp(code_gen)?;
         let parse_function = self.gen_parse_function(code_gen, build_env)?;
         let action_wrappers = match build_env.yacc_kind() {
@@ -1153,26 +1141,6 @@ where
                 #run_parser
             }
         })
-    }
-
-    fn gen_rule_consts(
-        &self,
-        code_gen: &ParserCodegen<LexerTypesT>,
-    ) -> Result<TokenStream, proc_macro2::LexError> {
-        let grm = code_gen.grm();
-        let mut toks = TokenStream::new();
-        for ridx in grm.iter_rules() {
-            if !grm.rule_to_prods(ridx).contains(&grm.start_prod()) {
-                let r_const = format_ident!("R_{}", grm.rule_name_str(ridx).to_ascii_uppercase());
-                let storage_ty = str::parse::<TokenStream>(type_name::<LexerTypesT::StorageT>())?;
-                let ridx = UnsuffixedUsize(usize::from(ridx));
-                toks.extend(quote! {
-                    #[allow(dead_code)]
-                    pub const #r_const: #storage_ty = #ridx;
-                });
-            }
-        }
-        Ok(toks)
     }
 
     fn gen_token_epp(

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -1,7 +1,6 @@
 //! Build grammars at compile-time so that they can be statically included into a binary.
 
 use std::{
-    any::type_name,
     collections::{HashMap, HashSet},
     env::{current_dir, var},
     error::Error,
@@ -24,7 +23,7 @@ use crate::{
 use crate::unstable_api::UnstableApi;
 
 use cfgrammar::{
-    Location, Symbol,
+    Location,
     header::{Header, HeaderError, HeaderErrorKind, HeaderValue, Namespaced, Setting, Value},
     markmap::{Entry, MergeBehavior},
     yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind, ast::ASTWithValidityInfo},
@@ -33,18 +32,11 @@ use filetime::FileTime;
 use lrtable::{StateGraph, StateTable, statetable::Conflicts};
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 use proc_macro2::TokenStream;
-use quote::{ToTokens, format_ident, quote};
+use quote::{ToTokens, quote};
 use syn::{Generics, parse_quote};
 use wincode::{SchemaRead, SchemaReadOwned, SchemaWrite};
 
-pub(crate) const ACTION_PREFIX: &str = "__gt_";
-pub(crate) const GLOBAL_PREFIX: &str = "__GT_";
-pub(crate) const ACTIONS_KIND: &str = "__GtActionsKind";
-pub(crate) const ACTIONS_KIND_PREFIX: &str = "Ak";
-pub(crate) const ACTIONS_KIND_HIDDEN: &str = "__GtActionsKindHidden";
-
 const RUST_FILE_EXT: &str = "rs";
-
 const WARNING: &str = "[Warning]";
 pub(crate) const ERROR: &str = "[Error]";
 
@@ -902,7 +894,7 @@ where
         let parse_function = code_gen.gen_parse_function(build_env)?;
         let action_wrappers = match  build_env.yacc_kind()  {
             YaccKind::Original(YaccOriginalActionKind::UserAction) | YaccKind::Grmtools => {
-                Some(self.gen_wrappers(code_gen, build_env)?)
+                Some(code_gen.gen_wrappers(build_env)?)
             }
             YaccKind::Original(YaccOriginalActionKind::NoAction)
             | YaccKind::Original(YaccOriginalActionKind::GenericParseTree) => None,
@@ -962,170 +954,6 @@ where
         f.write_all(outs.as_bytes())?;
         f.write_all(cache.as_bytes())?;
         Ok(())
-    }
-
-    /// Generate the wrappers that call user actions
-    fn gen_wrappers(
-        &self,
-        code_gen: &ParserCodegen<LexerTypesT>,
-        build_env: &ParserBuildEnv<LexerTypesT>,
-    ) -> Result<TokenStream, Box<dyn Error>> {
-        let grm = code_gen.grm();
-        let parsed_parse_generics = make_generics(grm.parse_generics().as_deref())?;
-        let (generics, type_generics, where_clause) = parsed_parse_generics.split_for_impl();
-
-        let (parse_paramname, parse_paramdef);
-        match grm.parse_param() {
-            Some((name, tyname)) => {
-                parse_paramname = str::parse::<TokenStream>(name)?;
-                let ty = str::parse::<TokenStream>(tyname)?;
-                parse_paramdef = quote!(#parse_paramname: #ty);
-            }
-            None => {
-                parse_paramname = quote!(());
-                parse_paramdef = quote! {_: ()};
-            }
-        };
-
-        let mut wrappers = TokenStream::new();
-        for pidx in grm.iter_pidxs() {
-            let ridx = grm.prod_to_rule(pidx);
-
-            // Iterate over all $-arguments and replace them with their respective
-            // element from the argument vector (e.g. $1 is replaced by args[0]). At
-            // the same time extract &str from tokens and actiontype from nonterminals.
-            let wrapper_fn = format_ident!("{}wrapper_{}", ACTION_PREFIX, usize::from(pidx));
-            let ridx_var = format_ident!("{}ridx", ACTION_PREFIX);
-            let lexer_var = format_ident!("{}lexer", ACTION_PREFIX);
-            let span_var = format_ident!("{}span", ACTION_PREFIX);
-            let args_var = format_ident!("{}args", ACTION_PREFIX);
-            let storaget = str::parse::<TokenStream>(type_name::<LexerTypesT::StorageT>())?;
-            let lexertypest = str::parse::<TokenStream>(type_name::<LexerTypesT>())?;
-            let actionskind = str::parse::<TokenStream>(ACTIONS_KIND)?;
-            let edition_lifetime = if build_env.rust_edition() != RustEdition::Rust2015 {
-                Some(quote!('_,))
-            } else {
-                None
-            };
-            let mut wrapper_fn_body = TokenStream::new();
-            if grm.action(pidx).is_some() {
-                // Unpack the arguments passed to us by the drain
-                for i in 0..grm.prod(pidx).len() {
-                    let arg = format_ident!("{}arg_{}", ACTION_PREFIX, i + 1);
-                    wrapper_fn_body.extend(match grm.prod(pidx)[i] {
-                        Symbol::Rule(ref_ridx) => {
-                            let ref_ridx = usize::from(ref_ridx);
-                            let actionvariant = format_ident!("{}{}", ACTIONS_KIND_PREFIX, ref_ridx);
-                            quote! {
-                                #[allow(clippy::let_unit_value)]
-                                let #arg = match #args_var.next().unwrap() {
-                                    ::lrpar::parser::AStackType::ActionType(#actionskind::#type_generics::#actionvariant(x)) => x,
-                                    _ => unreachable!()
-                                };
-                            }
-                        }
-                        Symbol::Token(_) => {
-                            quote! {
-                                let #arg = match #args_var.next().unwrap() {
-                                    ::lrpar::parser::AStackType::Lexeme(l) => {
-                                        if l.faulty() {
-                                            Err(l)
-                                        } else {
-                                            Ok(l)
-                                        }
-                                    },
-                                    ::lrpar::parser::AStackType::ActionType(_) => unreachable!()
-                                };
-                            }
-                        }
-                    })
-                }
-
-                // Call the user code
-                let args = (0..grm.prod(pidx).len())
-                    .map(|i| format_ident!("{}arg_{}", ACTION_PREFIX, i + 1))
-                    .collect::<Vec<_>>();
-                let action_fn = format_ident!("{}action_{}", ACTION_PREFIX, usize::from(pidx));
-                let actionsvariant = format_ident!("{}{}", ACTIONS_KIND_PREFIX, usize::from(ridx));
-
-                wrapper_fn_body.extend(match grm.actiontype(ridx) {
-                    Some(s) if s == "()" => {
-                        // If the rule `r` that we're calling has the unit type then Clippy will warn that
-                        // `enum::A(wrapper_r())` is pointless. We thus have to split it into two:
-                        // `wrapper_r(); enum::A(())`.
-                        quote! {
-                            #action_fn(#ridx_var, #lexer_var, #span_var, #parse_paramname, #(#args,)*);
-                            #actionskind::#type_generics::#actionsvariant(())
-                        }
-                    }
-                    _ => {
-                        quote! {
-                            #actionskind::#type_generics::#actionsvariant(#action_fn(#ridx_var, #lexer_var, #span_var, #parse_paramname, #(#args,)*))
-                        }
-                    }
-                })
-            } else if pidx == grm.start_prod() {
-                wrapper_fn_body.extend(quote!(unreachable!()));
-            } else {
-                unreachable!(
-                    "Production in rule '{}' must have an action body, which should have been handled by gen_user_actions.",
-                    grm.rule_name_str(grm.prod_to_rule(pidx))
-                );
-            };
-
-            let attrib = if pidx == grm.start_prod() {
-                // The start prod has an unreachable body so it doesn't use it's variables.
-                Some(quote!(#[allow(unused_variables)]))
-            } else {
-                None
-            };
-            wrappers.extend(quote! {
-                #attrib
-                fn #wrapper_fn #generics (
-                    #ridx_var: ::cfgrammar::RIdx<#storaget>,
-                    #lexer_var: &'lexer dyn ::lrpar::NonStreamingLexer<'input, #lexertypest>,
-                    #span_var: ::cfgrammar::Span,
-                    mut #args_var: ::std::vec::Drain<#edition_lifetime ::lrpar::parser::AStackType<<#lexertypest as ::lrpar::LexerTypes>::LexemeT, #actionskind #type_generics>>,
-                    #parse_paramdef
-                ) -> #actionskind #type_generics
-                #where_clause
-                {
-                    #wrapper_fn_body
-                }
-             })
-        }
-        let mut actionskindvariants = Vec::new();
-        let actionskindhidden = format_ident!("_{}", ACTIONS_KIND_HIDDEN);
-        let actionskind = str::parse::<TokenStream>(ACTIONS_KIND).unwrap();
-        let mut phantom_data_type = Vec::new();
-        for ridx in grm.iter_rules() {
-            if let Some(actiont) = grm.actiontype(ridx) {
-                let actionskindvariant =
-                    format_ident!("{}{}", ACTIONS_KIND_PREFIX, usize::from(ridx));
-                let actiont = str::parse::<TokenStream>(actiont).unwrap();
-                actionskindvariants.push(quote! {
-                    #actionskindvariant(#actiont)
-                })
-            }
-        }
-        for lifetime in parsed_parse_generics.lifetimes() {
-            let lifetime = &lifetime.lifetime;
-            phantom_data_type.push(quote! { &#lifetime () });
-        }
-        for type_param in parsed_parse_generics.type_params() {
-            let ident = &type_param.ident;
-            phantom_data_type.push(quote! { #ident });
-        }
-        actionskindvariants.push(quote! {
-            #actionskindhidden(::std::marker::PhantomData<(#(#phantom_data_type,)*)>)
-        });
-        wrappers.extend(quote! {
-            #[allow(dead_code)]
-            enum #actionskind #generics #where_clause {
-                #(#actionskindvariants,)*
-            }
-        });
-        Ok(wrappers)
     }
 }
 

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -16,8 +16,8 @@ use std::{
 
 use crate::{
     LexerTypes, RTParserBuilder, RecoveryKind,
-    codegen::{ParserBuildEnv, ParserBuildEnvArgs, ParserSrcEnv, QuoteOption},
-    diagnostics::{DiagnosticFormatter, SpannedDiagnosticFormatter},
+    codegen::{ParserBuildEnv, ParserBuildEnvArgs, ParserCodegen, ParserSrcEnv, QuoteOption},
+    diagnostics::DiagnosticFormatter,
 };
 
 #[cfg(feature = "_unstable_api")]
@@ -764,12 +764,10 @@ where
         src_env.check_unused_header_keys()?;
 
         self.output_file(
-            grm,
-            stable,
-            build_env.derived_mod_name(),
+            &code_gen,
             outp,
             &format!("/* CACHE INFORMATION {} */\n", cache),
-            src_env.yacc_diag(),
+            &src_env,
             &build_env,
         )?;
         let (grm, sgraph, stable) = code_gen.finish();
@@ -895,48 +893,46 @@ where
 
     fn output_file<P: AsRef<Path>>(
         &self,
-        grm: &YaccGrammar<StorageT>,
-        stable: &StateTable<StorageT>,
-        mod_name: &str,
+        code_gen: &ParserCodegen<LexerTypesT>,
         outp_rs: P,
         cache: &str,
-        _diag: &SpannedDiagnosticFormatter,
+        src_env: &ParserSrcEnv,
         build_env: &ParserBuildEnv<'_, LexerTypesT>,
     ) -> Result<(), Box<dyn Error>> {
-        let visibility = self.visibility.clone();
-        let user_actions = if let Some(
-            YaccKind::Original(YaccOriginalActionKind::UserAction) | YaccKind::Grmtools,
-        ) = self.yacckind
+        let mod_name = build_env.derived_mod_name();
+        let visibility = build_env.visibility();
+        let user_actions = if let YaccKind::Original(YaccOriginalActionKind::UserAction)
+        | YaccKind::Grmtools = build_env.yacc_kind()
         {
-            Some(self.gen_user_actions(grm)?)
+            Some(self.gen_user_actions(code_gen, src_env)?)
         } else {
             None
         };
-        let rule_consts = self.gen_rule_consts(grm)?;
-        let token_epp = self.gen_token_epp(grm)?;
-        let parse_function = self.gen_parse_function(grm, stable, build_env)?;
-        let action_wrappers = match self.yacckind.unwrap() {
+
+        let rule_consts = self.gen_rule_consts(code_gen)?;
+        let token_epp = self.gen_token_epp(code_gen)?;
+        let parse_function = self.gen_parse_function(code_gen, build_env)?;
+        let action_wrappers = match build_env.yacc_kind() {
             YaccKind::Original(YaccOriginalActionKind::UserAction) | YaccKind::Grmtools => {
-                Some(self.gen_wrappers(grm)?)
+                Some(self.gen_wrappers(code_gen, build_env)?)
             }
             YaccKind::Original(YaccOriginalActionKind::NoAction)
             | YaccKind::Original(YaccOriginalActionKind::GenericParseTree) => None,
             _ => unreachable!(),
         };
 
-        let additional_decls =
-            if let Some(YaccKind::Original(YaccOriginalActionKind::GenericParseTree)) =
-                self.yacckind
-            {
-                // `lrpar::Node`` is deprecated within the lrpar crate, but not from within this module,
-                // Once it is removed from `lrpar`, we should move the declaration here entirely.
-                Some(quote! {
-                            #[allow(unused_imports)]
-                            pub use ::lrpar::parser::_deprecated_moved_::Node;
-                })
-            } else {
-                None
-            };
+        let additional_decls = if let YaccKind::Original(YaccOriginalActionKind::GenericParseTree) =
+            build_env.yacc_kind()
+        {
+            // `lrpar::Node`` is deprecated within the lrpar crate, but not from within this module,
+            // Once it is removed from `lrpar`, we should move the declaration here entirely.
+            Some(quote! {
+                        #[allow(unused_imports)]
+                        pub use ::lrpar::parser::_deprecated_moved_::Node;
+            })
+        } else {
+            None
+        };
 
         let mod_name =
             match syn::parse_str::<proc_macro2::Ident>(mod_name) {
@@ -983,11 +979,12 @@ where
     /// Generate the main parse() function for the output file.
     fn gen_parse_function(
         &self,
-        grm: &YaccGrammar<StorageT>,
-        stable: &StateTable<StorageT>,
-        build_env: &ParserBuildEnv<'_, LexerTypesT>,
+        code_gen: &ParserCodegen<LexerTypesT>,
+        build_env: &ParserBuildEnv<LexerTypesT>,
     ) -> Result<TokenStream, Box<dyn Error>> {
-        let storaget = str::parse::<TokenStream>(type_name::<StorageT>())?;
+        let stable = code_gen.stable();
+        let grm = code_gen.grm();
+        let storaget = str::parse::<TokenStream>(type_name::<LexerTypesT::StorageT>())?;
         let lexertypest = str::parse::<TokenStream>(type_name::<LexerTypesT>())?;
         let recoverer = build_env.recoverer();
         let run_parser = match build_env.yacc_kind() {
@@ -1027,12 +1024,12 @@ where
                     let pidx = usize::from(pidx);
                     format_ident!("{}wrapper_{}", ACTION_PREFIX, pidx)
                 });
-                let edition_lifetime = if self.rust_edition != RustEdition::Rust2015 {
+                let edition_lifetime = if build_env.rust_edition() != RustEdition::Rust2015 {
                     quote!('_,)
                 } else {
                     quote!()
                 };
-                let ridx = usize::from(self.user_start_ridx(grm));
+                let ridx = usize::from(self.user_start_ridx(code_gen));
                 let action_ident = format_ident!("{}{}", ACTIONS_KIND_PREFIX, ridx);
 
                 quote! {
@@ -1081,7 +1078,7 @@ where
         let parse_fn_return_ty = match build_env.yacc_kind() {
             YaccKind::Original(YaccOriginalActionKind::UserAction) | YaccKind::Grmtools => {
                 let actiont = grm
-                    .actiontype(self.user_start_ridx(grm))
+                    .actiontype(self.user_start_ridx(code_gen))
                     .as_ref()
                     .map(|at| str::parse::<TokenStream>(at))
                     .transpose()?;
@@ -1160,13 +1157,14 @@ where
 
     fn gen_rule_consts(
         &self,
-        grm: &YaccGrammar<StorageT>,
+        code_gen: &ParserCodegen<LexerTypesT>,
     ) -> Result<TokenStream, proc_macro2::LexError> {
+        let grm = code_gen.grm();
         let mut toks = TokenStream::new();
         for ridx in grm.iter_rules() {
             if !grm.rule_to_prods(ridx).contains(&grm.start_prod()) {
                 let r_const = format_ident!("R_{}", grm.rule_name_str(ridx).to_ascii_uppercase());
-                let storage_ty = str::parse::<TokenStream>(type_name::<StorageT>())?;
+                let storage_ty = str::parse::<TokenStream>(type_name::<LexerTypesT::StorageT>())?;
                 let ridx = UnsuffixedUsize(usize::from(ridx));
                 toks.extend(quote! {
                     #[allow(dead_code)]
@@ -1179,14 +1177,15 @@ where
 
     fn gen_token_epp(
         &self,
-        grm: &YaccGrammar<StorageT>,
+        code_gen: &ParserCodegen<LexerTypesT>,
     ) -> Result<TokenStream, proc_macro2::LexError> {
+        let grm = code_gen.grm();
         let mut tidxs = Vec::new();
         for tidx in grm.iter_tidxs() {
             tidxs.push(QuoteOption(grm.token_epp(tidx)));
         }
         let const_epp_ident = format_ident!("{}EPP", GLOBAL_PREFIX);
-        let storage_ty = str::parse::<TokenStream>(type_name::<StorageT>())?;
+        let storage_ty = str::parse::<TokenStream>(type_name::<LexerTypesT::StorageT>())?;
         Ok(quote! {
             const #const_epp_ident: &[::std::option::Option<&str>] = &[
                 #(#tidxs,)*
@@ -1200,9 +1199,13 @@ where
             }
         })
     }
-
     /// Generate the wrappers that call user actions
-    fn gen_wrappers(&self, grm: &YaccGrammar<StorageT>) -> Result<TokenStream, Box<dyn Error>> {
+    fn gen_wrappers(
+        &self,
+        code_gen: &ParserCodegen<LexerTypesT>,
+        build_env: &ParserBuildEnv<LexerTypesT>,
+    ) -> Result<TokenStream, Box<dyn Error>> {
+        let grm = code_gen.grm();
         let parsed_parse_generics = make_generics(grm.parse_generics().as_deref())?;
         let (generics, type_generics, where_clause) = parsed_parse_generics.split_for_impl();
 
@@ -1231,10 +1234,10 @@ where
             let lexer_var = format_ident!("{}lexer", ACTION_PREFIX);
             let span_var = format_ident!("{}span", ACTION_PREFIX);
             let args_var = format_ident!("{}args", ACTION_PREFIX);
-            let storaget = str::parse::<TokenStream>(type_name::<StorageT>())?;
+            let storaget = str::parse::<TokenStream>(type_name::<LexerTypesT::StorageT>())?;
             let lexertypest = str::parse::<TokenStream>(type_name::<LexerTypesT>())?;
             let actionskind = str::parse::<TokenStream>(ACTIONS_KIND)?;
-            let edition_lifetime = if self.rust_edition != RustEdition::Rust2015 {
+            let edition_lifetime = if build_env.rust_edition() != RustEdition::Rust2015 {
                 Some(quote!('_,))
             } else {
                 None
@@ -1361,7 +1364,13 @@ where
     }
 
     /// Generate the user action functions (if any).
-    fn gen_user_actions(&self, grm: &YaccGrammar<StorageT>) -> Result<TokenStream, Box<dyn Error>> {
+    fn gen_user_actions(
+        &self,
+        code_gen: &ParserCodegen<LexerTypesT>,
+        src_env: &ParserSrcEnv,
+    ) -> Result<TokenStream, Box<dyn Error>> {
+        let grm = code_gen.grm();
+        let _diag = src_env.yacc_diag();
         let programs = grm
             .programs()
             .as_ref()
@@ -1426,7 +1435,7 @@ where
             let lexer_var = format_ident!("{}lexer", ACTION_PREFIX);
             let span_var = format_ident!("{}span", ACTION_PREFIX);
             let ridx_var = format_ident!("{}ridx", ACTION_PREFIX);
-            let storaget = str::parse::<TokenStream>(type_name::<StorageT>())?;
+            let storaget = str::parse::<TokenStream>(type_name::<LexerTypesT::StorageT>())?;
             let lexertypest = str::parse::<TokenStream>(type_name::<LexerTypesT>())?;
             let bind_parse_param = if !parse_param_unit {
                 Some(quote! {let _ = #parse_paramname;})
@@ -1496,7 +1505,11 @@ where
     /// Return the `RIdx` of the %start rule in the grammar (which will not be the same as
     /// grm.start_rule_idx because the latter has an additional rule insert by cfgrammar
     /// which then calls the user's %start rule).
-    fn user_start_ridx(&self, grm: &YaccGrammar<StorageT>) -> RIdx<StorageT> {
+    fn user_start_ridx(
+        &self,
+        code_gen: &ParserCodegen<LexerTypesT>,
+    ) -> RIdx<LexerTypesT::StorageT> {
+        let grm = code_gen.grm();
         debug_assert_eq!(grm.prod(grm.start_prod()).len(), 1);
         match grm.prod(grm.start_prod())[0] {
             Symbol::Rule(ridx) => ridx,

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -31,9 +31,6 @@ use cfgrammar::{
 use filetime::FileTime;
 use lrtable::{StateGraph, StateTable, statetable::Conflicts};
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
-use proc_macro2::TokenStream;
-use quote::{ToTokens, quote};
-use syn::{Generics, parse_quote};
 use wincode::{SchemaRead, SchemaReadOwned, SchemaWrite};
 
 const RUST_FILE_EXT: &str = "rs";
@@ -213,18 +210,6 @@ impl<T: Clone + Debug> TryFrom<&Value<T>> for SerialisationFormat {
 // We export this for generated code to refer to.
 #[doc(hidden)]
 pub use wincode;
-impl ToTokens for SerialisationFormat {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        tokens.extend(match self {
-            SerialisationFormat::FixedSizeInteger => {
-                quote! {::lrpar::ctbuilder::SerialisationFormat::FixedSizeInteger}
-            }
-            SerialisationFormat::VariableSizedInteger => {
-                quote! {::lrpar::ctbuilder::SerialisationFormat::VariableSizedInteger}
-            }
-        })
-    }
-}
 
 /// A `CTParserBuilder` allows one to specify the criteria for building a statically generated
 /// parser.
@@ -1002,18 +987,6 @@ where
 /// 4. Replace all `\n{indent}\n` with `\n\n`
 pub(crate) fn indent(indent: &str, s: &str) -> String {
     format!("{indent}{}\n", s.trim_end_matches('\n')).replace('\n', &format!("\n{}", indent))
-}
-
-pub(crate) fn make_generics(parse_generics: Option<&str>) -> Result<Generics, Box<dyn Error>> {
-    if let Some(parse_generics) = parse_generics {
-        let tokens = str::parse::<TokenStream>(parse_generics)?;
-        match syn::parse2(quote!(<'lexer, 'input: 'lexer, #tokens>)) {
-            Ok(res) => Ok(res),
-            Err(err) => Err(format!("unable to parse %parse-generics: {}", err).into()),
-        }
-    } else {
-        Ok(parse_quote!(<'lexer, 'input: 'lexer>))
-    }
 }
 
 // Tests dealing with the filesystem not supported under wasm32

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -15,8 +15,11 @@ use std::{
 
 use crate::{
     LexerTypes, RTParserBuilder, RecoveryKind,
-    codegen::{ParserBuildEnv, ParserBuildEnvArgs, ParserCodegen, ParserSrcEnv},
-    diagnostics::DiagnosticFormatter,
+    codegen::{
+        ParserBuildEnv, ParserBuildEnvArgs, ParserBuildEnvError, ParserCodegen, ParserSrcEnv,
+        ParserSrcEnvError,
+    },
+    diagnostics::{DiagnosticFormatter, SpannedDiagnosticFormatter},
 };
 
 #[cfg(feature = "_unstable_api")]
@@ -612,14 +615,31 @@ where
             read_to_string(grmp).map_err(|e| format!("When reading '{}': {e}", grmp.display()))?
         };
 
-        let mut src_env = ParserSrcEnv::new_with_header(&inc, grmp, header);
+        let src_env = ParserSrcEnv::new_with_header(&inc, Some(grmp), header);
+        let yacc_diag = SpannedDiagnosticFormatter::new(&inc, grmp);
         let build_args = ParserBuildEnvArgs::new()
             .ast_with_validity_info(self.from_ast.as_ref())
             .mod_name(self.mod_name)
             .show_warnings(self.show_warnings)
             .error_on_conflicts(self.error_on_conflicts)
-            .warnings_are_errors(self.warnings_are_errors);
-        let build_env = src_env.build_env::<LexerTypesT>(build_args)?;
+            .warnings_are_errors(self.warnings_are_errors)
+            .visibility(self.visibility.clone())
+            .rust_edition(self.rust_edition);
+        let mut build_env = src_env.build_env(build_args).map_err(|e| match e {
+            ParserSrcEnvError::GrmtoolsSectionParseError(es) => {
+                let mut out = String::new();
+                out.push_str(&format!(
+                    "\n{ERROR}{}\n",
+                    yacc_diag.file_location_msg(" parsing the `%grmtools` section", None)
+                ));
+                for e in es {
+                    out.push_str(&indent("     ", &yacc_diag.format_error(e).to_string()));
+                    out.push('\n');
+                }
+                Box::<dyn Error>::from(ErrorString(out))
+            }
+            e => e.to_string().into(),
+        })?;
         // Temporarily we update self.yacckind and self.recoverer from the build_env
         // Until codegen reads these variables from the build_env directly.
         self.recoverer = Some(build_env.recoverer());
@@ -630,19 +650,19 @@ where
             let mut out = String::new();
             out.push_str(&format!(
                 "\n{ERROR}{}\n",
-                src_env.yacc_diag().file_location_msg("", None)
+                yacc_diag.file_location_msg("", None)
             ));
             for e in warnings {
                 out.push_str(&format!(
                     "{}\n",
-                    indent("     ", &src_env.yacc_diag().format_warning(e).to_string())
+                    indent("     ", &yacc_diag.format_warning(e).to_string())
                 ));
             }
             return Err(ErrorString(out).into());
         } else if !warnings.is_empty() {
             for w in warnings {
-                let ws_loc = src_env.yacc_diag().file_location_msg("", None);
-                let ws = indent("     ", &src_env.yacc_diag().format_warning(w).to_string());
+                let ws_loc = yacc_diag.file_location_msg("", None);
+                let ws = indent("     ", &yacc_diag.format_warning(w).to_string());
                 // Assume if this variable is set we are running under cargo.
                 if std::env::var("OUT_DIR").is_ok() && self.show_warnings {
                     for line in ws_loc.lines().chain(ws.lines()) {
@@ -661,17 +681,29 @@ where
         }
 
         let timestamp = env!("VERGEN_BUILD_TIMESTAMP");
-        let code_gen = build_env.code_generator(&src_env, timestamp)?;
+        let code_gen = build_env.code_generator(timestamp).map_err(|e| match e {
+            ParserBuildEnvError::YaccGrammarErrors(errs) => {
+                let mut out = String::new();
+                out.push_str(&format!(
+                    "\n{ERROR}{}\n",
+                    yacc_diag.file_location_msg("", None)
+                ));
+                for e in errs {
+                    out.push_str(&indent("     ", &yacc_diag.format_error(e).to_string()));
+                    out.push('\n');
+                }
+                ErrorString(out)
+            }
+            e => ErrorString(e.to_string()),
+        })?;
         let grm = code_gen.grm();
-        let stable = code_gen.stable();
-
         let rule_ids = grm
             .tokens_map()
             .iter()
             .map(|(&n, &i)| (n.to_owned(), i.as_storaget()))
             .collect::<HashMap<_, _>>();
 
-        let cache = code_gen.cache_str(&src_env, &build_env);
+        let cache = code_gen.cache_str(&build_env);
 
         // We don't need to go through the full rigmarole of generating an output file if all of
         // the following are true: the output file exists; it is newer than the input file; and the
@@ -716,6 +748,35 @@ where
         // confusing than the alternatives).
         fs::remove_file(outp).ok();
 
+        let stable = code_gen.stable();
+        if self.error_on_conflicts
+            && let Some(c) = stable.conflicts()
+        {
+            match (grm.expect(), grm.expectrr()) {
+                (Some(i), Some(j)) if i == c.sr_len() && j == c.rr_len() => (),
+                (Some(i), None) if i == c.sr_len() && 0 == c.rr_len() => (),
+                (None, Some(j)) if 0 == c.sr_len() && j == c.rr_len() => (),
+                (None, None) if 0 == c.rr_len() && 0 == c.sr_len() => (),
+                _ => {
+                    let conflicts_diagnostic = yacc_diag.format_conflicts::<LexerTypesT>(
+                        grm,
+                        build_env.ast_with_validity_info().ast(),
+                        c,
+                        code_gen.sgraph(),
+                        stable,
+                    );
+                    #[cfg(test)]
+                    let (_, _, stable) = code_gen.finish();
+                    return Err(Box::new(CTConflictsError {
+                        conflicts_diagnostic,
+                        phantom: PhantomData,
+                        #[cfg(test)]
+                        stable,
+                    }));
+                }
+            }
+        }
+
         if let Some(ref mut inspector_rt) = self.inspect_rt {
             let rt: RTParserBuilder<'_, StorageT, LexerTypesT> = RTParserBuilder::new(grm, stable);
             let rt = if let Some(rk) = self.recoverer {
@@ -723,16 +784,17 @@ where
             } else {
                 rt
             };
-            inspector_rt(src_env.header_mut(), rt, &rule_ids, grmp)?
+            inspector_rt(build_env.header_mut(), rt, &rule_ids, grmp)?
         }
 
-        src_env.check_unused_header_keys()?;
+        build_env
+            .check_unused_header_keys()
+            .map_err(|e| ErrorString(e.to_string()))?;
 
         self.output_file(
             &code_gen,
             outp,
             &format!("/* CACHE INFORMATION {} */\n", cache),
-            &src_env,
             &build_env,
         )?;
         let (grm, sgraph, stable) = code_gen.finish();
@@ -861,10 +923,11 @@ where
         code_gen: &ParserCodegen<LexerTypesT>,
         outp_rs: P,
         cache: &str,
-        src_env: &ParserSrcEnv,
         build_env: &ParserBuildEnv<'_, LexerTypesT>,
     ) -> Result<(), Box<dyn Error>> {
-        let outs = code_gen.generate(src_env, build_env)?;
+        let outs = code_gen
+            .generate(build_env)
+            .map_err(|e| ErrorString(e.to_string()))?;
         let mut f = File::create(outp_rs)?;
         f.write_all(outs.as_bytes())?;
         f.write_all(cache.as_bytes())?;
@@ -1148,7 +1211,7 @@ A : 'a';"
                 let err_string = e.to_string();
                 assert_eq!(
                     err_string,
-                    "CTParserBuilder::mod_name(\"contains-a-dash_y\") is not a valid rust identifier due to 'unexpected token'"
+                    "mod_name \'contains-a-dash_y\' is not a valid rust identifier due to 'unexpected token'"
                 );
             }
         }

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -16,7 +16,7 @@ use std::{
 
 use crate::{
     LexerTypes, RTParserBuilder, RecoveryKind,
-    codegen::{ParserBuildEnv, ParserBuildEnvArgs, ParserCodegen, ParserSrcEnv},
+    codegen::{ParserBuildEnv, ParserBuildEnvArgs, ParserSrcEnv, QuoteOption},
     diagnostics::{DiagnosticFormatter, SpannedDiagnosticFormatter},
 };
 
@@ -59,22 +59,6 @@ pub(crate) struct CTConflictsError<StorageT: Eq + Hash> {
     pub(crate) phantom: PhantomData<StorageT>,
 }
 
-/// The quote impl of `ToTokens` for `Option` prints an empty string for `None`
-/// and the inner value for `Some(inner_value)`.
-///
-/// This wrapper instead emits both `Some` and `None` variants.
-/// See: [quote #20](https://github.com/dtolnay/quote/issues/20)
-struct QuoteOption<T>(Option<T>);
-
-impl<T: ToTokens> ToTokens for QuoteOption<T> {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        tokens.append_all(match self.0 {
-            Some(ref t) => quote! { ::std::option::Option::Some(#t) },
-            None => quote! { ::std::option::Option::None },
-        });
-    }
-}
-
 /// The quote impl of `ToTokens` for `usize` prints literal values
 /// including a type suffix for example `0usize`.
 ///
@@ -84,27 +68,6 @@ struct UnsuffixedUsize(usize);
 impl ToTokens for UnsuffixedUsize {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         tokens.append(Literal::usize_unsuffixed(self.0))
-    }
-}
-
-/// This wrapper adds a missing impl of `ToTokens` for tuples.
-/// For a tuple `(a, b)` emits `(a.to_tokens(), b.to_tokens())`
-struct QuoteTuple<T>(T);
-
-impl<A: ToTokens, B: ToTokens> ToTokens for QuoteTuple<(A, B)> {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        let (a, b) = &self.0;
-        tokens.append_all(quote!((#a, #b)));
-    }
-}
-
-/// The wrapped `&str` value will be emitted with a call to `to_string()`
-struct QuoteToString<'a>(&'a str);
-
-impl ToTokens for QuoteToString<'_> {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        let x = &self.0;
-        tokens.append_all(quote! { #x.to_string() });
     }
 }
 
@@ -178,48 +141,6 @@ pub enum RustEdition {
     Rust2015,
     Rust2018,
     Rust2021,
-}
-
-impl RustEdition {
-    fn to_variant_tokens(self) -> TokenStream {
-        match self {
-            RustEdition::Rust2015 => quote!(::lrpar::RustEdition::Rust2015),
-            RustEdition::Rust2018 => quote!(::lrpar::RustEdition::Rust2018),
-            RustEdition::Rust2021 => quote!(::lrpar::RustEdition::Rust2021),
-        }
-    }
-}
-
-impl ToTokens for Visibility {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        tokens.extend(match self {
-            Visibility::Private => quote!(),
-            Visibility::Public => quote! {pub},
-            Visibility::PublicSuper => quote! {pub(super)},
-            Visibility::PublicSelf => quote! {pub(self)},
-            Visibility::PublicCrate => quote! {pub(crate)},
-            Visibility::PublicIn(data) => {
-                let other = str::parse::<TokenStream>(data).unwrap();
-                quote! {pub(in #other)}
-            }
-        })
-    }
-}
-
-impl Visibility {
-    fn to_variant_tokens(&self) -> TokenStream {
-        match self {
-            Visibility::Private => quote!(::lrpar::Visibility::Private),
-            Visibility::Public => quote!(::lrpar::Visibility::Public),
-            Visibility::PublicSuper => quote!(::lrpar::Visibility::PublicSuper),
-            Visibility::PublicSelf => quote!(::lrpar::Visibility::PublicSelf),
-            Visibility::PublicCrate => quote!(::lrpar::Visibility::PublicCrate),
-            Visibility::PublicIn(data) => {
-                let data = QuoteToString(data);
-                quote!(::lrpar::Visibility::PublicIn(#data))
-            }
-        }
-    }
 }
 
 /// Sets the underlying encoding algorithm for serialising the `ParserData` into the generated source files.
@@ -785,7 +706,7 @@ where
             .map(|(&n, &i)| (n.to_owned(), i.as_storaget()))
             .collect::<HashMap<_, _>>();
 
-        let cache = self.rebuild_cache(&code_gen, &src_env, &build_env);
+        let cache = code_gen.cache_str(&src_env, &build_env);
 
         // We don't need to go through the full rigmarole of generating an output file if all of
         // the following are true: the output file exists; it is newer than the input file; and the
@@ -800,8 +721,7 @@ where
                 > FileTime::from_last_modification_time(inmd)
             && let Ok(outc) = read_to_string(outp)
         {
-
-            if outc.contains(&cache.to_string()) {
+            if outc.contains(&cache) {
                 let (grm, _, _) = code_gen.finish();
 
                 return Ok(CTParser {
@@ -1058,55 +978,6 @@ where
         f.write_all(outs.as_bytes())?;
         f.write_all(cache.as_bytes())?;
         Ok(())
-    }
-
-    /// Generate the cache, which determines if anything's changed enough that we need to
-    /// regenerate outputs and force rustc to recompile.
-    fn rebuild_cache(
-        &self,
-        code_gen: &ParserCodegen<LexerTypesT>,
-        src_env: &ParserSrcEnv,
-        build_env: &ParserBuildEnv<LexerTypesT>,
-    ) -> TokenStream {
-        let grm = code_gen.grm();
-        let build_time = env!("VERGEN_BUILD_TIMESTAMP");
-        let grammar_path = src_env.path().to_string_lossy();
-        let mod_name = QuoteOption(build_env.specified_mod_name());
-        let visibility = build_env.visibility().to_variant_tokens();
-        let rust_edition = build_env.rust_edition().to_variant_tokens();
-        let yacckind = build_env.yacc_kind();
-        let rule_map = grm
-            .iter_tidxs()
-            .map(|tidx| {
-                QuoteTuple((
-                    usize::from(tidx),
-                    grm.token_name(tidx).unwrap_or("<unknown>"),
-                ))
-            })
-            .collect::<Vec<_>>();
-        let derived_mod_name = build_env.derived_mod_name();
-        let serialisation_format = build_env.serialisation_format();
-        let recoverer = build_env.recoverer();
-        let error_on_conflicts = build_env.error_on_conflicts();
-        let show_warnings = build_env.show_warnings();
-        let warnings_are_errors = build_env.warnings_are_errors();
-        let cache_info = quote! {
-            BUILD_TIME = #build_time
-            DERIVED_MOD_NAME = #derived_mod_name
-            ENCODING_CONFIG = #serialisation_format
-            GRAMMAR_PATH = #grammar_path
-            MOD_NAME = #mod_name
-            RECOVERER = #recoverer
-            YACC_KIND = #yacckind
-            ERROR_ON_CONFLICTS = #error_on_conflicts
-            SHOW_WARNINGS = #show_warnings
-            WARNINGS_ARE_ERRORS = #warnings_are_errors
-            RUST_EDITION = #rust_edition
-            RULE_IDS_MAP = [#(#rule_map,)*]
-            VISIBILITY = #visibility
-        };
-        let cache_info_str = cache_info.to_string();
-        quote!(#cache_info_str)
     }
 
     /// Generate the main parse() function for the output file.

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -37,7 +37,7 @@ use quote::{ToTokens, TokenStreamExt, format_ident, quote};
 use syn::{Generics, parse_quote};
 use wincode::{SchemaRead, SchemaReadOwned, SchemaWrite};
 
-const ACTION_PREFIX: &str = "__gt_";
+pub(crate) const ACTION_PREFIX: &str = "__gt_";
 const GLOBAL_PREFIX: &str = "__GT_";
 const ACTIONS_KIND: &str = "__GtActionsKind";
 const ACTIONS_KIND_PREFIX: &str = "Ak";
@@ -904,7 +904,7 @@ where
         let user_actions = if let YaccKind::Original(YaccOriginalActionKind::UserAction)
         | YaccKind::Grmtools = build_env.yacc_kind()
         {
-            Some(self.gen_user_actions(code_gen, src_env)?)
+            Some(code_gen.gen_user_actions(src_env)?)
         } else {
             None
         };
@@ -1363,145 +1363,6 @@ where
         Ok(wrappers)
     }
 
-    /// Generate the user action functions (if any).
-    fn gen_user_actions(
-        &self,
-        code_gen: &ParserCodegen<LexerTypesT>,
-        src_env: &ParserSrcEnv,
-    ) -> Result<TokenStream, Box<dyn Error>> {
-        let grm = code_gen.grm();
-        let _diag = src_env.yacc_diag();
-        let programs = grm
-            .programs()
-            .as_ref()
-            .map(|s| str::parse::<TokenStream>(s))
-            .transpose()?;
-        let mut action_fns = TokenStream::new();
-        // Convert actions to functions
-        let parsed_parse_generics = make_generics(grm.parse_generics().as_deref())?;
-        let (generics, _, where_clause) = parsed_parse_generics.split_for_impl();
-        let (parse_paramname, parse_paramdef, parse_param_unit);
-        match grm.parse_param() {
-            Some((name, tyname)) => {
-                parse_param_unit = tyname.trim() == "()";
-                parse_paramname = str::parse::<TokenStream>(name)?;
-                let ty = str::parse::<TokenStream>(tyname)?;
-                parse_paramdef = quote!(#parse_paramname: #ty);
-            }
-            None => {
-                parse_param_unit = true;
-                parse_paramname = quote!(());
-                parse_paramdef = quote! {_: ()};
-            }
-        };
-        for pidx in grm.iter_pidxs() {
-            if pidx == grm.start_prod() {
-                continue;
-            }
-
-            // Work out the right type for each argument
-            let mut args = Vec::with_capacity(grm.prod(pidx).len());
-            for i in 0..grm.prod(pidx).len() {
-                let argt = match grm.prod(pidx)[i] {
-                    Symbol::Rule(ref_ridx) => {
-                        let action_type = grm.actiontype(ref_ridx)
-                           .as_ref()
-                           .expect("actiontype should have been checked during complete_and_validate for this YaccKind");
-                        str::parse::<TokenStream>(action_type)?
-                    }
-                    Symbol::Token(_) => {
-                        let lexemet =
-                            str::parse::<TokenStream>(type_name::<LexerTypesT::LexemeT>())?;
-                        quote!(::std::result::Result<#lexemet, #lexemet>)
-                    }
-                };
-                let arg = format_ident!("{}arg_{}", ACTION_PREFIX, i + 1);
-                args.push(quote!(mut #arg: #argt));
-            }
-
-            // If this rule's `actiont` is `()` then Clippy will warn that the return type `-> ()`
-            // is pointless (which is true). We therefore avoid outputting a return type if actiont
-            // is the unit type.
-            let returnt = {
-                let actiont = grm.actiontype(grm.prod_to_rule(pidx)).as_ref().unwrap();
-                if actiont == "()" {
-                    None
-                } else {
-                    let actiont = str::parse::<TokenStream>(actiont)?;
-                    Some(quote!( -> #actiont))
-                }
-            };
-            let action_fn = format_ident!("{}action_{}", ACTION_PREFIX, usize::from(pidx));
-            let lexer_var = format_ident!("{}lexer", ACTION_PREFIX);
-            let span_var = format_ident!("{}span", ACTION_PREFIX);
-            let ridx_var = format_ident!("{}ridx", ACTION_PREFIX);
-            let storaget = str::parse::<TokenStream>(type_name::<LexerTypesT::StorageT>())?;
-            let lexertypest = str::parse::<TokenStream>(type_name::<LexerTypesT>())?;
-            let bind_parse_param = if !parse_param_unit {
-                Some(quote! {let _ = #parse_paramname;})
-            } else {
-                None
-            };
-
-            // Iterate over all $-arguments and replace them with their respective
-            // element from the argument vector (e.g. $1 is replaced by args[0]).
-            let pre_action = grm.action(pidx).as_ref().expect("action code should have been checked during complete_and_validate for this YaccKind");
-            let mut last = 0;
-            let mut outs = String::new();
-            loop {
-                match pre_action[last..].find('$') {
-                    Some(off) => {
-                        if pre_action[last + off..].starts_with("$$") {
-                            outs.push_str(&pre_action[last..last + off + "$".len()]);
-                            last = last + off + "$$".len();
-                        } else if pre_action[last + off..].starts_with("$lexer") {
-                            outs.push_str(&pre_action[last..last + off]);
-                            write!(outs, "{prefix}lexer", prefix = ACTION_PREFIX).ok();
-                            last = last + off + "$lexer".len();
-                        } else if pre_action[last + off..].starts_with("$span") {
-                            outs.push_str(&pre_action[last..last + off]);
-                            write!(outs, "{prefix}span", prefix = ACTION_PREFIX).ok();
-                            last = last + off + "$span".len();
-                        } else if last + off + 1 < pre_action.len()
-                            && pre_action[last + off + 1..].starts_with(|c: char| c.is_numeric())
-                        {
-                            outs.push_str(&pre_action[last..last + off]);
-                            write!(outs, "{prefix}arg_", prefix = ACTION_PREFIX).ok();
-                            last = last + off + "$".len();
-                        } else {
-                            unreachable!("action variables checked during complete_and_validate");
-                        }
-                    }
-                    None => {
-                        outs.push_str(&pre_action[last..]);
-                        break;
-                    }
-                }
-            }
-
-            let action_body = str::parse::<TokenStream>(&outs)?;
-            action_fns.extend(quote! {
-                #[allow(clippy::too_many_arguments)]
-                fn #action_fn #generics (
-                    #ridx_var: ::cfgrammar::RIdx<#storaget>,
-                    #lexer_var: &'lexer dyn ::lrpar::NonStreamingLexer<'input, #lexertypest>,
-                    #span_var: ::cfgrammar::Span,
-                    #parse_paramdef,
-                    #(#args,)*
-                ) #returnt
-                #where_clause
-                {
-                    #bind_parse_param
-                    #action_body
-                }
-            })
-        }
-        Ok(quote! {
-            #programs
-            #action_fns
-        })
-    }
-
     /// Return the `RIdx` of the %start rule in the grammar (which will not be the same as
     /// grm.start_rule_idx because the latter has an additional rule insert by cfgrammar
     /// which then calls the user's %start rule).
@@ -1635,7 +1496,7 @@ pub(crate) fn indent(indent: &str, s: &str) -> String {
     format!("{indent}{}\n", s.trim_end_matches('\n')).replace('\n', &format!("\n{}", indent))
 }
 
-fn make_generics(parse_generics: Option<&str>) -> Result<Generics, Box<dyn Error>> {
+pub(crate) fn make_generics(parse_generics: Option<&str>) -> Result<Generics, Box<dyn Error>> {
     if let Some(parse_generics) = parse_generics {
         let tokens = str::parse::<TokenStream>(parse_generics)?;
         match syn::parse2(quote!(<'lexer, 'input: 'lexer, #tokens>)) {

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -24,7 +24,7 @@ use crate::{
 use crate::unstable_api::UnstableApi;
 
 use cfgrammar::{
-    Location, RIdx, Symbol,
+    Location, Symbol,
     header::{Header, HeaderError, HeaderErrorKind, HeaderValue, Namespaced, Setting, Value},
     markmap::{Entry, MergeBehavior},
     yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind, ast::ASTWithValidityInfo},
@@ -39,9 +39,9 @@ use wincode::{SchemaRead, SchemaReadOwned, SchemaWrite};
 
 pub(crate) const ACTION_PREFIX: &str = "__gt_";
 pub(crate) const GLOBAL_PREFIX: &str = "__GT_";
-const ACTIONS_KIND: &str = "__GtActionsKind";
-const ACTIONS_KIND_PREFIX: &str = "Ak";
-const ACTIONS_KIND_HIDDEN: &str = "__GtActionsKindHidden";
+pub(crate) const ACTIONS_KIND: &str = "__GtActionsKind";
+pub(crate) const ACTIONS_KIND_PREFIX: &str = "Ak";
+pub(crate) const ACTIONS_KIND_HIDDEN: &str = "__GtActionsKindHidden";
 
 const RUST_FILE_EXT: &str = "rs";
 
@@ -899,8 +899,8 @@ where
 
         let rule_consts = code_gen.gen_rule_consts()?;
         let token_epp = code_gen.gen_token_epp()?;
-        let parse_function = self.gen_parse_function(code_gen, build_env)?;
-        let action_wrappers = match build_env.yacc_kind() {
+        let parse_function = code_gen.gen_parse_function(build_env)?;
+        let action_wrappers = match  build_env.yacc_kind()  {
             YaccKind::Original(YaccOriginalActionKind::UserAction) | YaccKind::Grmtools => {
                 Some(self.gen_wrappers(code_gen, build_env)?)
             }
@@ -962,185 +962,6 @@ where
         f.write_all(outs.as_bytes())?;
         f.write_all(cache.as_bytes())?;
         Ok(())
-    }
-
-    /// Generate the main parse() function for the output file.
-    fn gen_parse_function(
-        &self,
-        code_gen: &ParserCodegen<LexerTypesT>,
-        build_env: &ParserBuildEnv<LexerTypesT>,
-    ) -> Result<TokenStream, Box<dyn Error>> {
-        let stable = code_gen.stable();
-        let grm = code_gen.grm();
-        let storaget = str::parse::<TokenStream>(type_name::<LexerTypesT::StorageT>())?;
-        let lexertypest = str::parse::<TokenStream>(type_name::<LexerTypesT>())?;
-        let recoverer = build_env.recoverer();
-        let run_parser = match build_env.yacc_kind() {
-            YaccKind::Original(YaccOriginalActionKind::GenericParseTree) => {
-                quote! {
-                    ::lrpar::RTParserBuilder::new(grm, stable)
-                        .recoverer(#recoverer)
-                        .parse_map(
-                            lexer,
-                            &|lexeme| Node::Term{lexeme},
-                            &|ridx, nodes| Node::Nonterm{ridx, nodes}
-                        )
-                }
-            }
-            YaccKind::Original(YaccOriginalActionKind::NoAction) => {
-                quote! {
-                    ::lrpar::RTParserBuilder::new(grm, stable)
-                        .recoverer(#recoverer)
-                        .parse_map(lexer, &|_| (), &|_, _| ()).1
-                }
-            }
-            YaccKind::Original(YaccOriginalActionKind::UserAction) | YaccKind::Grmtools => {
-                let actionskind = str::parse::<TokenStream>(ACTIONS_KIND)?;
-                let parsed_parse_generics = make_generics(grm.parse_generics().as_deref())?;
-                let (_, type_generics, _) = parsed_parse_generics.split_for_impl();
-                // actions always have a parse_param argument, and when the `parse` function lacks one
-                // that parameter will be unit.
-                let (action_fn_parse_param, action_fn_parse_param_ty) = match grm.parse_param() {
-                    Some((name, ty)) => {
-                        let name = str::parse::<TokenStream>(name)?;
-                        let ty = str::parse::<TokenStream>(ty)?;
-                        (quote!(#name), quote!(#ty))
-                    }
-                    None => (quote!(()), quote!(())),
-                };
-                let wrappers = grm.iter_pidxs().map(|pidx| {
-                    let pidx = usize::from(pidx);
-                    format_ident!("{}wrapper_{}", ACTION_PREFIX, pidx)
-                });
-                let edition_lifetime = if build_env.rust_edition() != RustEdition::Rust2015 {
-                    quote!('_,)
-                } else {
-                    quote!()
-                };
-                let ridx = usize::from(self.user_start_ridx(code_gen));
-                let action_ident = format_ident!("{}{}", ACTIONS_KIND_PREFIX, ridx);
-
-                quote! {
-                    let actions: ::std::vec::Vec<
-                            &dyn Fn(
-                                    ::cfgrammar::RIdx<#storaget>,
-                                    &'lexer dyn ::lrpar::NonStreamingLexer<'input, #lexertypest>,
-                                    ::cfgrammar::Span,
-                                    ::std::vec::Drain<#edition_lifetime ::lrpar::parser::AStackType<<#lexertypest as ::lrpar::LexerTypes>::LexemeT, #actionskind #type_generics>>,
-                                    #action_fn_parse_param_ty
-                            ) -> #actionskind #type_generics
-                        > = ::std::vec![#(&#wrappers,)*];
-                    match ::lrpar::RTParserBuilder::new(grm, stable)
-                        .recoverer(#recoverer)
-                        .parse_actions(lexer, &actions, #action_fn_parse_param) {
-                            (Some(#actionskind::#action_ident(x)), y) => (Some(x), y),
-                            (None, y) => (None, y),
-                            _ => unreachable!()
-                    }
-                }
-            }
-            kind => panic!("YaccKind {:?} not supported", kind),
-        };
-
-        let parsed_parse_generics: Generics = match build_env.yacc_kind() {
-            YaccKind::Original(YaccOriginalActionKind::UserAction) | YaccKind::Grmtools => {
-                make_generics(grm.parse_generics().as_deref())?
-            }
-            _ => make_generics(None)?,
-        };
-        let (generics, _, where_clause) = parsed_parse_generics.split_for_impl();
-
-        // `parse()` may or may not have an argument for `%parseparam`.
-        let parse_fn_parse_param = match build_env.yacc_kind() {
-            YaccKind::Original(YaccOriginalActionKind::UserAction) | YaccKind::Grmtools => {
-                if let Some((name, tyname)) = grm.parse_param() {
-                    let name = str::parse::<TokenStream>(name)?;
-                    let tyname = str::parse::<TokenStream>(tyname)?;
-                    Some(quote! {#name: #tyname})
-                } else {
-                    None
-                }
-            }
-            _ => None,
-        };
-        let parse_fn_return_ty = match build_env.yacc_kind() {
-            YaccKind::Original(YaccOriginalActionKind::UserAction) | YaccKind::Grmtools => {
-                let actiont = grm
-                    .actiontype(self.user_start_ridx(code_gen))
-                    .as_ref()
-                    .map(|at| str::parse::<TokenStream>(at))
-                    .transpose()?;
-                quote! {
-                    (::std::option::Option<#actiont>, ::std::vec::Vec<::lrpar::LexParseError<#storaget, #lexertypest>>)
-                }
-            }
-            YaccKind::Original(YaccOriginalActionKind::GenericParseTree) => quote! {
-                (::std::option::Option<Node<<#lexertypest as ::lrpar::LexerTypes>::LexemeT, #storaget>>,
-                    ::std::vec::Vec<::lrpar::LexParseError<#storaget, #lexertypest>>)
-            },
-            YaccKind::Original(YaccOriginalActionKind::NoAction) => quote! {
-                ::std::vec::Vec<::lrpar::LexParseError<#storaget, #lexertypest>>
-            },
-            _ => unreachable!(),
-        };
-
-        let serialisation_format = build_env.serialisation_format();
-        // Note that the configuration types use associated consts, and thus these configurations represent distinct types.
-        let (grm_data, stable_data): (Vec<u8>, Vec<u8>) = match serialisation_format {
-            SerialisationFormat::FixedSizeInteger => {
-                let config = wincode::config::Configuration::default().with_fixint_encoding();
-                let grm = wincode::config::serialize(grm, config)?;
-                let stable = wincode::config::serialize(stable, config)?;
-                (grm, stable)
-            }
-            SerialisationFormat::VariableSizedInteger => {
-                let config = wincode::config::Configuration::default().with_varint_encoding();
-                let grm = wincode::config::serialize(grm, config)?;
-                let stable = wincode::config::serialize(stable, config)?;
-                (grm, stable)
-            }
-        };
-        let serialisation_format_str = quote!(serialisation_format).to_string();
-        Ok(quote! {
-            const __GRM_DATA: &[u8] = &[#(#grm_data,)*];
-            const __STABLE_DATA: &[u8] = &[#(#stable_data,)*];
-            const __SERIALISATION_FORMAT: ::lrpar::ctbuilder::SerialisationFormat = #serialisation_format;
-
-            fn __lrpar_parser_data() -> &'static ::lrpar::ParserData<#storaget> {
-                static DATA: ::std::sync::OnceLock<::lrpar::ParserData<#storaget>>
-                    = ::std::sync::OnceLock::new();
-                DATA.get_or_init(
-                    || {
-                        // We have to call reconstitute like this because the config parameter takes a trait
-                        // which uses const generics. Thus the two config parameters here are not actually of the same type.
-                        match __SERIALISATION_FORMAT {
-                            ::lrpar::ctbuilder::SerialisationFormat::FixedSizeInteger => {
-                                ::lrpar::ctbuilder::_reconstitute(__GRM_DATA, __STABLE_DATA, ::lrpar::ctbuilder::wincode::config::Configuration::default().with_fixint_encoding())
-                            }
-                            ::lrpar::ctbuilder::SerialisationFormat::VariableSizedInteger => {
-                                ::lrpar::ctbuilder::_reconstitute(__GRM_DATA, __STABLE_DATA, ::lrpar::ctbuilder::wincode::config::Configuration::default().with_varint_encoding())
-                            }
-                            _ => {
-                                panic!("Parser source was generated using unknown `SerialisationFormat`: {:?}", #serialisation_format_str)
-                            }
-                        }
-                    }
-                )
-            }
-
-            #[allow(dead_code)]
-            pub fn parse #generics (
-                 lexer: &'lexer dyn ::lrpar::NonStreamingLexer<'input, #lexertypest>,
-                 #parse_fn_parse_param
-            ) -> #parse_fn_return_ty
-            #where_clause
-            {
-                let __data = __lrpar_parser_data();
-                let grm = __data.grm();
-                let stable = __data.stable();
-                #run_parser
-            }
-        })
     }
 
     /// Generate the wrappers that call user actions
@@ -1305,21 +1126,6 @@ where
             }
         });
         Ok(wrappers)
-    }
-
-    /// Return the `RIdx` of the %start rule in the grammar (which will not be the same as
-    /// grm.start_rule_idx because the latter has an additional rule insert by cfgrammar
-    /// which then calls the user's %start rule).
-    fn user_start_ridx(
-        &self,
-        code_gen: &ParserCodegen<LexerTypesT>,
-    ) -> RIdx<LexerTypesT::StorageT> {
-        let grm = code_gen.grm();
-        debug_assert_eq!(grm.prod(grm.start_prod()).len(), 1);
-        match grm.prod(grm.start_prod())[0] {
-            Symbol::Rule(ridx) => ridx,
-            _ => unreachable!(),
-        }
     }
 }
 

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -16,7 +16,7 @@ use std::{
 
 use crate::{
     LexerTypes, RTParserBuilder, RecoveryKind,
-    codegen::{ParserBuildEnv, ParserBuildEnvArgs, ParserCodegen, ParserSrcEnv, QuoteOption},
+    codegen::{ParserBuildEnv, ParserBuildEnvArgs, ParserCodegen, ParserSrcEnv},
     diagnostics::DiagnosticFormatter,
 };
 
@@ -38,7 +38,7 @@ use syn::{Generics, parse_quote};
 use wincode::{SchemaRead, SchemaReadOwned, SchemaWrite};
 
 pub(crate) const ACTION_PREFIX: &str = "__gt_";
-const GLOBAL_PREFIX: &str = "__GT_";
+pub(crate) const GLOBAL_PREFIX: &str = "__GT_";
 const ACTIONS_KIND: &str = "__GtActionsKind";
 const ACTIONS_KIND_PREFIX: &str = "Ak";
 const ACTIONS_KIND_HIDDEN: &str = "__GtActionsKindHidden";
@@ -898,7 +898,7 @@ where
         };
 
         let rule_consts = code_gen.gen_rule_consts()?;
-        let token_epp = self.gen_token_epp(code_gen)?;
+        let token_epp = code_gen.gen_token_epp()?;
         let parse_function = self.gen_parse_function(code_gen, build_env)?;
         let action_wrappers = match build_env.yacc_kind() {
             YaccKind::Original(YaccOriginalActionKind::UserAction) | YaccKind::Grmtools => {
@@ -1143,30 +1143,6 @@ where
         })
     }
 
-    fn gen_token_epp(
-        &self,
-        code_gen: &ParserCodegen<LexerTypesT>,
-    ) -> Result<TokenStream, proc_macro2::LexError> {
-        let grm = code_gen.grm();
-        let mut tidxs = Vec::new();
-        for tidx in grm.iter_tidxs() {
-            tidxs.push(QuoteOption(grm.token_epp(tidx)));
-        }
-        let const_epp_ident = format_ident!("{}EPP", GLOBAL_PREFIX);
-        let storage_ty = str::parse::<TokenStream>(type_name::<LexerTypesT::StorageT>())?;
-        Ok(quote! {
-            const #const_epp_ident: &[::std::option::Option<&str>] = &[
-                #(#tidxs,)*
-            ];
-
-            /// Return the %epp entry for token `tidx` (where `None` indicates \"the token has no
-            /// pretty-printed value\"). Panics if `tidx` doesn't exist.
-            #[allow(dead_code)]
-            pub fn token_epp<'a>(tidx: ::cfgrammar::TIdx<#storage_ty>) -> ::std::option::Option<&'a str> {
-                #const_epp_ident[usize::from(tidx)]
-            }
-        })
-    }
     /// Generate the wrappers that call user actions
     fn gen_wrappers(
         &self,

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -16,6 +16,7 @@ use std::{
 
 use crate::{
     LexerTypes, RTParserBuilder, RecoveryKind,
+    codegen::{ParserBuildEnv, ParserBuildEnvArgs, ParserSrcEnv},
     diagnostics::{DiagnosticFormatter, SpannedDiagnosticFormatter},
 };
 
@@ -24,10 +25,7 @@ use crate::unstable_api::UnstableApi;
 
 use cfgrammar::{
     Location, RIdx, Symbol,
-    header::{
-        GrmtoolsSectionParser, Header, HeaderError, HeaderErrorKind, HeaderValue, Namespaced,
-        Setting, Value,
-    },
+    header::{Header, HeaderError, HeaderErrorKind, HeaderValue, Namespaced, Setting, Value},
     markmap::{Entry, MergeBehavior},
     yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind, ast::ASTWithValidityInfo},
 };
@@ -48,7 +46,7 @@ const ACTIONS_KIND_HIDDEN: &str = "__GtActionsKindHidden";
 const RUST_FILE_EXT: &str = "rs";
 
 const WARNING: &str = "[Warning]";
-const ERROR: &str = "[Error]";
+pub(crate) const ERROR: &str = "[Error]";
 
 static GENERATED_PATHS: LazyLock<Mutex<HashSet<PathBuf>>> =
     LazyLock::new(|| Mutex::new(HashSet::new()));
@@ -727,73 +725,38 @@ where
         } else {
             read_to_string(grmp).map_err(|e| format!("When reading '{}': {e}", grmp.display()))?
         };
-        let yacc_diag = SpannedDiagnosticFormatter::new(&inc, grmp);
-        let parsed_header = GrmtoolsSectionParser::new(&inc, false).parse();
-        if let Err(errs) = parsed_header {
-            let mut out = String::new();
-            out.push_str(&format!(
-                "\n{ERROR}{}\n",
-                yacc_diag.file_location_msg(" parsing the `%grmtools` section", None)
-            ));
-            for e in errs {
-                out.push_str(&indent("     ", &yacc_diag.format_error(e).to_string()));
-            }
-            return Err(ErrorString(out).into());
-        };
-        let (parsed_header, _) = parsed_header.unwrap();
-        header.merge_from(parsed_header)?;
-        self.yacckind = header
-            .get("yacckind")
-            .map(|HeaderValue(_, val)| val)
-            .map(YaccKind::try_from)
-            .transpose()?;
-        header.mark_used(&"yacckind".to_string());
-        let ast_validation = if let Some(ast) = &self.from_ast {
-            ast.clone()
-        } else if let Some(yk) = self.yacckind {
-            ASTWithValidityInfo::new(yk, &inc)
-        } else {
-            Err("Missing 'yacckind'".to_string())?
-        };
 
-        header.mark_used(&"recoverer".to_string());
-        let rk_val = header.get("recoverer").map(|HeaderValue(_, rk_val)| rk_val);
+        let mut src_env = ParserSrcEnv::new_with_header(&inc, grmp, header);
+        let build_args = ParserBuildEnvArgs::new()
+            .ast_with_validity_info(self.from_ast.as_ref())
+            .mod_name(self.mod_name)
+            .show_warnings(self.show_warnings)
+            .error_on_conflicts(self.error_on_conflicts)
+            .warnings_are_errors(self.warnings_are_errors);
+        let build_env = src_env.build_env::<LexerTypesT>(build_args)?;
+        // Temporarily we update self.yacckind and self.recoverer from the build_env
+        // Until codegen reads these variables from the build_env directly.
+        self.recoverer = Some(build_env.recoverer());
+        self.yacckind = Some(build_env.yacc_kind());
 
-        if let Some(rk_val) = rk_val {
-            self.recoverer = Some(RecoveryKind::try_from(rk_val)?);
-        } else {
-            // Fallback to the default recoverykind.
-            self.recoverer = Some(RecoveryKind::CPCTPlus);
-        }
-        header.mark_used(&"serialisation_format".to_string());
-        if let Some(ec_val) = header
-            .get("serialisation_format")
-            .map(|HeaderValue(_, ec_val)| ec_val)
-        {
-            self.serialisation_format = Some(SerialisationFormat::try_from(ec_val)?);
-        } else {
-            self.serialisation_format = Some(SerialisationFormat::VariableSizedInteger);
-        }
-
-        self.yacckind = Some(ast_validation.yacc_kind());
-        let warnings = ast_validation.ast().warnings();
+        let warnings = build_env.ast_with_validity_info().ast().warnings();
         if self.warnings_are_errors && !warnings.is_empty() {
             let mut out = String::new();
             out.push_str(&format!(
                 "\n{ERROR}{}\n",
-                yacc_diag.file_location_msg("", None)
+                src_env.yacc_diag().file_location_msg("", None)
             ));
             for e in warnings {
                 out.push_str(&format!(
                     "{}\n",
-                    indent("     ", &yacc_diag.format_warning(e).to_string())
+                    indent("     ", &src_env.yacc_diag().format_warning(e).to_string())
                 ));
             }
             return Err(ErrorString(out).into());
         } else if !warnings.is_empty() {
             for w in warnings {
-                let ws_loc = yacc_diag.file_location_msg("", None);
-                let ws = indent("     ", &yacc_diag.format_warning(w).to_string());
+                let ws_loc = src_env.yacc_diag().file_location_msg("", None);
+                let ws = indent("     ", &src_env.yacc_diag().format_warning(w).to_string());
                 // Assume if this variable is set we are running under cargo.
                 if std::env::var("OUT_DIR").is_ok() && self.show_warnings {
                     for line in ws_loc.lines().chain(ws.lines()) {
@@ -805,16 +768,21 @@ where
                 }
             }
         }
-        let grm = match YaccGrammar::<StorageT>::new_from_ast_with_validity_info(&ast_validation) {
+        let grm = match YaccGrammar::<StorageT>::new_from_ast_with_validity_info(
+            build_env.ast_with_validity_info(),
+        ) {
             Ok(grm) => grm,
             Err(errs) => {
                 let mut out = String::new();
                 out.push_str(&format!(
                     "\n{ERROR}{}\n",
-                    yacc_diag.file_location_msg("", None)
+                    src_env.yacc_diag().file_location_msg("", None)
                 ));
                 for e in errs {
-                    out.push_str(&indent("     ", &yacc_diag.format_error(e).to_string()));
+                    out.push_str(&indent(
+                        "     ",
+                        &src_env.yacc_diag().format_error(e).to_string(),
+                    ));
                     out.push('\n');
                 }
                 return Err(ErrorString(out).into());
@@ -822,7 +790,7 @@ where
         };
         #[cfg(test)]
         if let Some(cb) = &self.inspect_callback {
-            cb(self.recoverer.expect("has a default value"))?;
+            cb(build_env.recoverer())?;
         }
 
         let rule_ids = grm
@@ -831,26 +799,7 @@ where
             .map(|(&n, &i)| (n.to_owned(), i.as_storaget()))
             .collect::<HashMap<_, _>>();
 
-        let derived_mod_name = match self.mod_name {
-            Some(s) => s.to_owned(),
-            None => {
-                // The user hasn't specified a module name, so we create one automatically: what we
-                // do is strip off all the filename extensions (note that it's likely that inp ends
-                // with `y.rs`, so we potentially have to strip off more than one extension) and
-                // then add `_y` to the end.
-                let mut stem = grmp.to_str().unwrap();
-                loop {
-                    let new_stem = Path::new(stem).file_stem().unwrap().to_str().unwrap();
-                    if stem == new_stem {
-                        break;
-                    }
-                    stem = new_stem;
-                }
-                format!("{}_y", stem)
-            }
-        };
-
-        let cache = self.rebuild_cache(&derived_mod_name, &grm);
+        let cache = self.rebuild_cache(build_env.derived_mod_name(), &grm);
 
         // We don't need to go through the full rigmarole of generating an output file if all of
         // the following are true: the output file exists; it is newer than the input file; and the
@@ -903,9 +852,9 @@ where
                 (None, Some(j)) if 0 == c.sr_len() && j == c.rr_len() => (),
                 (None, None) if 0 == c.rr_len() && 0 == c.sr_len() => (),
                 _ => {
-                    let conflicts_diagnostic = yacc_diag.format_conflicts::<LexerTypesT>(
+                    let conflicts_diagnostic = src_env.yacc_diag().format_conflicts::<LexerTypesT>(
                         &grm,
-                        ast_validation.ast(),
+                        build_env.ast_with_validity_info().ast(),
                         c,
                         &sgraph,
                         &stable,
@@ -928,32 +877,19 @@ where
             } else {
                 rt
             };
-            inspector_rt(&mut header, rt, &rule_ids, grmp)?
+            inspector_rt(src_env.header_mut(), rt, &rule_ids, grmp)?
         }
 
-        let unused_keys = header.unused();
-        if !unused_keys.is_empty() {
-            return Err(format!("Unused keys in header: {}", unused_keys.join(", ")).into());
-        }
-        let missing_keys = header
-            .missing()
-            .iter()
-            .map(|s| s.as_str())
-            .collect::<Vec<_>>();
-        if !missing_keys.is_empty() {
-            return Err(format!(
-                "Required values were missing from the header: {}",
-                missing_keys.join(", ")
-            )
-            .into());
-        }
+        src_env.check_unused_header_keys()?;
 
         self.output_file(
             &grm,
             &stable,
-            &derived_mod_name,
+            build_env.derived_mod_name(),
             outp,
             &format!("/* CACHE INFORMATION {} */\n", cache),
+            src_env.yacc_diag(),
+            &build_env,
         )?;
         let conflicts = if stable.conflicts().is_some() {
             Some((sgraph, stable))
@@ -1082,6 +1018,8 @@ where
         mod_name: &str,
         outp_rs: P,
         cache: &str,
+        _diag: &SpannedDiagnosticFormatter,
+        build_env: &ParserBuildEnv<'_, LexerTypesT>,
     ) -> Result<(), Box<dyn Error>> {
         let visibility = self.visibility.clone();
         let user_actions = if let Some(
@@ -1094,7 +1032,7 @@ where
         };
         let rule_consts = self.gen_rule_consts(grm)?;
         let token_epp = self.gen_token_epp(grm)?;
-        let parse_function = self.gen_parse_function(grm, stable)?;
+        let parse_function = self.gen_parse_function(grm, stable, build_env)?;
         let action_wrappers = match self.yacckind.unwrap() {
             YaccKind::Original(YaccOriginalActionKind::UserAction) | YaccKind::Grmtools => {
                 Some(self.gen_wrappers(grm)?)
@@ -1232,11 +1170,12 @@ where
         &self,
         grm: &YaccGrammar<StorageT>,
         stable: &StateTable<StorageT>,
+        build_env: &ParserBuildEnv<'_, LexerTypesT>,
     ) -> Result<TokenStream, Box<dyn Error>> {
         let storaget = str::parse::<TokenStream>(type_name::<StorageT>())?;
         let lexertypest = str::parse::<TokenStream>(type_name::<LexerTypesT>())?;
-        let recoverer = self.recoverer;
-        let run_parser = match self.yacckind.unwrap() {
+        let recoverer = build_env.recoverer();
+        let run_parser = match build_env.yacc_kind() {
             YaccKind::Original(YaccOriginalActionKind::GenericParseTree) => {
                 quote! {
                     ::lrpar::RTParserBuilder::new(grm, stable)
@@ -1303,7 +1242,7 @@ where
             kind => panic!("YaccKind {:?} not supported", kind),
         };
 
-        let parsed_parse_generics: Generics = match self.yacckind.unwrap() {
+        let parsed_parse_generics: Generics = match build_env.yacc_kind() {
             YaccKind::Original(YaccOriginalActionKind::UserAction) | YaccKind::Grmtools => {
                 make_generics(grm.parse_generics().as_deref())?
             }
@@ -1312,7 +1251,7 @@ where
         let (generics, _, where_clause) = parsed_parse_generics.split_for_impl();
 
         // `parse()` may or may not have an argument for `%parseparam`.
-        let parse_fn_parse_param = match self.yacckind.unwrap() {
+        let parse_fn_parse_param = match build_env.yacc_kind() {
             YaccKind::Original(YaccOriginalActionKind::UserAction) | YaccKind::Grmtools => {
                 if let Some((name, tyname)) = grm.parse_param() {
                     let name = str::parse::<TokenStream>(name)?;
@@ -1324,7 +1263,7 @@ where
             }
             _ => None,
         };
-        let parse_fn_return_ty = match self.yacckind.unwrap() {
+        let parse_fn_return_ty = match build_env.yacc_kind() {
             YaccKind::Original(YaccOriginalActionKind::UserAction) | YaccKind::Grmtools => {
                 let actiont = grm
                     .actiontype(self.user_start_ridx(grm))
@@ -1345,9 +1284,7 @@ where
             _ => unreachable!(),
         };
 
-        let serialisation_format = self
-            .serialisation_format
-            .expect("Should already have a default value");
+        let serialisation_format = build_env.serialisation_format();
         // Note that the configuration types use associated consts, and thus these configurations represent distinct types.
         let (grm_data, stable_data): (Vec<u8>, Vec<u8>) = match serialisation_format {
             SerialisationFormat::FixedSizeInteger => {
@@ -1866,7 +1803,7 @@ where
 ///
 /// It is plausible that we should a step 4, but currently do not:
 /// 4. Replace all `\n{indent}\n` with `\n\n`
-fn indent(indent: &str, s: &str) -> String {
+pub(crate) fn indent(indent: &str, s: &str) -> String {
     format!("{indent}{}\n", s.trim_end_matches('\n')).replace('\n', &format!("\n{}", indent))
 }
 

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -30,7 +30,7 @@ use cfgrammar::{
     yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind, ast::ASTWithValidityInfo},
 };
 use filetime::FileTime;
-use lrtable::{Minimiser, StateGraph, StateTable, from_yacc, statetable::Conflicts};
+use lrtable::{StateGraph, StateTable, statetable::Conflicts};
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 use proc_macro2::{Literal, TokenStream};
 use quote::{ToTokens, TokenStreamExt, format_ident, quote};
@@ -51,12 +51,12 @@ pub(crate) const ERROR: &str = "[Error]";
 static GENERATED_PATHS: LazyLock<Mutex<HashSet<PathBuf>>> =
     LazyLock::new(|| Mutex::new(HashSet::new()));
 
-struct CTConflictsError<StorageT: Eq + Hash> {
-    conflicts_diagnostic: String,
+pub(crate) struct CTConflictsError<StorageT: Eq + Hash> {
+    pub(crate) conflicts_diagnostic: String,
     #[cfg(test)]
     #[cfg_attr(test, allow(dead_code))]
-    stable: StateTable<StorageT>,
-    phantom: PhantomData<StorageT>,
+    pub(crate) stable: StateTable<StorageT>,
+    pub(crate) phantom: PhantomData<StorageT>,
 }
 
 /// The quote impl of `ToTokens` for `Option` prints an empty string for `None`
@@ -367,9 +367,9 @@ where
 }
 
 /// Defaults to `wincode::int_encoding::VarInt`.
-type FixIntConfig = wincode::config::Configuration;
+pub(crate) type FixIntConfig = wincode::config::Configuration;
 /// The default config with the last parameter set to `VarInt`
-type VarIntConfig = wincode::config::Configuration<
+pub(crate) type VarIntConfig = wincode::config::Configuration<
     true,
     4194304,
     wincode::len::BincodeLen,
@@ -768,30 +768,16 @@ where
                 }
             }
         }
-        let grm = match YaccGrammar::<StorageT>::new_from_ast_with_validity_info(
-            build_env.ast_with_validity_info(),
-        ) {
-            Ok(grm) => grm,
-            Err(errs) => {
-                let mut out = String::new();
-                out.push_str(&format!(
-                    "\n{ERROR}{}\n",
-                    src_env.yacc_diag().file_location_msg("", None)
-                ));
-                for e in errs {
-                    out.push_str(&indent(
-                        "     ",
-                        &src_env.yacc_diag().format_error(e).to_string(),
-                    ));
-                    out.push('\n');
-                }
-                return Err(ErrorString(out).into());
-            }
-        };
+
         #[cfg(test)]
         if let Some(cb) = &self.inspect_callback {
             cb(build_env.recoverer())?;
         }
+
+        let timestamp = env!("VERGEN_BUILD_TIMESTAMP");
+        let code_gen = build_env.code_generator(&src_env, timestamp)?;
+        let grm = code_gen.grm();
+        let stable = code_gen.stable();
 
         let rule_ids = grm
             .tokens_map()
@@ -799,7 +785,7 @@ where
             .map(|(&n, &i)| (n.to_owned(), i.as_storaget()))
             .collect::<HashMap<_, _>>();
 
-        let cache = self.rebuild_cache(build_env.derived_mod_name(), &grm);
+        let cache = self.rebuild_cache(build_env.derived_mod_name(), grm);
 
         // We don't need to go through the full rigmarole of generating an output file if all of
         // the following are true: the output file exists; it is newer than the input file; and the
@@ -814,7 +800,10 @@ where
                 > FileTime::from_last_modification_time(inmd)
             && let Ok(outc) = read_to_string(outp)
         {
+
             if outc.contains(&cache.to_string()) {
+                let (grm, _, _) = code_gen.finish();
+
                 return Ok(CTParser {
                     regenerated: false,
                     rule_ids,
@@ -842,36 +831,8 @@ where
         // confusing than the alternatives).
         fs::remove_file(outp).ok();
 
-        let (sgraph, stable) = from_yacc(&grm, Minimiser::Pager)?;
-        if self.error_on_conflicts
-            && let Some(c) = stable.conflicts()
-        {
-            match (grm.expect(), grm.expectrr()) {
-                (Some(i), Some(j)) if i == c.sr_len() && j == c.rr_len() => (),
-                (Some(i), None) if i == c.sr_len() && 0 == c.rr_len() => (),
-                (None, Some(j)) if 0 == c.sr_len() && j == c.rr_len() => (),
-                (None, None) if 0 == c.rr_len() && 0 == c.sr_len() => (),
-                _ => {
-                    let conflicts_diagnostic = src_env.yacc_diag().format_conflicts::<LexerTypesT>(
-                        &grm,
-                        build_env.ast_with_validity_info().ast(),
-                        c,
-                        &sgraph,
-                        &stable,
-                    );
-                    return Err(Box::new(CTConflictsError {
-                        conflicts_diagnostic,
-                        phantom: PhantomData,
-                        #[cfg(test)]
-                        stable,
-                    }));
-                }
-            }
-        }
-
         if let Some(ref mut inspector_rt) = self.inspect_rt {
-            let rt: RTParserBuilder<'_, StorageT, LexerTypesT> =
-                RTParserBuilder::new(&grm, &stable);
+            let rt: RTParserBuilder<'_, StorageT, LexerTypesT> = RTParserBuilder::new(grm, stable);
             let rt = if let Some(rk) = self.recoverer {
                 rt.recoverer(rk)
             } else {
@@ -883,14 +844,15 @@ where
         src_env.check_unused_header_keys()?;
 
         self.output_file(
-            &grm,
-            &stable,
+            grm,
+            stable,
             build_env.derived_mod_name(),
             outp,
             &format!("/* CACHE INFORMATION {} */\n", cache),
             src_env.yacc_diag(),
             &build_env,
         )?;
+        let (grm, sgraph, stable) = code_gen.finish();
         let conflicts = if stable.conflicts().is_some() {
             Some((sgraph, stable))
         } else {

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -26,7 +26,7 @@ use cfgrammar::{
     Location,
     header::{Header, HeaderError, HeaderErrorKind, HeaderValue, Namespaced, Setting, Value},
     markmap::{Entry, MergeBehavior},
-    yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind, ast::ASTWithValidityInfo},
+    yacc::{YaccGrammar, YaccKind, ast::ASTWithValidityInfo},
 };
 use filetime::FileTime;
 use lrtable::{StateGraph, StateTable, statetable::Conflicts};
@@ -879,77 +879,7 @@ where
         src_env: &ParserSrcEnv,
         build_env: &ParserBuildEnv<'_, LexerTypesT>,
     ) -> Result<(), Box<dyn Error>> {
-        let mod_name = build_env.derived_mod_name();
-        let visibility = build_env.visibility();
-        let user_actions = if let YaccKind::Original(YaccOriginalActionKind::UserAction)
-        | YaccKind::Grmtools = build_env.yacc_kind()
-        {
-            Some(code_gen.gen_user_actions(src_env)?)
-        } else {
-            None
-        };
-
-        let rule_consts = code_gen.gen_rule_consts()?;
-        let token_epp = code_gen.gen_token_epp()?;
-        let parse_function = code_gen.gen_parse_function(build_env)?;
-        let action_wrappers = match  build_env.yacc_kind()  {
-            YaccKind::Original(YaccOriginalActionKind::UserAction) | YaccKind::Grmtools => {
-                Some(code_gen.gen_wrappers(build_env)?)
-            }
-            YaccKind::Original(YaccOriginalActionKind::NoAction)
-            | YaccKind::Original(YaccOriginalActionKind::GenericParseTree) => None,
-            _ => unreachable!(),
-        };
-
-        let additional_decls = if let YaccKind::Original(YaccOriginalActionKind::GenericParseTree) =
-            build_env.yacc_kind()
-        {
-            // `lrpar::Node`` is deprecated within the lrpar crate, but not from within this module,
-            // Once it is removed from `lrpar`, we should move the declaration here entirely.
-            Some(quote! {
-                        #[allow(unused_imports)]
-                        pub use ::lrpar::parser::_deprecated_moved_::Node;
-            })
-        } else {
-            None
-        };
-
-        let mod_name =
-            match syn::parse_str::<proc_macro2::Ident>(mod_name) {
-                Ok(s) => s,
-                Err(e) => return Err(format!(
-                    "CTParserBuilder::mod_name(\"{}\") is not a valid rust identifier due to '{}'",
-                    mod_name, e
-                )
-                .into()),
-            };
-        let out_tokens = quote! {
-            #visibility mod #mod_name {
-                // At the top so that `user_actions` may contain #![inner_attribute]
-                #user_actions
-                mod _parser_ {
-                    #![allow(clippy::type_complexity)]
-                    #![allow(clippy::unnecessary_wraps)]
-                    #![deny(unsafe_code)]
-                    #[allow(unused_imports)]
-                    use super::*;
-                    #additional_decls
-                    #parse_function
-                    #rule_consts
-                    #token_epp
-                    #action_wrappers
-                } // End of `mod _parser_`
-                #[allow(unused_imports)]
-                pub use _parser_::*;
-                #[allow(unused_imports)]
-                use ::lrpar::Lexeme;
-            } // End of `mod #mod_name`
-        };
-        // Try and run a code formatter on the generated code.
-        let unformatted = out_tokens.to_string();
-        let outs = syn::parse_str(&unformatted)
-            .map(|syntax_tree| prettyplease::unparse(&syntax_tree))
-            .unwrap_or(unformatted);
+        let outs = code_gen.generate(src_env, build_env)?;
         let mut f = File::create(outp_rs)?;
         f.write_all(outs.as_bytes())?;
         f.write_all(cache.as_bytes())?;

--- a/lrpar/src/lib/mod.rs
+++ b/lrpar/src/lib/mod.rs
@@ -205,6 +205,8 @@ pub mod parser;
 #[cfg(test)]
 pub mod test_utils;
 
+mod codegen;
+
 pub use crate::{
     ctbuilder::{
         CTParser, CTParserBuilder, ParserData, RustEdition, SerialisationFormat, Visibility,


### PR DESCRIPTION
I think this is probably as reviewable as I'm going to manage to make this large of a patch.
The basic idea behind this patch is to have a kind of "functional pipeline", for doing code generation,

`(SrcEnv?, BuildEnvArgs) -> BuildEnv? -> Codegen(SrcEnv, BuildEnv) -> rust_code?`

A bit of an oversimplification, as there are some other minor details...

1. `BuildEnvArgs` is kind of a minimalist equivalent of the current builder, it's just full of `Option` values.
2. `BuildEnv` is full of `derived` values, it mostly strips off the `Option`, but it also contains values like `ASTWithValidityInfo` that are derived from all the other args.
3. `Codegen` then owns the `YaccGrammar`, `StateTable` and `StateGraphs`, which you can take ownership of after generating code.

This may not be totally perfect basis for traits and external usage, for example it currently returns `Box<dyn Error>` instead of typed errors. But it should be a pretty faithful conversion of the existing process, into a more targeted/self contained module.

