### PR TITLE
Add crate name to grmtools section entries

### DIFF
--- a/cfgrammar/src/lib/header.rs
+++ b/cfgrammar/src/lib/header.rs
@@ -6,7 +6,7 @@ use crate::{
     },
 };
 use regex::{Regex, RegexBuilder};
-use std::{error::Error, fmt, sync::LazyLock};
+use std::{collections::HashMap, error::Error, fmt, sync::LazyLock};
 
 /// An error regarding the `%grmtools` header section.
 ///
@@ -239,13 +239,53 @@ impl<T> Namespaced<T> {
 static RE_LEADING_WS: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^[\p{Pattern_White_Space}]*").unwrap());
 static RE_NAME: LazyLock<Regex> = LazyLock::new(|| {
-    RegexBuilder::new(r"^[A-Z][A-Z_]*")
+    RegexBuilder::new(r"^[A-Z][A-Z_\.]*")
+        .case_insensitive(true)
+        .build()
+        .unwrap()
+});
+#[doc(hidden)]
+pub static RE_CRATE_DOT: LazyLock<Regex> = LazyLock::new(|| {
+    RegexBuilder::new(r"^[A-Z][A-Z_]*\.")
         .case_insensitive(true)
         .build()
         .unwrap()
 });
 static RE_DIGITS: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[0-9]+").unwrap());
 static RE_STRING: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"^\"(\\.|[^"\\])*\""#).unwrap());
+#[doc(hidden)]
+pub static CRATE_KEY_MAP: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(|| {
+    let mut map = HashMap::new();
+    let cfgrammar = ["yacckind"];
+    let lrpar = ["recoverer", "test_files", "serialisation_format"];
+
+    let lrlex = ["lexerkind", "allow_wholeline_comments", "posix_escapes"];
+    let regex = [
+        "case_insensitive",
+        "dot_matches_new_line",
+        "multi_line",
+        "octal",
+        "swap_greed",
+        "ignore_whitespace",
+        "unicode",
+        "size_limit",
+        "dfa_size_limit",
+        "nest_limit",
+    ];
+    for s in cfgrammar {
+        map.insert(s, "cfgrammar");
+    }
+    for s in lrpar {
+        map.insert(s, "lrpar");
+    }
+    for s in lrlex {
+        map.insert(s, "lrlex");
+    }
+    for s in regex {
+        map.insert(s, "regex");
+    }
+    map
+});
 
 const MAGIC: &str = "%grmtools";
 
