### PR TITLE
Initial parsing of %user section as a `Header`.

### DIFF
--- a/cfgrammar/src/lib/header.rs
+++ b/cfgrammar/src/lib/header.rs
@@ -6,8 +6,11 @@ use crate::{
     },
 };
 use regex::{Regex, RegexBuilder};
-use std::{error::Error, fmt, sync::LazyLock,
-    collections::{HashSet, HashMap}
+use std::{
+    collections::{HashMap, HashSet},
+    error::Error,
+    fmt,
+    sync::LazyLock,
 };
 
 #[derive(Debug)]
@@ -15,7 +18,7 @@ use std::{error::Error, fmt, sync::LazyLock,
 pub struct FileHeaders {
     pub grmtools: Header<Span>,
     pub grmtools_span: Span,
-    pub user: Header<Span>,
+    pub user: HashMap<String, (Span, UserSectionValue)>,
     pub user_span: Span,
 }
 
@@ -80,6 +83,15 @@ pub enum HeaderErrorKind {
     DuplicateEntry,
     InvalidEntry(&'static str),
     ConversionError(&'static str, &'static str),
+    InvalidUserSectionValueType,
+}
+
+#[derive(Debug)]
+pub enum UserSectionValue {
+    String(String, Span),
+    Num(u64, Span),
+    Bool(bool, Span),
+    Array(Vec<UserSectionValue>, Span),
 }
 
 impl fmt::Display for HeaderErrorKind {
@@ -93,6 +105,9 @@ impl fmt::Display for HeaderErrorKind {
             }
             HeaderErrorKind::InvalidEntry(s) => &format!("Invalid entry: '{}'", s),
             HeaderErrorKind::DuplicateEntry => "Duplicate Entry",
+            HeaderErrorKind::InvalidUserSectionValueType => {
+                "Invalid value type for the %user section"
+            }
             HeaderErrorKind::ConversionError(t, err_str) => {
                 &format!("Converting header value to type '{}': {}", t, err_str)
             }
@@ -441,19 +456,89 @@ impl<'input> GrmtoolsSectionParser<'input> {
         }
 
         // When a default empty header is produced, we currently give it an empty span at (0, 0) for convenience
-        let (grmtools, grmtools_span) = headers.remove("%grmtools").unwrap_or_else(|| (Header::new(), Span::new(0, 0)));
-        let (user, user_span) = headers.remove("%user").unwrap_or_else(|| (Header::new(), Span::new(0, 0)));
-        eprintln!("{:?} {:?}", grmtools, user);
-        Ok((FileHeaders{
-            grmtools,
-            grmtools_span,
-            user,
-            user_span,
-        }, cur_pos))
+        let (grmtools, grmtools_span) = headers
+            .remove("%grmtools")
+            .unwrap_or_else(|| (Header::new(), Span::new(0, 0)));
+        let (user_header, user_span) = headers
+            .remove("%user")
+            .unwrap_or_else(|| (Header::new(), Span::new(0, 0)));
+        let mut user = HashMap::new();
+        let mut errs = Vec::new();
+        for (key, HeaderValue(key_span, value)) in user_header.into_iter() {
+            match value {
+                Value::Flag(flag, val_span) => {
+                    user.insert(
+                        key.clone(),
+                        (*key_span, UserSectionValue::Bool(*flag, *val_span)),
+                    );
+                }
+                Value::Setting(setting) => match setting {
+                    Setting::Array(v, start_span, _) => {
+                        let mut out = Vec::with_capacity(v.capacity());
+                        for val in v {
+                            match val {
+                                Setting::String(s, val_span) => {
+                                    out.push(UserSectionValue::String(s.clone(), *val_span))
+                                }
+                                Setting::Num(n, val_span) => {
+                                    out.push(UserSectionValue::Num(*n, *val_span))
+                                }
+                                _ => {
+                                    errs.push(HeaderError {
+                                        kind: HeaderErrorKind::InvalidUserSectionValueType,
+                                        locations: vec![*key_span],
+                                    });
+                                }
+                            }
+                        }
+                        user.insert(
+                            key.clone(),
+                            (*key_span, UserSectionValue::Array(out, *start_span)),
+                        );
+                    }
+                    Setting::String(s, val_span) => {
+                        user.insert(
+                            key.clone(),
+                            (*key_span, UserSectionValue::String(s.clone(), *val_span)),
+                        );
+                    }
+                    Setting::Num(n, val_span) => {
+                        user.insert(
+                            key.clone(),
+                            (*key_span, UserSectionValue::Num(*n, *val_span)),
+                        );
+
+                    }
+
+                    _ => {
+                        errs.push(HeaderError {
+                            kind: HeaderErrorKind::InvalidUserSectionValueType,
+                            locations: vec![*key_span],
+                        });
+                    }
+                },
+            }
+        }
+        if !errs.is_empty() {
+            return Err(errs);
+        }
+        Ok((
+            FileHeaders {
+                grmtools,
+                grmtools_span,
+                user,
+                user_span,
+            },
+            cur_pos,
+        ))
     }
 
     #[allow(clippy::type_complexity)]
-    pub fn parse_sections(&'_ self, start_pos: usize, sections: &HashSet<&'static str>) -> Result<(Option<(Header<Span>, &'static str)>, usize), Vec<HeaderError<Span>>> {
+    pub fn parse_sections(
+        &'_ self,
+        start_pos: usize,
+        sections: &HashSet<&'static str>,
+    ) -> Result<(Option<(Header<Span>, &'static str)>, usize), Vec<HeaderError<Span>>> {
         for magic_string in sections {
             let grmtools_required = self.required && magic_string == &"%grmtools";
             let mut errs = Vec::new();

--- a/cfgrammar/src/lib/header.rs
+++ b/cfgrammar/src/lib/header.rs
@@ -6,7 +6,18 @@ use crate::{
     },
 };
 use regex::{Regex, RegexBuilder};
-use std::{error::Error, fmt, sync::LazyLock};
+use std::{error::Error, fmt, sync::LazyLock,
+    collections::{HashSet, HashMap}
+};
+
+#[derive(Debug)]
+#[doc(hidden)]
+pub struct FileHeaders {
+    pub grmtools: Header<Span>,
+    pub grmtools_span: Span,
+    pub user: Header<Span>,
+    pub user_span: Span,
+}
 
 /// An error regarding the `%grmtools` header section.
 ///
@@ -239,15 +250,13 @@ impl<T> Namespaced<T> {
 static RE_LEADING_WS: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^[\p{Pattern_White_Space}]*").unwrap());
 static RE_NAME: LazyLock<Regex> = LazyLock::new(|| {
-    RegexBuilder::new(r"^[A-Z][A-Z_]*")
+    RegexBuilder::new(r"^[A-Z][A-Z_\.]*")
         .case_insensitive(true)
         .build()
         .unwrap()
 });
 static RE_DIGITS: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[0-9]+").unwrap());
 static RE_STRING: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"^\"(\\.|[^"\\])*\""#).unwrap());
-
-const MAGIC: &str = "%grmtools";
 
 fn add_duplicate_occurrence<T: Eq + PartialEq + Clone>(
     errs: &mut Vec<HeaderError<T>>,
@@ -418,83 +427,110 @@ impl<'input> GrmtoolsSectionParser<'input> {
         Self { src, required }
     }
 
+    pub fn parse(&'_ self) -> Result<(FileHeaders, usize), Vec<HeaderError<Span>>> {
+        let mut sections_lookup = HashSet::from_iter(["%grmtools", "%user"]);
+        let mut cur_pos = 0;
+        let mut headers: HashMap<&'static str, (Header<Span>, Span)> = HashMap::new();
+        // This will error when a duplicate section is encountered, but only in a round about fashion.
+        // Because we remove the section from `sections_lookup`, the next go around it'll be unrecognized.
+        // As such, it's likely to be an `unrecognized declaration` instead of a nicer error.
+        while let (Some((header, section)), pos) = self.parse_sections(cur_pos, &sections_lookup)? {
+            sections_lookup.remove(section);
+            headers.insert(section, (header, Span::new(cur_pos, pos)));
+            cur_pos = pos;
+        }
+
+        // When a default empty header is produced, we currently give it an empty span at (0, 0) for convenience
+        let (grmtools, grmtools_span) = headers.remove("%grmtools").unwrap_or_else(|| (Header::new(), Span::new(0, 0)));
+        let (user, user_span) = headers.remove("%user").unwrap_or_else(|| (Header::new(), Span::new(0, 0)));
+        eprintln!("{:?} {:?}", grmtools, user);
+        Ok((FileHeaders{
+            grmtools,
+            grmtools_span,
+            user,
+            user_span,
+        }, cur_pos))
+    }
+
     #[allow(clippy::type_complexity)]
-    pub fn parse(&'_ self) -> Result<(Header<Span>, usize), Vec<HeaderError<Span>>> {
-        let mut errs = Vec::new();
-        if let Some(mut i) = self.lookahead_is(MAGIC, self.parse_ws(0)) {
-            let mut ret = Header::new();
-            i = self.parse_ws(i);
-            let section_start_pos = i;
-            if let Some(j) = self.lookahead_is("{", i) {
-                i = self.parse_ws(j);
-                while self.lookahead_is("}", i).is_none() && i < self.src.len() {
-                    let (key, key_loc, val, j) = match self.parse_key_value(i) {
-                        Ok((key, key_loc, val, pos)) => (key, key_loc, val, pos),
-                        Err(e) => {
-                            errs.push(e);
+    pub fn parse_sections(&'_ self, start_pos: usize, sections: &HashSet<&'static str>) -> Result<(Option<(Header<Span>, &'static str)>, usize), Vec<HeaderError<Span>>> {
+        for magic_string in sections {
+            let grmtools_required = self.required && magic_string == &"%grmtools";
+            let mut errs = Vec::new();
+            if let Some(mut i) = self.lookahead_is(magic_string, self.parse_ws(start_pos)) {
+                let mut ret = Header::new();
+                i = self.parse_ws(i);
+                let section_start_pos = i;
+                if let Some(j) = self.lookahead_is("{", i) {
+                    i = self.parse_ws(j);
+                    while self.lookahead_is("}", i).is_none() && i < self.src.len() {
+                        let (key, key_loc, val, j) = match self.parse_key_value(i) {
+                            Ok((key, key_loc, val, pos)) => (key, key_loc, val, pos),
+                            Err(e) => {
+                                errs.push(e);
+                                return Err(errs);
+                            }
+                        };
+                        match ret.entry(key) {
+                            Entry::Occupied(orig) => {
+                                let HeaderValue(orig_loc, _): &HeaderValue<Span> = orig.get();
+                                add_duplicate_occurrence(
+                                    &mut errs,
+                                    HeaderErrorKind::DuplicateEntry,
+                                    *orig_loc,
+                                    key_loc,
+                                )
+                            }
+                            Entry::Vacant(entry) => {
+                                entry.insert(HeaderValue(key_loc, val));
+                            }
+                        }
+                        if let Some(j) = self.lookahead_is(",", j) {
+                            i = self.parse_ws(j);
+                            continue;
+                        } else {
+                            i = self.parse_ws(j);
+                            break;
+                        }
+                    }
+                    if let Some(j) = self.lookahead_is("*", i) {
+                        errs.push(HeaderError {
+                            kind: HeaderErrorKind::UnexpectedToken(
+                                '*',
+                                "perhaps this is a glob, in which case it requires string quoting.",
+                            ),
+                            locations: vec![Span::new(i, j)],
+                        });
+                        return Err(errs);
+                    } else if let Some(i) = self.lookahead_is("}", i) {
+                        if errs.is_empty() {
+                            return Ok((Some((ret, magic_string)), i));
+                        } else {
                             return Err(errs);
                         }
-                    };
-                    match ret.entry(key) {
-                        Entry::Occupied(orig) => {
-                            let HeaderValue(orig_loc, _): &HeaderValue<Span> = orig.get();
-                            add_duplicate_occurrence(
-                                &mut errs,
-                                HeaderErrorKind::DuplicateEntry,
-                                *orig_loc,
-                                key_loc,
-                            )
-                        }
-                        Entry::Vacant(entry) => {
-                            entry.insert(HeaderValue(key_loc, val));
-                        }
-                    }
-                    if let Some(j) = self.lookahead_is(",", j) {
-                        i = self.parse_ws(j);
-                        continue;
                     } else {
-                        i = self.parse_ws(j);
-                        break;
-                    }
-                }
-                if let Some(j) = self.lookahead_is("*", i) {
-                    errs.push(HeaderError {
-                        kind: HeaderErrorKind::UnexpectedToken(
-                            '*',
-                            "perhaps this is a glob, in which case it requires string quoting.",
-                        ),
-                        locations: vec![Span::new(i, j)],
-                    });
-                    Err(errs)
-                } else if let Some(i) = self.lookahead_is("}", i) {
-                    if errs.is_empty() {
-                        Ok((ret, i))
-                    } else {
-                        Err(errs)
+                        errs.push(HeaderError {
+                            kind: HeaderErrorKind::ExpectedToken('}'),
+                            locations: vec![Span::new(section_start_pos, i)],
+                        });
+                        return Err(errs);
                     }
                 } else {
                     errs.push(HeaderError {
-                        kind: HeaderErrorKind::ExpectedToken('}'),
-                        locations: vec![Span::new(section_start_pos, i)],
+                        kind: HeaderErrorKind::ExpectedToken('{'),
+                        locations: vec![Span::new(i, i)],
                     });
-                    Err(errs)
+                    return Err(errs);
                 }
-            } else {
+            } else if grmtools_required {
                 errs.push(HeaderError {
-                    kind: HeaderErrorKind::ExpectedToken('{'),
-                    locations: vec![Span::new(i, i)],
+                    kind: HeaderErrorKind::MissingGrmtoolsSection,
+                    locations: vec![Span::new(0, 0)],
                 });
-                Err(errs)
+                return Err(errs);
             }
-        } else if self.required {
-            errs.push(HeaderError {
-                kind: HeaderErrorKind::MissingGrmtoolsSection,
-                locations: vec![Span::new(0, 0)],
-            });
-            Err(errs)
-        } else {
-            Ok((Header::new(), 0))
         }
+        Ok((None, start_pos))
     }
 
     fn parse_name(&self, i: usize) -> Result<(String, usize), HeaderError<Span>> {
@@ -755,12 +791,12 @@ mod test {
             let res = parser.parse();
             let errs = res.unwrap_err();
             assert_eq!(errs.len(), 1);
-            match errs[0] {
+            match &errs[0] {
                 HeaderError {
                     kind: HeaderErrorKind::UnexpectedToken('*', _),
                     locations: _,
                 } => (),
-                _ => panic!("Expected glob specific error"),
+                e => panic!("Expected glob specific error got '{e}'"),
             }
         }
     }

--- a/cfgrammar/src/lib/header.rs
+++ b/cfgrammar/src/lib/header.rs
@@ -18,8 +18,8 @@ use std::{
 pub struct FileHeaders {
     pub grmtools: Header<Span>,
     pub grmtools_span: Span,
-    pub user: HashMap<String, (Span, UserSectionValue)>,
-    pub user_span: Span,
+    pub user_section: HashMap<String, (Span, UserSectionValue)>,
+    pub user_section_span: Span,
 }
 
 /// An error regarding the `%grmtools` header section.
@@ -86,7 +86,7 @@ pub enum HeaderErrorKind {
     InvalidUserSectionValueType,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum UserSectionValue {
     String(String, Span),
     Num(u64, Span),
@@ -459,15 +459,15 @@ impl<'input> GrmtoolsSectionParser<'input> {
         let (grmtools, grmtools_span) = headers
             .remove("%grmtools")
             .unwrap_or_else(|| (Header::new(), Span::new(0, 0)));
-        let (user_header, user_span) = headers
+        let (user_header, user_section_span) = headers
             .remove("%user")
             .unwrap_or_else(|| (Header::new(), Span::new(0, 0)));
-        let mut user = HashMap::new();
+        let mut user_section = HashMap::new();
         let mut errs = Vec::new();
         for (key, HeaderValue(key_span, value)) in user_header.into_iter() {
             match value {
                 Value::Flag(flag, val_span) => {
-                    user.insert(
+                    user_section.insert(
                         key.clone(),
                         (*key_span, UserSectionValue::Bool(*flag, *val_span)),
                     );
@@ -491,23 +491,22 @@ impl<'input> GrmtoolsSectionParser<'input> {
                                 }
                             }
                         }
-                        user.insert(
+                        user_section.insert(
                             key.clone(),
                             (*key_span, UserSectionValue::Array(out, *start_span)),
                         );
                     }
                     Setting::String(s, val_span) => {
-                        user.insert(
+                        user_section.insert(
                             key.clone(),
                             (*key_span, UserSectionValue::String(s.clone(), *val_span)),
                         );
                     }
                     Setting::Num(n, val_span) => {
-                        user.insert(
+                        user_section.insert(
                             key.clone(),
                             (*key_span, UserSectionValue::Num(*n, *val_span)),
                         );
-
                     }
 
                     _ => {
@@ -526,8 +525,8 @@ impl<'input> GrmtoolsSectionParser<'input> {
             FileHeaders {
                 grmtools,
                 grmtools_span,
-                user,
-                user_span,
+                user_section,
+                user_section_span,
             },
             cur_pos,
         ))

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -118,7 +118,7 @@ impl FromStr for ASTWithValidityInfo {
         let (header, _) = GrmtoolsSectionParser::new(src, true)
             .parse()
             .map_err(|mut errs| errs.drain(..).map(|e| e.into()).collect::<Vec<_>>())?;
-        if let Some(HeaderValue(_, yk_val)) = header.get("yacckind") {
+        if let Some(HeaderValue(_, yk_val)) = header.grmtools.get("yacckind") {
             let yacc_kind = YaccKind::try_from(yk_val).map_err(|e| vec![e.into()])?;
             let ast = {
                 // We don't want to strip off the header so that span's will be correct.

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -13,9 +13,7 @@ use super::{
 };
 
 use crate::{
-    Span,
-    header::{GrmtoolsSectionParser, HeaderError, HeaderErrorKind, HeaderValue},
-    yacc::YaccOriginalActionKind,
+    Span, header::{GrmtoolsSectionParser, HeaderError, HeaderErrorKind, HeaderValue, UserSectionValue}, yacc::YaccOriginalActionKind,
 };
 
 /// Any error from the Yacc parser returns an instance of this struct.
@@ -178,6 +176,7 @@ pub struct GrammarAST {
     // The set of symbol names that, if unused in a
     // grammar, will not cause a warning or error.
     pub expect_unused: Vec<Symbol>,
+    pub user_section: HashMap<String, (Span, UserSectionValue)>,
 }
 
 #[derive(Debug, Clone)]
@@ -255,6 +254,7 @@ impl GrammarAST {
             parse_generics: None,
             programs: None,
             expect_unused: Vec::new(),
+            user_section: HashMap::new(),
         }
     }
 
@@ -983,5 +983,56 @@ start -> () : "a" {$;;;; };
                 spans: vec![Span::new(32, 33)],
             }]
         );
+    }
+
+        #[test]
+    fn test_user_section() {
+        use super::*;
+        let ast_validity = ASTWithValidityInfo::new(
+            YaccKind::Grmtools,
+            r#"
+%user {
+   flag,
+   !negative,
+   string: "foo",
+   vec: ["a", "b"],
+   num: 0,
+}
+%token a
+%%
+start -> () : "a" { () };
+"#,
+        );
+
+        if let Some((_, UserSectionValue::Bool(true, _))) = ast_validity.ast().user_section.get("flag") {
+        } else {
+            panic!("Expected true flag");
+        }
+
+        if let Some((_, UserSectionValue::Bool(false, _))) = ast_validity.ast().user_section.get("negative") {
+        }    else {
+            panic!("Expected false flag");
+        }
+
+        if let Some((_, UserSectionValue::String(s, _))) = ast_validity.ast().user_section.get("string") {
+            assert_eq!(s, "foo");
+        } else {
+            panic!("Expected string");
+        }
+        if let Some((_, UserSectionValue::Array(arr, _))) = ast_validity.ast().user_section.get("vec") {
+            let string_vals = arr.iter().cloned().map(|s| match s {
+                UserSectionValue::String(s, _) => s,
+                _ => panic!("Expected string"),
+            }).collect::<Vec<String>>();
+            assert_eq!(string_vals, vec!["a".to_string(), "b".to_string()]);
+        } else {
+            panic!("Expected vec of strings");
+        }
+
+        if let Some((_, UserSectionValue::Num(n, _))) = ast_validity.ast().user_section.get("num") {
+            assert_eq!(*n, 0);
+        } else {
+            panic!("Expected numeric");
+        }
     }
 }

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -13,7 +13,9 @@ use super::{
 };
 
 use crate::{
-    Span, header::{GrmtoolsSectionParser, HeaderError, HeaderErrorKind, HeaderValue, UserSectionValue}, yacc::YaccOriginalActionKind,
+    Span,
+    header::{GrmtoolsSectionParser, HeaderError, HeaderErrorKind, HeaderValue, UserSectionValue},
+    yacc::YaccOriginalActionKind,
 };
 
 /// Any error from the Yacc parser returns an instance of this struct.
@@ -985,7 +987,7 @@ start -> () : "a" {$;;;; };
         );
     }
 
-        #[test]
+    #[test]
     fn test_user_section() {
         use super::*;
         let ast_validity = ASTWithValidityInfo::new(
@@ -1004,26 +1006,38 @@ start -> () : "a" { () };
 "#,
         );
 
-        if let Some((_, UserSectionValue::Bool(true, _))) = ast_validity.ast().user_section.get("flag") {
+        if let Some((_, UserSectionValue::Bool(true, _))) =
+            ast_validity.ast().user_section.get("flag")
+        {
         } else {
             panic!("Expected true flag");
         }
 
-        if let Some((_, UserSectionValue::Bool(false, _))) = ast_validity.ast().user_section.get("negative") {
-        }    else {
+        if let Some((_, UserSectionValue::Bool(false, _))) =
+            ast_validity.ast().user_section.get("negative")
+        {
+        } else {
             panic!("Expected false flag");
         }
 
-        if let Some((_, UserSectionValue::String(s, _))) = ast_validity.ast().user_section.get("string") {
+        if let Some((_, UserSectionValue::String(s, _))) =
+            ast_validity.ast().user_section.get("string")
+        {
             assert_eq!(s, "foo");
         } else {
             panic!("Expected string");
         }
-        if let Some((_, UserSectionValue::Array(arr, _))) = ast_validity.ast().user_section.get("vec") {
-            let string_vals = arr.iter().cloned().map(|s| match s {
-                UserSectionValue::String(s, _) => s,
-                _ => panic!("Expected string"),
-            }).collect::<Vec<String>>();
+        if let Some((_, UserSectionValue::Array(arr, _))) =
+            ast_validity.ast().user_section.get("vec")
+        {
+            let string_vals = arr
+                .iter()
+                .cloned()
+                .map(|s| match s {
+                    UserSectionValue::String(s, _) => s,
+                    _ => panic!("Expected string"),
+                })
+                .collect::<Vec<String>>();
             assert_eq!(string_vals, vec!["a".to_string(), "b".to_string()]);
         } else {
             panic!("Expected vec of strings");

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -337,9 +337,10 @@ impl YaccParser<'_> {
 
     pub(crate) fn parse(&mut self) -> YaccGrammarResult<usize> {
         let mut errs = Vec::new();
-        let (_, pos) = GrmtoolsSectionParser::new(self.src, false)
+        let (headers, pos) = GrmtoolsSectionParser::new(self.src, false)
             .parse()
             .map_err(|mut errs| errs.drain(..).map(|e| e.into()).collect::<Vec<_>>())?;
+        self.ast.user_section = headers.user_section;
         // We pass around an index into the *bytes* of self.src. We guarantee that at all times
         // this points to the beginning of a UTF-8 character (since multibyte characters exist, not
         // every byte within the string is also a valid character).

--- a/lrlex/src/lib/ctbuilder.rs
+++ b/lrlex/src/lib/ctbuilder.rs
@@ -511,7 +511,7 @@ where
                 }
                 ErrorString(out)
             })?;
-        header.merge_from(parsed_header)?;
+        header.merge_from(parsed_header.grmtools)?;
         header.mark_used(&"lexerkind".to_string());
         let lexerkind = match self.lexerkind {
             Some(lexerkind) => lexerkind,

--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -9,7 +9,10 @@ use std::{
 
 use cfgrammar::{
     NewlineCache, Span,
-    header::{GrmtoolsSectionParser, Header, HeaderError, HeaderErrorKind, HeaderValue, Value},
+    header::{
+        GrmtoolsSectionParser, Header, HeaderError, HeaderErrorKind, HeaderValue, UserSectionValue,
+        Value,
+    },
     span::Location,
 };
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
@@ -399,6 +402,7 @@ where
     start_states: Vec<StartState>,
     lex_flags: LexFlags,
     pub(crate) expected_missing_tokens: Vec<String>,
+    user_section: HashMap<String, (Span, UserSectionValue)>,
     phantom: PhantomData<LexerTypesT>,
 }
 
@@ -416,6 +420,7 @@ where
             start_states,
             lex_flags: DEFAULT_LEX_FLAGS,
             expected_missing_tokens: vec![],
+            user_section: HashMap::new(),
             phantom: PhantomData,
         }
     }
@@ -433,6 +438,7 @@ where
                 start_states: p.start_states,
                 lex_flags: flags,
                 expected_missing_tokens: p.expected_missing_tokens,
+                user_section: header.user_section,
                 phantom: PhantomData,
             }
         })
@@ -544,13 +550,14 @@ where
         s: &str,
         lex_flags: LexFlags,
     ) -> LexBuildResult<LRNonStreamingLexerDef<LexerTypesT>> {
-        let (_, pos) = GrmtoolsSectionParser::new(s, false).parse().unwrap();
+        let (header, pos) = GrmtoolsSectionParser::new(s, false).parse().unwrap();
         LexParser::<LexerTypesT>::new_with_lex_flags(s[pos..].to_string(), lex_flags.clone()).map(
             |p| LRNonStreamingLexerDef {
                 rules: p.rules,
                 start_states: p.start_states,
                 lex_flags,
                 expected_missing_tokens: p.expected_missing_tokens,
+                user_section: header.user_section,
                 phantom: PhantomData,
             },
         )
@@ -680,6 +687,10 @@ where
     /// after all forced and default flags have been resolved.
     pub(crate) fn lex_flags(&self) -> Option<&LexFlags> {
         Some(&self.lex_flags)
+    }
+
+    pub fn user_section(&self) -> &HashMap<String, (Span, UserSectionValue)> {
+        &self.user_section
     }
 }
 

--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -426,7 +426,7 @@ where
         let (mut header, pos) = GrmtoolsSectionParser::new(s, false)
             .parse()
             .map_err(|mut errs| errs.drain(..).map(LexBuildError::from).collect::<Vec<_>>())?;
-        let flags = LexFlags::try_from(&mut header).map_err(|e| vec![e.into()])?;
+        let flags = LexFlags::try_from(&mut header.grmtools).map_err(|e| vec![e.into()])?;
         LexParser::<LexerTypesT>::new_with_lex_flags(s[pos..].to_string(), flags.clone()).map(|p| {
             LRNonStreamingLexerDef {
                 rules: p.rules,

--- a/lrlex/src/lib/parser.rs
+++ b/lrlex/src/lib/parser.rs
@@ -1885,4 +1885,56 @@ b "A"
             assert_eq!(expected, trimmed)
         }
     }
+
+    #[test]
+    fn test_user_section() {
+        use cfgrammar::header::UserSectionValue;
+        let src = r#"
+%user {
+   flag,
+   !negative,
+   string: "foo",
+   vec: ["a", "b"],
+   num: 0,
+}
+%%
+. 'dot'
+"#;
+        let lexerdef = LRNonStreamingLexerDef::<DefaultLexerTypes<u8>>::from_str(src).unwrap();
+        if let Some((_, UserSectionValue::Bool(true, _))) = lexerdef.user_section().get("flag") {
+        } else {
+            panic!("Expected true flag");
+        }
+
+        if let Some((_, UserSectionValue::Bool(false, _))) = lexerdef.user_section().get("negative")
+        {
+        } else {
+            panic!("Expected false flag");
+        }
+
+        if let Some((_, UserSectionValue::String(s, _))) = lexerdef.user_section().get("string") {
+            assert_eq!(s, "foo");
+        } else {
+            panic!("Expected string");
+        }
+        if let Some((_, UserSectionValue::Array(arr, _))) = lexerdef.user_section().get("vec") {
+            let string_vals = arr
+                .iter()
+                .cloned()
+                .map(|s| match s {
+                    UserSectionValue::String(s, _) => s,
+                    _ => panic!("Expected string"),
+                })
+                .collect::<Vec<String>>();
+            assert_eq!(string_vals, vec!["a".to_string(), "b".to_string()]);
+        } else {
+            panic!("Expected vec of strings");
+        }
+
+        if let Some((_, UserSectionValue::Num(n, _))) = lexerdef.user_section().get("num") {
+            assert_eq!(*n, 0);
+        } else {
+            panic!("Expected numeric");
+        }
+    }
 }

--- a/lrlex/src/main.rs
+++ b/lrlex/src/main.rs
@@ -82,7 +82,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let lex_l_path = &matches.free[0];
     let lex_src = read_file(lex_l_path);
     let lex_diag = SpannedDiagnosticFormatter::new(&lex_src, Path::new(lex_l_path));
-    let (mut header, _) = match GrmtoolsSectionParser::new(&lex_src, false).parse() {
+    let (header, _) = match GrmtoolsSectionParser::new(&lex_src, false).parse() {
         Ok(x) => x,
         Err(es) => {
             eprintln!(
@@ -95,6 +95,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             process::exit(1);
         }
     };
+    let mut header = header.grmtools;
     header.mark_used(&"lexerkind".to_string());
     let lexerkind = if let Some(HeaderValue(_, lk_val)) = header.get("lexerkind") {
         LexerKind::try_from(lk_val)?

--- a/lrpar/cttests/src/grmtools_section.test
+++ b/lrpar/cttests/src/grmtools_section.test
@@ -4,11 +4,15 @@ grammar: |
         recoverer: RecoveryKind::CPCTPlus,
         test_files: ["*.input_grmtools_section"]
     }
-    %token MAGIC IDENT NUM STRING
-    %epp MAGIC "%grmtools"
+    %token IDENT NUM STRING
     %%
     start -> Result<Header<Span>, Vec<HeaderError<Span>>>
     : MAGIC '{' contents '}' { $3 }
+    ;
+
+    MAGIC -> ()
+    : '%grmtools' { () }
+    | '%user' { () }
     ;
 
     contents -> Result<Header<Span>, Vec<HeaderError<Span>>>
@@ -151,7 +155,8 @@ grammar: |
 lexer: |
     %grmtools{case_insensitive}
     %%
-    %grmtools 'MAGIC'
+    %grmtools '%grmtools'
+    %user '%user'
     ! '!'
     [A-Z][A-Z_]* 'IDENT'
     [0-9]+ 'NUM'

--- a/lrpar/cttests/src/lib.rs
+++ b/lrpar/cttests/src/lib.rs
@@ -389,7 +389,7 @@ fn test_grmtools_section_files() {
             let (yacc_parsed, errs) = grmtools_section_y::parse(&l);
             let parser = cfgrammar::header::GrmtoolsSectionParser::new(&s, true);
             let (header_parsed, _) = parser.parse().unwrap();
-            assert_eq!(yacc_parsed.unwrap().unwrap(), header_parsed);
+            assert_eq!(yacc_parsed.unwrap().unwrap(), header_parsed.grmtools);
             assert!(errs.is_empty());
         }
     }
@@ -428,7 +428,7 @@ fn test_grmtools_section_strings() {
         let yacc_parsed = yacc_parsed.unwrap().unwrap();
         let parser = cfgrammar::header::GrmtoolsSectionParser::new(src, true);
         let (header_parsed, _) = parser.parse().unwrap();
-        assert_eq!(yacc_parsed, header_parsed);
+        assert_eq!(yacc_parsed, header_parsed.grmtools);
         assert!(errs.is_empty());
     }
 }

--- a/lrpar/cttests/src/user_section.test
+++ b/lrpar/cttests/src/user_section.test
@@ -1,7 +1,13 @@
 vname: Test %user section
 grammar: |
     %grmtools {yacckind: Original(UserAction), recoverer: RecoveryKind::None}
-    %user {test.anything: "foo"}
+    %user {
+        test.anything: "foo",
+        test.flag,
+        !flag,
+        num: 5,
+        globs: ["*.foo", "*.bar"],
+    }
     %start Expr
     %actiontype Result<u64, ()>
     %avoid_insert 'INT'

--- a/lrpar/cttests/src/user_section.test
+++ b/lrpar/cttests/src/user_section.test
@@ -1,0 +1,40 @@
+vname: Test %user section
+grammar: |
+    %grmtools {yacckind: Original(UserAction), recoverer: RecoveryKind::None}
+    %user {test.anything: "foo"}
+    %start Expr
+    %actiontype Result<u64, ()>
+    %avoid_insert 'INT'
+    %%
+    Expr: Expr '+' Term { Ok($1? + $3?) }
+        | Term { $1 }
+        ;
+
+    Term: Term '*' Factor { Ok($1? * $3?) }
+        | Factor { $1 }
+        ;
+
+    Factor: '(' Expr ')' { $2 }
+          | 'INT' {
+                let l = $1.map_err(|_| ())?;
+                match $lexer.span_str(l.span()).parse::<u64>() {
+                    Ok(v) => Ok(v),
+                    Err(_) => {
+                        let ((_, col), _) = $lexer.line_col(l.span());
+                        eprintln!("Error at column {}: '{}' cannot be represented as a u64",
+                                  col,
+                                  $lexer.span_str(l.span()));
+                        Err(())
+                    }
+                }
+            }
+          ;
+
+lexer: |
+    %%
+    [0-9]+ "INT"
+    \+ "+"
+    \* "*"
+    \( "("
+    \) ")"
+    [\t ]+ ;

--- a/lrpar/src/lib/codegen.rs
+++ b/lrpar/src/lib/codegen.rs
@@ -301,7 +301,8 @@ where
     }
 
     fn parse_header(&self) -> Result<(Header<Span>, usize), Vec<HeaderError<Span>>> {
-        GrmtoolsSectionParser::new(self.src, false).parse()
+        let (headers, pos) = GrmtoolsSectionParser::new(self.src, false).parse()?;
+        Ok((headers.grmtools, pos))
     }
 
     /// Looks up the `yacckind` field from the header, marks the field

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -242,7 +242,7 @@ fn main() {
         match parsed_header {
             Ok((parsed_header, _)) => {
                 header
-                    .merge_from(parsed_header)
+                    .merge_from(parsed_header.grmtools)
                     .expect("Specified merge behavior cannot fail");
             }
             Err(errs) => {


### PR DESCRIPTION
This still needs some work, but is an initial attempt at a `%user` section we can parse by reusing the `%grmtools` section parser, then restrict the types within it as a post processing stage.

In a subsequent patch we can iterate over the `%user` section and convert it into a nicer to use `HashMap`. Throwing invalid value errors on the more rust-like constructs available via `HeaderValue`

This is also currently missing any way to access the information from the section.