### PR TITLE
Update docs

### DIFF
--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -142,9 +142,7 @@ impl FromStr for ASTWithValidityInfo {
     }
 }
 
-/// An AST representing a grammar. This is built up gradually: when it is finished, the
-/// `complete_and_validate` must be called exactly once in order to finish the set-up. At that
-/// point, any further mutations made to the struct lead to undefined behaviour.
+/// An AST representing a grammar. Typically these will only be constructed through [`ASTWithValidityInfo`] struct.
 #[derive(Debug, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 #[non_exhaustive]


### PR DESCRIPTION
I noticed a few issues with the documentation for `GrammarAST`, while trying to figure out why the
`action_type` error is so late during codegen, rather than AST construction.

The referenced fn `complete_and_validate` is now private. While construction through `ASTWithValidityInfo` is read-only.

Edit: Since this was going to conflict with another PR, I moved the conflicting change to that other PR.

