### PR TITLE
Mark codegen enums non_exhaustive

### DIFF
--- a/lrlex/src/lib/codegen.rs
+++ b/lrlex/src/lib/codegen.rs
@@ -21,6 +21,7 @@ use std::{
 static RE_TOKEN_ID: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^[a-zA-Z_][a-zA-Z_0-9]*$").unwrap());
 
+#[non_exhaustive]
 pub(crate) enum LexerSrcEnvError {
     GrmtoolsSectionParseError(Vec<HeaderError<Span>>),
     GrmtoolsSectionMergeError(MergeError<String, Box<HeaderValue<Location>>>),
@@ -229,6 +230,7 @@ where
     }
 }
 
+#[non_exhaustive]
 pub(crate) enum LexerBuildEnvError {}
 
 impl fmt::Display for LexerBuildEnvError {
@@ -279,6 +281,7 @@ where
     }
 }
 
+#[non_exhaustive]
 pub(crate) enum LexerCodegenError {
     InvalidRustIdentifierModName { mod_name: String, error: syn::Error },
 }

--- a/lrpar/src/lib/codegen.rs
+++ b/lrpar/src/lib/codegen.rs
@@ -32,6 +32,7 @@ const ACTIONS_KIND: &str = "__GtActionsKind";
 const ACTIONS_KIND_PREFIX: &str = "Ak";
 const ACTIONS_KIND_HIDDEN: &str = "__GtActionsKindHidden";
 
+#[non_exhaustive]
 pub(crate) enum ParserSrcEnvError {
     GrmtoolsSectionParseError(Vec<HeaderError<Span>>),
     GrmtoolsSectionMergeError(MergeError<String, Box<HeaderValue<Location>>>),
@@ -40,6 +41,7 @@ pub(crate) enum ParserSrcEnvError {
     MissingModName,
 }
 
+#[non_exhaustive]
 pub(crate) enum ParserBuildEnvError<LexerTypesT>
 where
     LexerTypesT: LexerTypes,
@@ -51,6 +53,7 @@ where
     GrmtoolsSectionMissingRequiredKeys(Vec<String>),
 }
 
+#[non_exhaustive]
 pub(crate) enum CodegenError {
     ProcMacro2Error(proc_macro2::LexError),
     InvalidRustIdentifierModName(syn::Error, String),


### PR DESCRIPTION
I realized I had forgotten to mark the enums in these modules `non_exhaustive`.
I left the `struct` types as-is because they don't have pub fields.