@@ -429,7 +469,18 @@ impl<'input> GrmtoolsSectionParser<'input> {
                 i = self.parse_ws(j);
                 while self.lookahead_is("}", i).is_none() && i < self.src.len() {
                     let (key, key_loc, val, j) = match self.parse_key_value(i) {
-                        Ok((key, key_loc, val, pos)) => (key, key_loc, val, pos),
+                        Ok((key, key_loc, val, pos)) => {
+                            let key = if !RE_CRATE_DOT.is_match(&key) {
+                                if let Some(crate_name) = CRATE_KEY_MAP.get(key.as_str()) {
+                                    format!("{crate_name}.{key}")
+                                } else {
+                                    key
+                                }
+                            } else {
+                                key
+                            };
+                            (key, key_loc, val, pos)
+                        }
                         Err(e) => {
                             errs.push(e);
                             return Err(errs);

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -118,7 +118,7 @@ impl FromStr for ASTWithValidityInfo {
         let (header, _) = GrmtoolsSectionParser::new(src, true)
             .parse()
             .map_err(|mut errs| errs.drain(..).map(|e| e.into()).collect::<Vec<_>>())?;
-        if let Some(HeaderValue(_, yk_val)) = header.get("yacckind") {
+        if let Some(HeaderValue(_, yk_val)) = header.get("cfgrammar.yacckind") {
             let yacc_kind = YaccKind::try_from(yk_val).map_err(|e| vec![e.into()])?;
             let ast = {
                 // We don't want to strip off the header so that span's will be correct.
@@ -138,7 +138,7 @@ impl FromStr for ASTWithValidityInfo {
         } else {
             Err(vec![
                 HeaderError {
-                    kind: HeaderErrorKind::InvalidEntry("yacckind"),
+                    kind: HeaderErrorKind::InvalidEntry("cfgrammar.yacckind"),
                     locations: vec![Span::new(0, 0)],
                 }
                 .into(),

--- a/doc/src/lexextensions.md
+++ b/doc/src/lexextensions.md
@@ -26,26 +26,26 @@ other flags should specify their value immediately after the flag name.
 
 ## List of flags:
 
-| Flag                          | Value     | Required | Regex[^regex] |
-|-------------------------------|-----------|----------|---------------|
-| `lexerkind`                   | [LexerKind](lexcompatibility.md#lexerkinds) | &cross;  | &cross; |
-| `posix_escapes`[^†]           | bool      | &cross;  | &cross;       |
-| `allow_wholeline_comment`[^‡] | bool      | &cross;  | &cross;       |
-| `case_insensitive`            | bool      | &cross;  | &checkmark;   |
-| `dot_matches_new_line`        | bool      | &cross;  | &checkmark;   |
-| `multi_line`                  | bool      | &cross;  | &checkmark;   |
-| `octal`                       | bool      | &cross;  | &checkmark;   |
-| `swap_greed`                  | bool      | &cross;  | &checkmark;   |
-| `ignore_whitespace`           | bool      | &cross;  | &checkmark;   |
-| `unicode`                     | bool      | &cross;  | &checkmark;   |
-| `size_limit`                  | usize     | &cross;  | &checkmark;   |
-| `dfa_size_limit`              | usize     | &cross;  | &checkmark;   |
-| `nest_limit`                  | u32       | &cross;  | &checkmark;   |
+| Flag                          | Value     | Required |
+|-------------------------------|-----------|----------|
+| `lrlex.lexerkind`                   | [LexerKind](lexcompatibility.md#lexerkinds) | &cross;  |
+| `lrlex.posix_escapes`[^†]           | bool      | &cross;  |
+| `lrlex.allow_wholeline_comments`[^‡] | bool      | &cross;  |
+| `regex.case_insensitive`            | bool      | &cross;  |
+| `regex.dot_matches_new_line`        | bool      | &cross;  |
+| `regex.multi_line`                  | bool      | &cross;  |
+| `regex.octal`                       | bool      | &cross;  |
+| `regex.swap_greed`                  | bool      | &cross;  |
+| `regex.ignore_whitespace`           | bool      | &cross;  |
+| `regex.unicode`                     | bool      | &cross;  |
+| `regex.size_limit`                  | usize     | &cross;  |
+| `regex.dfa_size_limit`              | usize     | &cross;  |
+| `regex.nest_limit`                  | u32       | &cross;  |
 
 [^†]: Enable compatibility with posix escape sequences.
 [^‡]: Enables rust style `// comments` at the start of lines.
 Which requires escaping of `/` when used in a regex.
-[^regex]: &checkmark; Flag gets passed directly to `regex::RegexBuilder`.
+[^regex]: Flag gets passed directly to `regex::RegexBuilder`.
 
 
 ## Flags affecting Posix compatibility

--- a/doc/src/yaccextensions.md
+++ b/doc/src/yaccextensions.md
@@ -5,10 +5,10 @@ But a default can be set or forced by using a `YaccKindResolver`.
 
 | Flag             | Value                                           | Required     |
 |------------------|-------------------------------------------------|--------------|
-| `yacckind`       |  [YaccKind](yacccompatibility.md#yacckinds)     | &checkmark;  |
-| `recoverykind`   |  [RecoveryKind](errorrecovery.md#recoverykinds) | &cross;      |
-| `test_files`[^†] |  Array of string values                         | &cross;      |
-| `serialisation_format`[^⹋] |  `lrpar::SerialisationFormat`         | &cross;      |
+| `cfgrammar.yacckind`       |  [YaccKind](yacccompatibility.md#yacckinds)     | &checkmark;  |
+| `lrpar.recoverykind`   |  [RecoveryKind](errorrecovery.md#recoverykinds) | &cross;      |
+| `lrpar.test_files`[^†] |  Array of string values                         | &cross;      |
+| `lrpar.serialisation_format`[^⹋] |  `lrpar::SerialisationFormat`         | &cross;      |
 
 [^†]: Strings containing globs are resolved relative to the yacc `.y` source file.
       `test_files` is currently experimental.

--- a/lrlex/src/lib/codegen.rs
+++ b/lrlex/src/lib/codegen.rs
@@ -195,11 +195,11 @@ where
     {
         self.merge_headers()?;
         let mod_name = self.resolve_mod_name(&args)?;
-        self.header.mark_used(&"lexerkind".to_string());
+        self.header.mark_used(&"lrlex.lexerkind".to_string());
         let lexerkind = match args.lexerkind {
             Some(lexerkind) => lexerkind,
             None => {
-                if let Some(HeaderValue(_, lk_val)) = self.header.get("lexerkind") {
+                if let Some(HeaderValue(_, lk_val)) = self.header.get("lrlex.lexerkind") {
                     LexerKind::try_from(lk_val)?
                 } else {
                     LexerKind::LRNonStreamingLexer

--- a/lrlex/src/lib/ctbuilder.rs
+++ b/lrlex/src/lib/ctbuilder.rs
@@ -504,9 +504,9 @@ where
                         .map(|(x, y)| (&**x, *y))
                         .collect::<HashMap<_, _>>();
                     closure_lexerdef.set_rule_ids(&owned_map);
-                    yacc_header.mark_used(&"test_files".to_string());
+                    yacc_header.mark_used(&"lrpar.test_files".to_string());
                     let grammar = rtpb.grammar();
-                    let test_glob = yacc_header.get("test_files");
+                    let test_glob = yacc_header.get("lrpar.test_files");
                     let mut err_str = None;
                     let add_error_line = |err_str: &mut Option<String>, line| {
                         if let Some(err_str) = err_str {
@@ -841,7 +841,7 @@ where
     ///
     /// Setting this flag will override the same flag within a `%grmtools` section.
     pub fn allow_wholeline_comments(mut self, flag: bool) -> Self {
-        let key = "allow_wholeline_comments".to_string();
+        let key = "lrlex.allow_wholeline_comments".to_string();
         self.header.insert(
             key,
             HeaderValue(
@@ -857,7 +857,7 @@ where
     ///
     /// Setting this flag will override the same flag within a `%grmtools` section.
     pub fn dot_matches_new_line(mut self, flag: bool) -> Self {
-        let key = "dot_matches_new_line".to_string();
+        let key = "regex.dot_matches_new_line".to_string();
         self.header.insert(
             key,
             HeaderValue(
@@ -873,7 +873,7 @@ where
     ///
     /// Setting this flag will override the same flag within a `%grmtools` section.
     pub fn multi_line(mut self, flag: bool) -> Self {
-        let key = "multi_line".to_string();
+        let key = "regex.multi_line".to_string();
         self.header.insert(
             key,
             HeaderValue(
@@ -889,7 +889,7 @@ where
     ///
     /// Setting this flag will override the same flag within a `%grmtools` section.
     pub fn posix_escapes(mut self, flag: bool) -> Self {
-        let key = "posix_escapes".to_string();
+        let key = "lrlex.posix_escapes".to_string();
         self.header.insert(
             key,
             HeaderValue(
@@ -905,7 +905,7 @@ where
     ///
     /// Setting this flag will override the same flag within a `%grmtools` section.
     pub fn octal(mut self, flag: bool) -> Self {
-        let key = "octal".to_string();
+        let key = "regex.octal".to_string();
         self.header.insert(
             key,
             HeaderValue(
@@ -921,7 +921,7 @@ where
     ///
     /// Setting this flag will override the same flag within a `%grmtools` section.
     pub fn swap_greed(mut self, flag: bool) -> Self {
-        let key = "swap_greed".to_string();
+        let key = "regex.swap_greed".to_string();
         self.header.insert(
             key,
             HeaderValue(
@@ -937,7 +937,7 @@ where
     ///
     /// Setting this flag will override the same flag within a `%grmtools` section.
     pub fn ignore_whitespace(mut self, flag: bool) -> Self {
-        let key = "ignore_whitespace".to_string();
+        let key = "regex.ignore_whitespace".to_string();
         self.header.insert(
             key,
             HeaderValue(
@@ -953,7 +953,7 @@ where
     ///
     /// Setting this flag will override the same flag within a `%grmtools` section.
     pub fn unicode(mut self, flag: bool) -> Self {
-        let key = "unicode".to_string();
+        let key = "regex.unicode".to_string();
         self.header.insert(
             key,
             HeaderValue(
@@ -969,7 +969,7 @@ where
     ///
     /// Setting this flag will override the same flag within a `%grmtools` section.
     pub fn case_insensitive(mut self, flag: bool) -> Self {
-        let key = "case_insensitive".to_string();
+        let key = "regex.case_insensitive".to_string();
         self.header.insert(
             key,
             HeaderValue(
@@ -985,7 +985,7 @@ where
     ///
     /// Setting this flag will override the same flag within a `%grmtools` section.
     pub fn size_limit(mut self, sz: usize) -> Self {
-        let key = "size_limit".to_string();
+        let key = "regex.size_limit".to_string();
         self.header.insert(
             key,
             HeaderValue(
@@ -1004,7 +1004,7 @@ where
     ///
     /// Setting this flag will override the same flag within a `%grmtools` section.
     pub fn dfa_size_limit(mut self, sz: usize) -> Self {
-        let key = "dfa_size_limit".to_string();
+        let key = "regex.dfa_size_limit".to_string();
         self.header.insert(
             key,
             HeaderValue(
@@ -1023,7 +1023,7 @@ where
     ///
     /// Setting this flag will override the same flag within a `%grmtools` section.
     pub fn nest_limit(mut self, lim: u32) -> Self {
-        let key = "nest_limit".to_string();
+        let key = "regex.nest_limit".to_string();
         self.header.insert(
             key,
             HeaderValue(

--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -64,9 +64,9 @@ impl<T: Clone> TryFrom<&mut Header<T>> for LexFlags {
             nest_limit,
         } = &mut lex_flags;
         macro_rules! cvt_flag {
-            ($it:ident) => {
-                header.mark_used(&stringify!($it).to_string());
-                *$it = match header.get(stringify!($it)) {
+            ($prefix:ident, $it:ident) => {
+                header.mark_used(&stringify!($prefix.$it).to_string());
+                *$it = match header.get(stringify!($prefix.$it)) {
                     Some(HeaderValue(_, Value::Flag(flag, _))) => Some(*flag),
                     Some(HeaderValue(loc, _)) => Err(HeaderError {
                         kind: HeaderErrorKind::ConversionError("LexFlags", "Expected boolean"),
@@ -76,19 +76,19 @@ impl<T: Clone> TryFrom<&mut Header<T>> for LexFlags {
                 }
             };
         }
-        cvt_flag!(dot_matches_new_line);
-        cvt_flag!(multi_line);
-        cvt_flag!(octal);
-        cvt_flag!(posix_escapes);
-        cvt_flag!(allow_wholeline_comments);
-        cvt_flag!(case_insensitive);
-        cvt_flag!(swap_greed);
-        cvt_flag!(ignore_whitespace);
-        cvt_flag!(unicode);
+        cvt_flag!(regex, dot_matches_new_line);
+        cvt_flag!(regex, multi_line);
+        cvt_flag!(regex, octal);
+        cvt_flag!(lrlex, posix_escapes);
+        cvt_flag!(lrlex, allow_wholeline_comments);
+        cvt_flag!(regex, case_insensitive);
+        cvt_flag!(regex, swap_greed);
+        cvt_flag!(regex, ignore_whitespace);
+        cvt_flag!(regex, unicode);
         macro_rules! cvt_num {
-            ($it:ident, $num_ty: ty) => {
-                header.mark_used(&stringify!($it).to_string());
-                *$it = match header.get(stringify!($it)) {
+            ($prefix:ident, $it:ident, $num_ty: ty) => {
+                header.mark_used(&stringify!($prefix.$it).to_string());
+                *$it = match header.get(stringify!($prefix.$it)) {
                     Some(HeaderValue(_, Value::Setting(Setting::Num(n, _)))) => Some(*n as $num_ty),
                     Some(HeaderValue(loc, _)) => Err(HeaderError {
                         kind: HeaderErrorKind::ConversionError("LexFlags", "Expected numeric"),
@@ -98,9 +98,9 @@ impl<T: Clone> TryFrom<&mut Header<T>> for LexFlags {
                 }
             };
         }
-        cvt_num!(size_limit, usize);
-        cvt_num!(dfa_size_limit, usize);
-        cvt_num!(nest_limit, u32);
+        cvt_num!(regex, size_limit, usize);
+        cvt_num!(regex, dfa_size_limit, usize);
+        cvt_num!(regex, nest_limit, u32);
         Ok(lex_flags)
     }
 }

--- a/lrlex/src/main.rs
+++ b/lrlex/src/main.rs
@@ -95,8 +95,8 @@ fn main() -> Result<(), Box<dyn Error>> {
             process::exit(1);
         }
     };
-    header.mark_used(&"lexerkind".to_string());
-    let lexerkind = if let Some(HeaderValue(_, lk_val)) = header.get("lexerkind") {
+    header.mark_used(&"lrlex.lexerkind".to_string());
+    let lexerkind = if let Some(HeaderValue(_, lk_val)) = header.get("lrlex.lexerkind") {
         LexerKind::try_from(lk_val)?
     } else {
         LexerKind::LRNonStreamingLexer

--- a/lrpar/cttests/src/grmtools_section.test
+++ b/lrpar/cttests/src/grmtools_section.test
@@ -1,6 +1,6 @@
 grammar: |
     %grmtools{
-        yacckind: Grmtools,
+        cfgrammar.yacckind: Grmtools,
         recoverer: RecoveryKind::CPCTPlus,
         test_files: ["*.input_grmtools_section"]
     }
@@ -19,6 +19,15 @@ grammar: |
     val_seq -> Result<Header<Span>, Vec<HeaderError<Span>>>
     : valbind {
         let ((key, key_loc), val) = $1;
+        let key = if !RE_CRATE_DOT.is_match(&key) {
+            if let Some(crate_name) = CRATE_KEY_MAP.get(key.as_str()) {
+                format!("{crate_name}.{key}")
+            } else {
+                key
+            }
+        } else {
+            key
+        };
         let mut ret = Header::<Span>::new();
         match ret.entry(key) {
             Entry::Occupied(orig) => {
@@ -38,6 +47,15 @@ grammar: |
     }
     | val_seq ',' valbind {
         let ((key, key_loc), val) = $3;
+        let key = if !RE_CRATE_DOT.is_match(&key) {
+            if let Some(crate_name) = CRATE_KEY_MAP.get(key.as_str()) {
+                format!("{crate_name}.{key}")
+            } else {
+                key
+            }
+        } else {
+            key
+        };
         let mut ret = $1?;
         match ret.entry(key) {
             Entry::Occupied(orig) => {
@@ -144,8 +162,15 @@ grammar: |
             Namespaced,
             Header,
             HeaderValue,
+            CRATE_KEY_MAP,
+            RE_CRATE_DOT,
         },
         markmap::Entry,
+    };
+
+    use std::{
+        collections::HashMap,
+        sync::LazyLock
     };
 
 lexer: |
@@ -153,7 +178,7 @@ lexer: |
     %%
     %grmtools 'MAGIC'
     ! '!'
-    [A-Z][A-Z_]* 'IDENT'
+    [A-Z][A-Z_\.]* 'IDENT'
     [0-9]+ 'NUM'
     , ','
     \{ '{'

--- a/lrpar/src/lib/codegen.rs
+++ b/lrpar/src/lib/codegen.rs
@@ -310,12 +310,12 @@ where
         &mut self,
         from_ast: Option<&ASTWithValidityInfo>,
     ) -> Result<ASTWithValidityInfo, ParserSrcEnvError> {
-        self.header.mark_used(&"yacckind".to_string());
+        self.header.mark_used(&"cfgrammar.yacckind".to_string());
         if let Some(ast) = from_ast {
             Ok(ast.clone())
         } else if let Some(yk) = self
             .header
-            .get("yacckind")
+            .get("cfgrammar.yacckind")
             .map(|HeaderValue(_, val)| val)
             .map(YaccKind::try_from)
             .transpose()?
@@ -329,10 +329,10 @@ where
     /// Looks up the `recoverer` field in the header, marks the field
     /// as used, and defaulting to `CPCTPlus` if unfound.
     fn resolve_recoverer(&mut self) -> Result<RecoveryKind, ParserSrcEnvError> {
-        self.header.mark_used(&"recoverer".to_string());
+        self.header.mark_used(&"lrpar.recoverer".to_string());
         let rk_val = self
             .header
-            .get("recoverer")
+            .get("lrpar.recoverer")
             .map(|HeaderValue(_, rk_val)| rk_val);
         if let Some(rk_val) = rk_val {
             Ok(RecoveryKind::try_from(rk_val)?)
@@ -345,10 +345,11 @@ where
     /// Looks up the `serialisation_format` field in the header, marks the field
     /// as used, and defaults to `VariableSizedInteger` if unfound.
     fn resolve_serialisation_format(&mut self) -> Result<SerialisationFormat, ParserSrcEnvError> {
-        self.header.mark_used(&"serialisation_format".to_string());
+        self.header
+            .mark_used(&"lrpar.serialisation_format".to_string());
         if let Some(ec_val) = self
             .header
-            .get("serialisation_format")
+            .get("lrpar.serialisation_format")
             .map(|HeaderValue(_, ec_val)| ec_val)
         {
             Ok(SerialisationFormat::try_from(ec_val)?)

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -556,7 +556,7 @@ where
             .expect("output_path must be specified before processing.");
         let mut header = Header::new();
 
-        match header.entry("yacckind".to_string()) {
+        match header.entry("cfgrammar.yacckind".to_string()) {
             Entry::Occupied(_) => unreachable!(),
             Entry::Vacant(mut v) => match self.yacckind {
                 Some(YaccKind::Eco) => panic!("Eco compile-time grammar generation not supported."),
@@ -574,7 +574,7 @@ where
             },
         }
         if let Some(recoverer) = self.recoverer {
-            match header.entry("recoverer".to_string()) {
+            match header.entry("lrpar.recoverer".to_string()) {
                 Entry::Occupied(_) => unreachable!(),
                 Entry::Vacant(v) => {
                     let rk_value: Value<Location> = Value::try_from(recoverer)?;
@@ -588,7 +588,7 @@ where
         }
 
         if let Some(encoding) = self.serialisation_format {
-            match header.entry("serialisation_format".to_string()) {
+            match header.entry("lrpar.serialisation_format".to_string()) {
                 Entry::Occupied(_) => unreachable!(),
                 Entry::Vacant(v) => {
                     let rk_value: Value<Location> = Value::try_from(encoding)?;

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -178,11 +178,11 @@ fn main() {
         None => (),
         Some(s) => {
             header.set_merge_behavior(
-                &"recoverer".to_string(),
+                &"lrpar.recoverer".to_string(),
                 cfgrammar::markmap::MergeBehavior::Ours,
             );
             header.insert(
-                "recoverer".to_string(),
+                "lrpar.recoverer".to_string(),
                 HeaderValue(
                     Location::CommandLine,
                     Value::try_from(match &*s.to_lowercase() {
@@ -195,7 +195,7 @@ fn main() {
             );
         }
     };
-    let entry = match header.entry("yacckind".to_string()) {
+    let entry = match header.entry("cfgrammar.yacckind".to_string()) {
         Entry::Occupied(_) => unreachable!("Header should be empty"),
         Entry::Vacant(v) => v,
     };
@@ -236,7 +236,7 @@ fn main() {
     let yacc_y_path = PathBuf::from(&matches.free[1]);
     let yacc_src = read_file(&yacc_y_path);
     let yacc_diag = SpannedDiagnosticFormatter::new(&yacc_src, &yacc_y_path);
-    let yk_val = header.get("yacckind");
+    let yk_val = header.get("cfgrammar.yacckind");
     if yk_val.is_none() {
         let parsed_header = GrmtoolsSectionParser::new(&yacc_src, true).parse();
         match parsed_header {
@@ -257,7 +257,7 @@ fn main() {
             }
         }
     }
-    let yk_val = header.get("yacckind");
+    let yk_val = header.get("cfgrammar.yacckind");
     if yk_val.is_none() {
         eprintln!(
             "yacckind not specified in the %grmtools section of the grammar or via the '-y' parameter"
@@ -267,7 +267,7 @@ fn main() {
     let HeaderValue(_, yk_val) = yk_val.unwrap();
     let yacc_kind = YaccKind::try_from(yk_val).unwrap_or(YaccKind::Grmtools);
     let ast_validation = ASTWithValidityInfo::new(yacc_kind, &yacc_src);
-    let recoverykind = if let Some(HeaderValue(_, rk_val)) = header.get("recoverer") {
+    let recoverykind = if let Some(HeaderValue(_, rk_val)) = header.get("lrpar.recoverer") {
         match RecoveryKind::try_from(rk_val) {
             Err(e) => {
                 eprintln!(
@@ -551,7 +551,7 @@ where
             );
         } else {
             // If given no input paths, try to find some with `test_files` in the header.
-            match self.header.get("test_files") {
+            match self.header.get("lrpar.test_files") {
                 Some(HeaderValue(_, Value::Setting(Setting::Array(test_globs, _, _)))) => {
                     for setting in test_globs {
                         match setting {
@@ -564,7 +564,7 @@ where
                                         if glob_paths.peek().is_none() {
                                             return Err(NimbleparseError::Other(
                                                 format!(
-                                                    "'test_files' glob '{}' matched no paths",
+                                                    "'lrpar.test_files' glob '{}' matched no paths",
                                                     s
                                                 )
                                                 .to_string()
@@ -578,7 +578,7 @@ where
                                                 && ext.starts_with("grm")
                                             {
                                                 Err(NimbleparseError::Other(
-                                                        "test_files extensions beginning with `grm` are reserved."
+                                                        "lrpar.test_files extensions beginning with `grm` are reserved."
                                                         .into(),
                                                     ))?
                                             }
@@ -607,7 +607,7 @@ where
 
                             _ => {
                                 return Err(NimbleparseError::Other(
-                                    "Expected string values in `test_files`".into(),
+                                    "Expected string values in `lrpar.test_files`".into(),
                                 ));
                             }
                         }
@@ -615,7 +615,7 @@ where
                 }
                 Some(_) => {
                     return Err(NimbleparseError::Other(
-                        "Expected Array of string values in `test_files`".into(),
+                        "Expected Array of string values in `lrpar.test_files`".into(),
                     ));
                 }
                 None => {
@@ -631,7 +631,7 @@ where
             ));
         }
         let pb = RTParserBuilder::new(&self.grm, &self.stable).recoverer(self.recoverykind);
-        // Actually parse the given arguments or the `test_files` specified in the grammar.
+        // Actually parse the given arguments or the `lrpar.test_files` specified in the grammar.
         for input_path in paths {
             let input = read_file(&input_path);
             let lexer = self.lexerdef.lexer(&input);


### PR DESCRIPTION
So here is a first foray into adding a default "tool name" for `%grmtools` section entries,
This turned out a bit more complex than I had thought, for one it seemed that since `lex_flags` largely get passed
directly into the `regex` crate, we should name those `regex.foo` rather than `grmtools.foo`.

I named this "tool name" because there is already a thing we call `namespace` in this area, and that like `YaccKind::` and the like.
