### PR TITLE
Add grmtools_section to ast

### DIFF
--- a/cfgrammar/src/lib/header.rs
+++ b/cfgrammar/src/lib/header.rs
@@ -254,7 +254,7 @@ impl From<Value<Span>> for GrmtoolsSectionValue {
                     let array_span = Span::new(start_span.start(), end_span.end());
                     let mut out = Vec::with_capacity(v.capacity());
                     for setting in v {
-                        // To Call this function recursively we need to convert the `Setting<Span>` to a `HeaderValue<Span>`
+                        // To call this function recursively we need to convert the `Setting<Span>` to a `Value<Span>`
                         out.push(GrmtoolsSectionValue::from(Value::Setting(setting)));
                     }
                     GrmtoolsSectionValue::Array(out, array_span)

--- a/cfgrammar/src/lib/header.rs
+++ b/cfgrammar/src/lib/header.rs
@@ -48,7 +48,7 @@ impl Spanned for HeaderError<Span> {
 
 // This is essentially a tuple that needs a newtype so we can implement `From` for it.
 // Thus we aren't worried about it being `pub`.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 #[doc(hidden)]
 pub struct HeaderValue<T>(pub T, pub Value<T>);
 
@@ -69,6 +69,15 @@ pub enum HeaderErrorKind {
     DuplicateEntry,
     InvalidEntry(&'static str),
     ConversionError(&'static str, &'static str),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub enum GrmtoolsSectionValue {
+    String(String, Span),
+    Num(u64, Span),
+    Bool(bool, Span),
+    Array(Vec<GrmtoolsSectionValue>, Span),
+    RustLike(String, Span),
 }
 
 impl fmt::Display for HeaderErrorKind {
@@ -116,14 +125,14 @@ impl<T> HeaderError<T> {
 ///     member: ("Bar", ...)
 /// }
 /// ```
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 #[doc(hidden)]
 pub struct Namespaced<T> {
     pub namespace: Option<(String, T)>,
     pub member: (String, T),
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 #[doc(hidden)]
 pub enum Setting<T> {
     /// A value like `YaccKind::Grmtools`
@@ -152,7 +161,7 @@ pub struct GrmtoolsSectionParser<'input> {
 ///
 /// To be useful across diverse crates this types fields are limited to types derived from `core::` types.
 /// like booleans, numeric types, and string values.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 #[doc(hidden)]
 pub enum Value<T> {
     Flag(bool, T),
@@ -233,6 +242,72 @@ impl<T> Setting<T> {
 impl<T> Namespaced<T> {
     fn primary_location(&self) -> &T {
         &self.member.1
+    }
+}
+
+impl From<Value<Span>> for GrmtoolsSectionValue {
+    fn from(value: Value<Span>) -> GrmtoolsSectionValue {
+        match value {
+            Value::Flag(value, value_span) => GrmtoolsSectionValue::Bool(value, value_span),
+            Value::Setting(setting) => match setting {
+                Setting::Array(v, start_span, end_span) => {
+                    let array_span = Span::new(start_span.start(), end_span.end());
+                    let mut out = Vec::with_capacity(v.capacity());
+                    for setting in v {
+                        // To Call this function recursively we need to convert the `Setting<Span>` to a `HeaderValue<Span>`
+                        out.push(GrmtoolsSectionValue::from(Value::Setting(setting)));
+                    }
+                    GrmtoolsSectionValue::Array(out, array_span)
+                }
+                Setting::String(s, val_span) => GrmtoolsSectionValue::String(s.clone(), val_span),
+                Setting::Num(n, val_span) => GrmtoolsSectionValue::Num(n, val_span),
+                Setting::Unitary(Namespaced {
+                    namespace,
+                    member: (member, member_span),
+                }) => {
+                    let mut s = String::new();
+                    let mut start_pos = member_span.start();
+                    if let Some((ns, ns_span)) = namespace {
+                        s.push_str(&ns);
+                        s.push_str("::");
+                        start_pos = ns_span.start();
+                    }
+                    s.push_str(&member);
+                    GrmtoolsSectionValue::RustLike(s, Span::new(start_pos, member_span.end()))
+                }
+                Setting::Constructor {
+                    ctor:
+                        Namespaced {
+                            namespace: ctor_namespace,
+                            member: (ctor_member, ctor_member_span),
+                        },
+                    arg:
+                        Namespaced {
+                            namespace: arg_namespace,
+                            member: (arg_member, arg_member_span),
+                        },
+                } => {
+                    let mut s = String::new();
+                    let mut ctor_start_pos = ctor_member_span.start();
+                    if let Some((ns, namespace_span)) = ctor_namespace {
+                        ctor_start_pos = namespace_span.start();
+                        s.push_str(&ns);
+                        s.push_str("::");
+                    }
+                    s.push_str(&ctor_member);
+                    s.push('(');
+                    if let Some((arg_ns, _)) = arg_namespace {
+                        s.push_str(&arg_ns);
+                    }
+                    s.push_str(&arg_member);
+                    s.push(')');
+                    GrmtoolsSectionValue::RustLike(
+                        s,
+                        Span::new(ctor_start_pos, arg_member_span.end()),
+                    )
+                }
+            },
+        }
     }
 }
 

--- a/cfgrammar/src/lib/header.rs
+++ b/cfgrammar/src/lib/header.rs
@@ -298,12 +298,13 @@ impl From<Value<Span>> for GrmtoolsSectionValue {
                     s.push('(');
                     if let Some((arg_ns, _)) = arg_namespace {
                         s.push_str(&arg_ns);
+                        s.push_str("::");
                     }
                     s.push_str(&arg_member);
                     s.push(')');
                     GrmtoolsSectionValue::RustLike(
                         s,
-                        Span::new(ctor_start_pos, arg_member_span.end()),
+                        Span::new(ctor_start_pos, arg_member_span.end() + ")".len()),
                     )
                 }
             },

--- a/cfgrammar/src/lib/header.rs
+++ b/cfgrammar/src/lib/header.rs
@@ -628,10 +628,7 @@ impl<'input> GrmtoolsSectionParser<'input> {
         match RE_NAME.find(&self.src[i..]) {
             Some(m) => {
                 assert_eq!(m.start(), 0);
-                Ok((
-                    self.src[i..i + m.end()].to_string(),
-                    i + m.end(),
-                ))
+                Ok((self.src[i..i + m.end()].to_string(), i + m.end()))
             }
             None => {
                 if self.src[i..].starts_with("*") {

--- a/cfgrammar/src/lib/header.rs
+++ b/cfgrammar/src/lib/header.rs
@@ -629,7 +629,7 @@ impl<'input> GrmtoolsSectionParser<'input> {
             Some(m) => {
                 assert_eq!(m.start(), 0);
                 Ok((
-                    self.src[i..i + m.end()].to_string().to_lowercase(),
+                    self.src[i..i + m.end()].to_string(),
                     i + m.end(),
                 ))
             }
@@ -678,30 +678,30 @@ impl TryFrom<YaccKind> for Value<Location> {
         let from_loc = Location::Other("From<YaccKind>".to_string());
         Ok(match kind {
             YaccKind::Grmtools => Value::Setting(Setting::Unitary(Namespaced {
-                namespace: Some(("yacckind".to_string(), from_loc.clone())),
-                member: ("grmtools".to_string(), from_loc),
+                namespace: Some(("YaccKind".to_string(), from_loc.clone())),
+                member: ("Grmtools".to_string(), from_loc),
             })),
             YaccKind::Eco => Value::Setting(Setting::Unitary(Namespaced {
-                namespace: Some(("yacckind".to_string(), from_loc.clone())),
-                member: ("eco".to_string(), from_loc),
+                namespace: Some(("YaccKind".to_string(), from_loc.clone())),
+                member: ("Eco".to_string(), from_loc),
             })),
             YaccKind::Original(action_kind) => Value::Setting(Setting::Constructor {
                 ctor: Namespaced {
-                    namespace: Some(("yacckind".to_string(), from_loc.clone())),
-                    member: ("original".to_string(), from_loc.clone()),
+                    namespace: Some(("YaccKind".to_string(), from_loc.clone())),
+                    member: ("Original".to_string(), from_loc.clone()),
                 },
                 arg: match action_kind {
                     YaccOriginalActionKind::NoAction => Namespaced {
-                        namespace: Some(("yaccoriginalactionkind".to_string(), from_loc.clone())),
-                        member: ("noaction".to_string(), from_loc),
+                        namespace: Some(("YaccOriginalActionKind".to_string(), from_loc.clone())),
+                        member: ("NoAction".to_string(), from_loc),
                     },
                     YaccOriginalActionKind::UserAction => Namespaced {
-                        namespace: Some(("yaccoriginalactionkind".to_string(), from_loc.clone())),
-                        member: ("useraction".to_string(), from_loc),
+                        namespace: Some(("YaccOriginalActionKind".to_string(), from_loc.clone())),
+                        member: ("UserAction".to_string(), from_loc),
                     },
                     YaccOriginalActionKind::GenericParseTree => Namespaced {
-                        namespace: Some(("yaccoriginalactionkind".to_string(), from_loc.clone())),
-                        member: ("genericparsetree".to_string(), from_loc),
+                        namespace: Some(("YaccOriginalActionKind".to_string(), from_loc.clone())),
+                        member: ("GenericParseTree".to_string(), from_loc),
                     },
                 },
             }),
@@ -719,13 +719,13 @@ impl<T: Clone> TryFrom<&Value<T>> for YaccKind {
                 member: (yk_value, yk_value_loc),
             })) => {
                 if let Some((ns, ns_loc)) = namespace
-                    && ns != "yacckind"
+                    && ns != "YaccKind"
                 {
                     err_locs.push(ns_loc.clone());
                 }
                 let yacckinds = [
-                    ("grmtools".to_string(), YaccKind::Grmtools),
-                    ("eco".to_string(), YaccKind::Eco),
+                    ("Grmtools".to_string(), YaccKind::Grmtools),
+                    ("Eco".to_string(), YaccKind::Eco),
                 ];
                 let yk_found = yacckinds
                     .iter()
@@ -760,24 +760,24 @@ impl<T: Clone> TryFrom<&Value<T>> for YaccKind {
                     },
             }) => {
                 if let Some((yk_ns, yk_ns_loc)) = yk_namespace
-                    && yk_ns != "yacckind"
+                    && yk_ns != "YaccKind"
                 {
                     err_locs.push(yk_ns_loc.clone());
                 }
 
-                if yk_str != "original" {
+                if yk_str != "Original" {
                     err_locs.push(yk_loc.clone());
                 }
 
                 if let Some((ak_ns, ak_ns_loc)) = ak_namespace
-                    && ak_ns != "yaccoriginalactionkind"
+                    && ak_ns != "YaccOriginalActionKind"
                 {
                     err_locs.push(ak_ns_loc.clone());
                 }
                 let actionkinds = [
-                    ("noaction", YaccOriginalActionKind::NoAction),
-                    ("useraction", YaccOriginalActionKind::UserAction),
-                    ("genericparsetree", YaccOriginalActionKind::GenericParseTree),
+                    ("NoAction", YaccOriginalActionKind::NoAction),
+                    ("UserAction", YaccOriginalActionKind::UserAction),
+                    ("GenericParseTree", YaccOriginalActionKind::GenericParseTree),
                 ];
                 let yk_found = actionkinds.iter().find_map(|(actionkind_str, actionkind)| {
                     (ak_str == actionkind_str).then_some(YaccKind::Original(*actionkind))

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -1166,7 +1166,8 @@ start: "a" { () };
         let ast_validity = ASTWithValidityInfo::from_str(src).unwrap();
         let mut cfgrammar_crate_expected = HashMap::new();
         let yacckind_span = src.find_span("yacckind");
-        let yacckind_val_span = src.find_span("YaccKind::Original(YaccOriginalActionKind::UserAction)");
+        let yacckind_val_span =
+            src.find_span("YaccKind::Original(YaccOriginalActionKind::UserAction)");
         cfgrammar_crate_expected.insert(
             "cfgrammar.yacckind".to_string(),
             (
@@ -1185,7 +1186,7 @@ start: "a" { () };
         assert_eq!(cfgrammar_crate_parsed, cfgrammar_crate_expected);
     }
 
-        #[test]
+    #[test]
     fn test_grmtools_section_values4() {
         use super::*;
         let src = r#"

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -548,18 +548,19 @@ impl GrammarAST {
             )
     }
 
-    pub fn grmtools_section_values(
-        &self,
-    ) -> impl Iterator<Item = (&String, &(Span, GrmtoolsSectionValue))> {
-        self.grmtools_section.iter()
-    }
-
+    /// Returns the entries from the grmtools section with keys that are prefixed with the `crate_name`
+    /// followed by a dot. If `crate_name` is empty returns all entries for all crates.
     pub fn grmtools_section_values_for_crate(
         &self,
         crate_name: &str,
     ) -> impl Iterator<Item = (&String, &(Span, GrmtoolsSectionValue))> {
-        self.grmtools_section_values()
-            .filter(move |(key, _)| key.starts_with(&format!("{crate_name}.")))
+        self.grmtools_section.iter().filter(move |(key, _)| {
+            if !crate_name.is_empty() {
+                key.starts_with(&format!("{crate_name}."))
+            } else {
+                true
+            }
+        })
     }
 }
 

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -1002,4 +1002,168 @@ start -> () : "a" {$;;;; };
             }]
         );
     }
+
+    #[test]
+    fn test_grmtools_section() {
+        use super::*;
+        let src = r#"
+%grmtools {
+   yacckind: Grmtools,
+   lrpar.recoverer: CPCTPlus,
+   test.flag,
+   !test.negative,
+   test.string: "Foo",
+   test.vec: ["Aaaa", "Bbbb"],
+   test.num: 1234,
+}
+%token a
+%%
+start -> () : "a" { () };
+"#;
+        let ast_validity = ASTWithValidityInfo::new(YaccKind::Grmtools, src);
+        let test_flag_span_start = src.find("test.flag").unwrap();
+        let test_flag_span = Span::new(
+            test_flag_span_start,
+            test_flag_span_start + "test.flag".len(),
+        );
+        let test_neg_span_start = src.find("test.negative").unwrap();
+        let test_neg_span = Span::new(
+            test_neg_span_start,
+            test_neg_span_start + "test.negative".len(),
+        );
+        let test_string_span_start = src.find("test.string").unwrap();
+        let test_string_span = Span::new(
+            test_string_span_start,
+            test_string_span_start + "test.string".len(),
+        );
+        let test_string_val_span_start = src.find("Foo").unwrap();
+        let test_string_val_span = Span::new(
+            test_string_val_span_start,
+            test_string_val_span_start + "Foo".len(),
+        );
+        let test_vec_span_start = src.find("test.vec").unwrap();
+        let test_vec_span = Span::new(test_vec_span_start, test_vec_span_start + "test.vec".len());
+        let test_vec_a_span_start = src.find("Aaaa").unwrap();
+        let test_vec_a_span =
+            Span::new(test_vec_a_span_start, test_vec_a_span_start + "Aaaa".len());
+        let test_vec_b_span_start = src.find("Bbbb").unwrap();
+        let test_vec_b_span =
+            Span::new(test_vec_b_span_start, test_vec_b_span_start + "Bbbb".len());
+        let test_vec_val_span_start = src.find("[\"Aaaa\", \"Bbbb\"]").unwrap();
+        let test_vec_val_span = Span::new(
+            test_vec_val_span_start,
+            test_vec_val_span_start + "[\"Aaaa\", \"Bbbb\"]".len(),
+        );
+        let test_num_span_start = src.find("test.num").unwrap();
+        let test_num_span = Span::new(test_num_span_start, test_num_span_start + "test.num".len());
+        let test_num_val_span_start = src.find("1234").unwrap();
+        let test_num_val_span = Span::new(
+            test_num_val_span_start,
+            test_num_val_span_start + "1234".len(),
+        );
+
+        let mut test_crate_expected = HashMap::new();
+        test_crate_expected.insert(
+            "test.flag".to_string(),
+            (
+                test_flag_span,
+                GrmtoolsSectionValue::Bool(true, test_flag_span),
+            ),
+        );
+        test_crate_expected.insert(
+            "test.negative".to_string(),
+            (
+                test_neg_span,
+                GrmtoolsSectionValue::Bool(
+                    false,
+                    Span::new(
+                        test_neg_span_start - 1,
+                        test_neg_span_start + "test.negative".len(),
+                    ),
+                ),
+            ),
+        );
+        test_crate_expected.insert(
+            "test.string".to_string(),
+            (
+                test_string_span,
+                GrmtoolsSectionValue::String("Foo".to_string(), test_string_val_span),
+            ),
+        );
+        test_crate_expected.insert(
+            "test.vec".to_string(),
+            (
+                test_vec_span,
+                GrmtoolsSectionValue::Array(
+                    vec![
+                        GrmtoolsSectionValue::String("Aaaa".to_string(), test_vec_a_span),
+                        GrmtoolsSectionValue::String("Bbbb".to_string(), test_vec_b_span),
+                    ],
+                    test_vec_val_span,
+                ),
+            ),
+        );
+        test_crate_expected.insert(
+            "test.num".to_string(),
+            (
+                test_num_span,
+                GrmtoolsSectionValue::Num(1234, test_num_val_span),
+            ),
+        );
+        let test_crate_parsed = ast_validity
+            .ast()
+            .grmtools_section_values_for_crate("test")
+            .map(|(key, (key_span, val))| (key.clone(), (*key_span, val.clone())))
+            .collect::<HashMap<_, _>>();
+        assert_eq!(test_crate_parsed, test_crate_expected);
+
+        let mut cfgrammar_crate_expected = HashMap::new();
+        let yacckind_span_start = src.find("yacckind").unwrap();
+        let yacckind_span = Span::new(yacckind_span_start, yacckind_span_start + "yacckind".len());
+        let yacckind_val_span_start = src.find("Grmtools").unwrap();
+        let yacckind_val_span = Span::new(
+            yacckind_val_span_start,
+            yacckind_val_span_start + "Grmtools".len(),
+        );
+        cfgrammar_crate_expected.insert(
+            "cfgrammar.yacckind".to_string(),
+            (
+                yacckind_span,
+                // The actual value we receive has been lower cased
+                GrmtoolsSectionValue::RustLike("grmtools".to_string(), yacckind_val_span),
+            ),
+        );
+        let cfgrammar_crate_parsed = ast_validity
+            .ast()
+            .grmtools_section_values_for_crate("cfgrammar")
+            .map(|(key, (key_span, val))| (key.clone(), (*key_span, val.clone())))
+            .collect::<HashMap<_, _>>();
+        assert_eq!(cfgrammar_crate_parsed, cfgrammar_crate_expected);
+
+        let mut lrpar_crate_expected = HashMap::new();
+        let recoverer_span_start = src.find("lrpar.recoverer").unwrap();
+        let recoverer_span = Span::new(
+            recoverer_span_start,
+            recoverer_span_start + "lrpar.recoverer".len(),
+        );
+        let recoverer_val_span_start = src.find("CPCTPlus").unwrap();
+        let recoverer_val_span = Span::new(
+            recoverer_val_span_start,
+            recoverer_val_span_start + "CPCTPlus".len(),
+        );
+        lrpar_crate_expected.insert(
+            "lrpar.recoverer".to_string(),
+            (
+                recoverer_span,
+                // The actual value we receive has been lower cased
+                GrmtoolsSectionValue::RustLike("cpctplus".to_string(), recoverer_val_span),
+            ),
+        );
+        let lrpar_crate_parsed = ast_validity
+            .ast()
+            .grmtools_section_values_for_crate("lrpar")
+            .map(|(key, (key_span, val))| (key.clone(), (*key_span, val.clone())))
+            .collect::<HashMap<_, _>>();
+        assert_eq!(lrpar_crate_parsed, lrpar_crate_expected);
+    }
 }

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -1004,7 +1004,7 @@ start -> () : "a" {$;;;; };
     }
 
     #[test]
-    fn test_grmtools_section() {
+    fn test_grmtools_section_values() {
         use super::*;
         let src = r#"
 %grmtools {
@@ -1021,22 +1021,17 @@ start -> () : "a" {$;;;; };
 start -> () : "a" { () };
 "#;
         let ast_validity = ASTWithValidityInfo::from_str(src).unwrap();
-
-        let find_span = |s: &str| {
-            let start_pos = src.find(s).unwrap();
-            Span::new(start_pos, start_pos + s.len())
-        };
-        let test_flag_span = find_span("test.flag");
-        let test_neg_span = find_span("test.negative");
-        let test_neg_val_span = find_span("!test.negative");
-        let test_string_span = find_span("test.string");
-        let test_string_val_span = find_span("Foo");
-        let test_vec_span = find_span("test.vec");
-        let test_vec_a_span = find_span("Aaaa");
-        let test_vec_b_span = find_span("Bbbb");
-        let test_vec_val_span = find_span("[\"Aaaa\", \"Bbbb\"]");
-        let test_num_span = find_span("test.num");
-        let test_num_val_span = find_span("1234");
+        let test_flag_span = src.find_span("test.flag");
+        let test_neg_span = src.find_span("test.negative");
+        let test_neg_val_span = src.find_span("!test.negative");
+        let test_string_span = src.find_span("test.string");
+        let test_string_val_span = src.find_span("Foo");
+        let test_vec_span = src.find_span("test.vec");
+        let test_vec_a_span = src.find_span("Aaaa");
+        let test_vec_b_span = src.find_span("Bbbb");
+        let test_vec_val_span = src.find_span("[\"Aaaa\", \"Bbbb\"]");
+        let test_num_span = src.find_span("test.num");
+        let test_num_val_span = src.find_span("1234");
         let mut test_crate_expected = HashMap::new();
         test_crate_expected.insert(
             "test.flag".to_string(),
@@ -1049,10 +1044,7 @@ start -> () : "a" { () };
             "test.negative".to_string(),
             (
                 test_neg_span,
-                GrmtoolsSectionValue::Bool(
-                    false,
-                    test_neg_val_span,
-                ),
+                GrmtoolsSectionValue::Bool(false, test_neg_val_span),
             ),
         );
         test_crate_expected.insert(
@@ -1090,13 +1082,8 @@ start -> () : "a" { () };
         assert_eq!(test_crate_parsed, test_crate_expected);
 
         let mut cfgrammar_crate_expected = HashMap::new();
-        let yacckind_span_start = src.find("yacckind").unwrap();
-        let yacckind_span = Span::new(yacckind_span_start, yacckind_span_start + "yacckind".len());
-        let yacckind_val_span_start = src.find("Grmtools").unwrap();
-        let yacckind_val_span = Span::new(
-            yacckind_val_span_start,
-            yacckind_val_span_start + "Grmtools".len(),
-        );
+        let yacckind_span = src.find_span("yacckind");
+        let yacckind_val_span = src.find_span("Grmtools");
         cfgrammar_crate_expected.insert(
             "cfgrammar.yacckind".to_string(),
             (
@@ -1113,16 +1100,8 @@ start -> () : "a" { () };
         assert_eq!(cfgrammar_crate_parsed, cfgrammar_crate_expected);
 
         let mut lrpar_crate_expected = HashMap::new();
-        let recoverer_span_start = src.find("lrpar.recoverer").unwrap();
-        let recoverer_span = Span::new(
-            recoverer_span_start,
-            recoverer_span_start + "lrpar.recoverer".len(),
-        );
-        let recoverer_val_span_start = src.find("CPCTPlus").unwrap();
-        let recoverer_val_span = Span::new(
-            recoverer_val_span_start,
-            recoverer_val_span_start + "CPCTPlus".len(),
-        );
+        let recoverer_span = src.find_span("lrpar.recoverer");
+        let recoverer_val_span = src.find_span("CPCTPlus");
         lrpar_crate_expected.insert(
             "lrpar.recoverer".to_string(),
             (
@@ -1137,5 +1116,51 @@ start -> () : "a" { () };
             .map(|(key, (key_span, val))| (key.clone(), (*key_span, val.clone())))
             .collect::<HashMap<_, _>>();
         assert_eq!(lrpar_crate_parsed, lrpar_crate_expected);
+    }
+
+    #[test]
+    fn test_grmtools_section_values2() {
+        use super::*;
+        let src = r#"
+%grmtools {
+   yacckind: Original(YaccOriginalActionKind::UserAction),
+}
+%token a
+%actiontype ()
+%%
+start: "a" { () };
+"#;
+        let ast_validity = ASTWithValidityInfo::from_str(src).unwrap();
+        let mut cfgrammar_crate_expected = HashMap::new();
+        let yacckind_span = src.find_span("yacckind");
+        let yacckind_val_span = src.find_span("Original(YaccOriginalActionKind::UserAction)");
+        cfgrammar_crate_expected.insert(
+            "cfgrammar.yacckind".to_string(),
+            (
+                yacckind_span,
+                // The actual value we receive has been lower cased
+                GrmtoolsSectionValue::RustLike(
+                    "original(yaccoriginalactionkind::useraction)".to_string(),
+                    yacckind_val_span,
+                ),
+            ),
+        );
+        let cfgrammar_crate_parsed = ast_validity
+            .ast()
+            .grmtools_section_values_for_crate("cfgrammar")
+            .map(|(key, (key_span, val))| (key.clone(), (*key_span, val.clone())))
+            .collect::<HashMap<_, _>>();
+        assert_eq!(cfgrammar_crate_parsed, cfgrammar_crate_expected);
+    }
+
+    trait FindSpan {
+        fn find_span(&self, s: &str) -> Span;
+    }
+
+    impl FindSpan for &'_ str {
+        fn find_span(&self, s: &str) -> Span {
+            let start_pos = self.find(s).unwrap();
+            Span::new(start_pos, start_pos + s.len())
+        }
     }
 }

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -14,7 +14,9 @@ use super::{
 
 use crate::{
     Span,
-    header::{GrmtoolsSectionParser, HeaderError, HeaderErrorKind, HeaderValue},
+    header::{
+        GrmtoolsSectionParser, GrmtoolsSectionValue, HeaderError, HeaderErrorKind, HeaderValue,
+    },
     yacc::YaccOriginalActionKind,
 };
 
@@ -178,6 +180,7 @@ pub struct GrammarAST {
     // The set of symbol names that, if unused in a
     // grammar, will not cause a warning or error.
     pub expect_unused: Vec<Symbol>,
+    pub grmtools_section: HashMap<String, (Span, GrmtoolsSectionValue)>,
 }
 
 #[derive(Debug, Clone)]
@@ -255,6 +258,7 @@ impl GrammarAST {
             parse_generics: None,
             programs: None,
             expect_unused: Vec::new(),
+            grmtools_section: HashMap::new(),
         }
     }
 
@@ -542,6 +546,20 @@ impl GrammarAST {
                         }
                     }),
             )
+    }
+
+    pub fn grmtools_section_values(
+        &self,
+    ) -> impl Iterator<Item = (&String, &(Span, GrmtoolsSectionValue))> {
+        self.grmtools_section.iter()
+    }
+
+    pub fn grmtools_section_values_for_crate(
+        &self,
+        crate_name: &str,
+    ) -> impl Iterator<Item = (&String, &(Span, GrmtoolsSectionValue))> {
+        self.grmtools_section_values()
+            .filter(move |(key, _)| key.starts_with(&format!("{crate_name}.")))
     }
 }
 

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -1008,7 +1008,7 @@ start -> () : "a" {$;;;; };
         use super::*;
         let src = r#"
 %grmtools {
-   YaccKind: Grmtools,
+   yacckind: Grmtools,
    lrpar.recoverer: CPCTPlus,
    test.Flag,
    !test.Negative,
@@ -1034,16 +1034,14 @@ start -> () : "a" { () };
         let test_num_val_span = src.find_span("1234");
         let mut test_crate_expected = HashMap::new();
         test_crate_expected.insert(
-            // Note the case difference.
-            "test.flag".to_string(),
+            "test.Flag".to_string(),
             (
                 test_flag_span,
                 GrmtoolsSectionValue::Bool(true, test_flag_span),
             ),
         );
         test_crate_expected.insert(
-            // Note the case difference.
-            "test.negative".to_string(),
+            "test.Negative".to_string(),
             (
                 test_neg_span,
                 GrmtoolsSectionValue::Bool(false, test_neg_val_span),
@@ -1084,14 +1082,14 @@ start -> () : "a" { () };
         assert_eq!(test_crate_parsed, test_crate_expected);
 
         let mut cfgrammar_crate_expected = HashMap::new();
-        let yacckind_span = src.find_span("YaccKind");
+        let yacckind_span = src.find_span("yacckind");
         let yacckind_val_span = src.find_span("Grmtools");
         cfgrammar_crate_expected.insert(
             "cfgrammar.yacckind".to_string(),
             (
                 yacckind_span,
                 // The actual value we receive has been lower cased
-                GrmtoolsSectionValue::RustLike("grmtools".to_string(), yacckind_val_span),
+                GrmtoolsSectionValue::RustLike("Grmtools".to_string(), yacckind_val_span),
             ),
         );
         let cfgrammar_crate_parsed = ast_validity
@@ -1108,8 +1106,7 @@ start -> () : "a" { () };
             "lrpar.recoverer".to_string(),
             (
                 recoverer_span,
-                // The actual value we receive has been lower cased
-                GrmtoolsSectionValue::RustLike("cpctplus".to_string(), recoverer_val_span),
+                GrmtoolsSectionValue::RustLike("CPCTPlus".to_string(), recoverer_val_span),
             ),
         );
         let lrpar_crate_parsed = ast_validity
@@ -1140,9 +1137,8 @@ start: "a" { () };
             "cfgrammar.yacckind".to_string(),
             (
                 yacckind_span,
-                // The actual value we receive has been lower cased
                 GrmtoolsSectionValue::RustLike(
-                    "original(yaccoriginalactionkind::useraction)".to_string(),
+                    "Original(YaccOriginalActionKind::UserAction)".to_string(),
                     yacckind_val_span,
                 ),
             ),
@@ -1175,9 +1171,8 @@ start: "a" { () };
             "cfgrammar.yacckind".to_string(),
             (
                 yacckind_span,
-                // The actual value we receive has been lower cased
                 GrmtoolsSectionValue::RustLike(
-                    "yacckind::original(yaccoriginalactionkind::useraction)".to_string(),
+                    "YaccKind::Original(YaccOriginalActionKind::UserAction)".to_string(),
                     yacckind_val_span,
                 ),
             ),
@@ -1210,9 +1205,8 @@ start: "a" { () };
             "cfgrammar.yacckind".to_string(),
             (
                 yacckind_span,
-                // The actual value we receive has been lower cased
                 GrmtoolsSectionValue::RustLike(
-                    "yacckind::original(useraction)".to_string(),
+                    "YaccKind::Original(UserAction)".to_string(),
                     yacckind_val_span,
                 ),
             ),

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -1020,48 +1020,23 @@ start -> () : "a" {$;;;; };
 %%
 start -> () : "a" { () };
 "#;
-        let ast_validity = ASTWithValidityInfo::new(YaccKind::Grmtools, src);
-        let test_flag_span_start = src.find("test.flag").unwrap();
-        let test_flag_span = Span::new(
-            test_flag_span_start,
-            test_flag_span_start + "test.flag".len(),
-        );
-        let test_neg_span_start = src.find("test.negative").unwrap();
-        let test_neg_span = Span::new(
-            test_neg_span_start,
-            test_neg_span_start + "test.negative".len(),
-        );
-        let test_string_span_start = src.find("test.string").unwrap();
-        let test_string_span = Span::new(
-            test_string_span_start,
-            test_string_span_start + "test.string".len(),
-        );
-        let test_string_val_span_start = src.find("Foo").unwrap();
-        let test_string_val_span = Span::new(
-            test_string_val_span_start,
-            test_string_val_span_start + "Foo".len(),
-        );
-        let test_vec_span_start = src.find("test.vec").unwrap();
-        let test_vec_span = Span::new(test_vec_span_start, test_vec_span_start + "test.vec".len());
-        let test_vec_a_span_start = src.find("Aaaa").unwrap();
-        let test_vec_a_span =
-            Span::new(test_vec_a_span_start, test_vec_a_span_start + "Aaaa".len());
-        let test_vec_b_span_start = src.find("Bbbb").unwrap();
-        let test_vec_b_span =
-            Span::new(test_vec_b_span_start, test_vec_b_span_start + "Bbbb".len());
-        let test_vec_val_span_start = src.find("[\"Aaaa\", \"Bbbb\"]").unwrap();
-        let test_vec_val_span = Span::new(
-            test_vec_val_span_start,
-            test_vec_val_span_start + "[\"Aaaa\", \"Bbbb\"]".len(),
-        );
-        let test_num_span_start = src.find("test.num").unwrap();
-        let test_num_span = Span::new(test_num_span_start, test_num_span_start + "test.num".len());
-        let test_num_val_span_start = src.find("1234").unwrap();
-        let test_num_val_span = Span::new(
-            test_num_val_span_start,
-            test_num_val_span_start + "1234".len(),
-        );
+        let ast_validity = ASTWithValidityInfo::from_str(src).unwrap();
 
+        let find_span = |s: &str| {
+            let start_pos = src.find(s).unwrap();
+            Span::new(start_pos, start_pos + s.len())
+        };
+        let test_flag_span = find_span("test.flag");
+        let test_neg_span = find_span("test.negative");
+        let test_neg_val_span = find_span("!test.negative");
+        let test_string_span = find_span("test.string");
+        let test_string_val_span = find_span("Foo");
+        let test_vec_span = find_span("test.vec");
+        let test_vec_a_span = find_span("Aaaa");
+        let test_vec_b_span = find_span("Bbbb");
+        let test_vec_val_span = find_span("[\"Aaaa\", \"Bbbb\"]");
+        let test_num_span = find_span("test.num");
+        let test_num_val_span = find_span("1234");
         let mut test_crate_expected = HashMap::new();
         test_crate_expected.insert(
             "test.flag".to_string(),
@@ -1076,10 +1051,7 @@ start -> () : "a" { () };
                 test_neg_span,
                 GrmtoolsSectionValue::Bool(
                     false,
-                    Span::new(
-                        test_neg_span_start - 1,
-                        test_neg_span_start + "test.negative".len(),
-                    ),
+                    test_neg_val_span,
                 ),
             ),
         );

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -1153,6 +1153,76 @@ start: "a" { () };
         assert_eq!(cfgrammar_crate_parsed, cfgrammar_crate_expected);
     }
 
+    #[test]
+    fn test_grmtools_section_values3() {
+        use super::*;
+        let src = r#"
+%grmtools {
+   yacckind: YaccKind::Original(YaccOriginalActionKind::UserAction),
+}
+%token a
+%actiontype ()
+%%
+start: "a" { () };
+"#;
+        let ast_validity = ASTWithValidityInfo::from_str(src).unwrap();
+        let mut cfgrammar_crate_expected = HashMap::new();
+        let yacckind_span = src.find_span("yacckind");
+        let yacckind_val_span = src.find_span("YaccKind::Original(YaccOriginalActionKind::UserAction)");
+        cfgrammar_crate_expected.insert(
+            "cfgrammar.yacckind".to_string(),
+            (
+                yacckind_span,
+                // The actual value we receive has been lower cased
+                GrmtoolsSectionValue::RustLike(
+                    "yacckind::original(yaccoriginalactionkind::useraction)".to_string(),
+                    yacckind_val_span,
+                ),
+            ),
+        );
+        let cfgrammar_crate_parsed = ast_validity
+            .ast()
+            .grmtools_section_values_for_crate("cfgrammar")
+            .map(|(key, (key_span, val))| (key.clone(), (*key_span, val.clone())))
+            .collect::<HashMap<_, _>>();
+        assert_eq!(cfgrammar_crate_parsed, cfgrammar_crate_expected);
+    }
+
+        #[test]
+    fn test_grmtools_section_values4() {
+        use super::*;
+        let src = r#"
+%grmtools {
+   yacckind: YaccKind::Original(UserAction),
+}
+%token a
+%actiontype ()
+%%
+start: "a" { () };
+"#;
+        let ast_validity = ASTWithValidityInfo::from_str(src).unwrap();
+        let mut cfgrammar_crate_expected = HashMap::new();
+        let yacckind_span = src.find_span("yacckind");
+        let yacckind_val_span = src.find_span("YaccKind::Original(UserAction)");
+        cfgrammar_crate_expected.insert(
+            "cfgrammar.yacckind".to_string(),
+            (
+                yacckind_span,
+                // The actual value we receive has been lower cased
+                GrmtoolsSectionValue::RustLike(
+                    "yacckind::original(useraction)".to_string(),
+                    yacckind_val_span,
+                ),
+            ),
+        );
+        let cfgrammar_crate_parsed = ast_validity
+            .ast()
+            .grmtools_section_values_for_crate("cfgrammar")
+            .map(|(key, (key_span, val))| (key.clone(), (*key_span, val.clone())))
+            .collect::<HashMap<_, _>>();
+        assert_eq!(cfgrammar_crate_parsed, cfgrammar_crate_expected);
+    }
+
     trait FindSpan {
         fn find_span(&self, s: &str) -> Span;
     }

--- a/cfgrammar/src/lib/yacc/ast.rs
+++ b/cfgrammar/src/lib/yacc/ast.rs
@@ -1008,10 +1008,10 @@ start -> () : "a" {$;;;; };
         use super::*;
         let src = r#"
 %grmtools {
-   yacckind: Grmtools,
+   YaccKind: Grmtools,
    lrpar.recoverer: CPCTPlus,
-   test.flag,
-   !test.negative,
+   test.Flag,
+   !test.Negative,
    test.string: "Foo",
    test.vec: ["Aaaa", "Bbbb"],
    test.num: 1234,
@@ -1021,9 +1021,9 @@ start -> () : "a" {$;;;; };
 start -> () : "a" { () };
 "#;
         let ast_validity = ASTWithValidityInfo::from_str(src).unwrap();
-        let test_flag_span = src.find_span("test.flag");
-        let test_neg_span = src.find_span("test.negative");
-        let test_neg_val_span = src.find_span("!test.negative");
+        let test_flag_span = src.find_span("test.Flag");
+        let test_neg_span = src.find_span("test.Negative");
+        let test_neg_val_span = src.find_span("!test.Negative");
         let test_string_span = src.find_span("test.string");
         let test_string_val_span = src.find_span("Foo");
         let test_vec_span = src.find_span("test.vec");
@@ -1034,6 +1034,7 @@ start -> () : "a" { () };
         let test_num_val_span = src.find_span("1234");
         let mut test_crate_expected = HashMap::new();
         test_crate_expected.insert(
+            // Note the case difference.
             "test.flag".to_string(),
             (
                 test_flag_span,
@@ -1041,6 +1042,7 @@ start -> () : "a" { () };
             ),
         );
         test_crate_expected.insert(
+            // Note the case difference.
             "test.negative".to_string(),
             (
                 test_neg_span,
@@ -1082,7 +1084,7 @@ start -> () : "a" { () };
         assert_eq!(test_crate_parsed, test_crate_expected);
 
         let mut cfgrammar_crate_expected = HashMap::new();
-        let yacckind_span = src.find_span("yacckind");
+        let yacckind_span = src.find_span("YaccKind");
         let yacckind_val_span = src.find_span("Grmtools");
         cfgrammar_crate_expected.insert(
             "cfgrammar.yacckind".to_string(),
@@ -1228,6 +1230,7 @@ start: "a" { () };
     }
 
     impl FindSpan for &'_ str {
+        #[track_caller]
         fn find_span(&self, s: &str) -> Span {
             let start_pos = self.find(s).unwrap();
             Span::new(start_pos, start_pos + s.len())

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -1570,11 +1570,11 @@ mod test {
             "%grmtools{yacckind: YaccKind::Original(GenericParseTree)}
                  %%
                  Start: ;",
-            "%grmtools{yacckind: YaccKind::Original(yaccoriginalactionkind::useraction)}
+            "%grmtools{yacckind: YaccKind::Original(YaccOriginalActionKind::UserAction)}
                  %actiontype ()
                  %%
                  Start: {};",
-            "%grmtools{yacckind: Original(YACCOriginalActionKind::NoAction)}
+            "%grmtools{yacckind: Original(YaccOriginalActionKind::NoAction)}
                  %%
                  Start: ;",
             "%grmtools{yacckind: YaccKind::Grmtools}

--- a/cfgrammar/src/lib/yacc/parser.rs
+++ b/cfgrammar/src/lib/yacc/parser.rs
@@ -16,7 +16,7 @@ use wincode::{SchemaRead, SchemaWrite};
 
 use crate::{
     Span, Spanned,
-    header::{GrmtoolsSectionParser, HeaderErrorKind},
+    header::{GrmtoolsSectionParser, GrmtoolsSectionValue, HeaderErrorKind, HeaderValue},
 };
 
 pub type YaccGrammarResult<T> = Result<T, Vec<YaccGrammarError>>;
@@ -337,9 +337,15 @@ impl YaccParser<'_> {
 
     pub(crate) fn parse(&mut self) -> YaccGrammarResult<usize> {
         let mut errs = Vec::new();
-        let (_, pos) = GrmtoolsSectionParser::new(self.src, false)
+        let (header, pos) = GrmtoolsSectionParser::new(self.src, false)
             .parse()
             .map_err(|mut errs| errs.drain(..).map(|e| e.into()).collect::<Vec<_>>())?;
+        for (key, HeaderValue(key_span, value)) in header.into_iter() {
+            let value = value.clone();
+            self.ast
+                .grmtools_section
+                .insert(key.clone(), (*key_span, GrmtoolsSectionValue::from(value)));
+        }
         // We pass around an index into the *bytes* of self.src. We guarantee that at all times
         // this points to the beginning of a UTF-8 character (since multibyte characters exist, not
         // every byte within the string is also a valid character).

--- a/lrlex/src/lib/ctbuilder.rs
+++ b/lrlex/src/lib/ctbuilder.rs
@@ -98,7 +98,7 @@ impl<T: Clone> TryFrom<&Value<T>> for LexerKind {
                 member: (member, member_loc),
             })) => {
                 if let Some((ns, loc)) = namespace
-                    && ns.to_lowercase() != "lexerkind"
+                    && ns != "LexerKind"
                 {
                     return Err(HeaderError {
                         kind: HeaderErrorKind::ConversionError(
@@ -1286,9 +1286,7 @@ mod test {
     fn test_grmtools_section_lexerkind() {
         let lexerkinds = [
             "LRNonStreamingLexer",
-            "lrnonstreaminglexer",
-            "LexerKind::lrnonstreaminglexer",
-            "lexerkind::LRNonStreamingLexer",
+            "LexerKind::LRNonStreamingLexer",
         ];
         for (i, kind) in lexerkinds.iter().enumerate() {
             let lex_src = format!(

--- a/lrlex/src/lib/ctbuilder.rs
+++ b/lrlex/src/lib/ctbuilder.rs
@@ -1284,10 +1284,7 @@ mod test {
     use super::{CTLexerBuilder, LexerKind};
     #[test]
     fn test_grmtools_section_lexerkind() {
-        let lexerkinds = [
-            "LRNonStreamingLexer",
-            "LexerKind::LRNonStreamingLexer",
-        ];
+        let lexerkinds = ["LRNonStreamingLexer", "LexerKind::LRNonStreamingLexer"];
         for (i, kind) in lexerkinds.iter().enumerate() {
             let lex_src = format!(
                 "

--- a/lrpar/cttests/src/grmtools_section.test
+++ b/lrpar/cttests/src/grmtools_section.test
@@ -78,7 +78,7 @@ grammar: |
     namespaced -> Namespaced<Span>
     : IDENT {
         let ident_span = $1.as_ref().unwrap().span();
-        let ident = $lexer.span_str(ident_span).to_string().to_lowercase();
+        let ident = $lexer.span_str(ident_span).to_string();
         Namespaced{
             namespace: None,
             member: (ident, ident_span)
@@ -86,10 +86,10 @@ grammar: |
     }
     | IDENT '::' IDENT {
         let namespace_span = $1.as_ref().unwrap().span();
-        let namespace = $lexer.span_str(namespace_span).to_string().to_lowercase();
+        let namespace = $lexer.span_str(namespace_span).to_string();
 
         let ident_span = $3.as_ref().unwrap().span();
-        let ident = $lexer.span_str(ident_span).to_string().to_lowercase();
+        let ident = $lexer.span_str(ident_span).to_string();
         Namespaced {
             namespace: Some((namespace, namespace_span)),
             member: (ident, ident_span)
@@ -100,18 +100,18 @@ grammar: |
     valbind -> ((String, Span), Value<Span>)
     : IDENT ':' val {
         let key_span = $1.as_ref().unwrap().span();
-        let key = $lexer.span_str(key_span).to_string().to_lowercase();
+        let key = $lexer.span_str(key_span).to_string();
         ((key, key_span), Value::Setting($3))
     }
     | IDENT {
         let key_span = $1.as_ref().unwrap().span();
-        let key = $lexer.span_str(key_span).to_string().to_lowercase();
+        let key = $lexer.span_str(key_span).to_string();
         ((key, key_span), Value::Flag(true, key_span))
     }
     | '!' IDENT {
         let bang_span = $1.as_ref().unwrap().span();
         let key_span = $2.as_ref().unwrap().span();
-        let key = $lexer.span_str(key_span).to_string().to_lowercase();
+        let key = $lexer.span_str(key_span).to_string();
         ((key, key_span), Value::Flag(false, Span::new(bang_span.start(), key_span.end())))
     }
     ;

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -141,13 +141,13 @@ impl TryFrom<SerialisationFormat> for Value<Location> {
         let from_loc = Location::Other("From<SerialisationFormat>".to_string());
         Ok(match kind {
             SerialisationFormat::FixedSizeInteger => Value::Setting(Setting::Unitary(Namespaced {
-                namespace: Some(("serialisationformat".to_string(), from_loc.clone())),
-                member: ("fixedsizeinteger".to_string(), from_loc),
+                namespace: Some(("SerialisationFormat".to_string(), from_loc.clone())),
+                member: ("FixedSizeInteger".to_string(), from_loc),
             })),
             SerialisationFormat::VariableSizedInteger => {
                 Value::Setting(Setting::Unitary(Namespaced {
-                    namespace: Some(("serialisationformat".to_string(), from_loc.clone())),
-                    member: ("variablesizedinteger".to_string(), from_loc),
+                    namespace: Some(("SerialisationFormat".to_string(), from_loc.clone())),
+                    member: ("VariableSizedInteger".to_string(), from_loc),
                 }))
             }
         })
@@ -165,17 +165,17 @@ impl<T: Clone + Debug> TryFrom<&Value<T>> for SerialisationFormat {
                 member: (enc_value, enc_value_loc),
             })) => {
                 if let Some((ns, ns_loc)) = namespace
-                    && ns != "serialisationformat"
+                    && ns != "SerialisationFormat"
                 {
                     err_locs.push(ns_loc.clone());
                 }
                 let encodings = [
                     (
-                        "fixedsizeinteger".to_string(),
+                        "FixedSizeInteger".to_string(),
                         SerialisationFormat::FixedSizeInteger,
                     ),
                     (
-                        "variablesizedinteger".to_string(),
+                        "VariableSizedInteger".to_string(),
                         SerialisationFormat::VariableSizedInteger,
                     ),
                 ];

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -667,7 +667,7 @@ impl TryFrom<&Value<Location>> for RecoveryKind {
                 member: (kind, kind_loc),
             })) => {
                 match namespace {
-                    Some((ns, loc)) if ns.to_lowercase() != "recoverykind" => {
+                    Some((ns, loc)) if ns != "RecoveryKind" => {
                         return Err(HeaderError {
                             kind: HeaderErrorKind::ConversionError(
                                 "RecoveryKind",
@@ -678,9 +678,9 @@ impl TryFrom<&Value<Location>> for RecoveryKind {
                     }
                     _ => {}
                 }
-                match kind.to_lowercase().as_ref() {
-                    "cpctplus" => Ok(RecoveryKind::CPCTPlus),
-                    "none" => Ok(RecoveryKind::None),
+                match kind.as_ref() {
+                    "CPCTPlus" => Ok(RecoveryKind::CPCTPlus),
+                    "None" => Ok(RecoveryKind::None),
                     _ => Err(HeaderError {
                         kind: HeaderErrorKind::ConversionError("RecoveryKind", "Unknown variant"),
                         locations: vec![kind_loc.clone()],
@@ -1367,7 +1367,7 @@ Call: 'ID' '(' ')';";
 \* '*'
 "#;
         let grammar_src = "
-%grmtools{YaccKind: Original(NoAction)}
+%grmtools{yacckind: Original(NoAction)}
 %start Expr
 %%
 Expr : Expr '+' Term | Term;

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -185,9 +185,9 @@ fn main() {
                 "lrpar.recoverer".to_string(),
                 HeaderValue(
                     Location::CommandLine,
-                    Value::try_from(match &*s.to_lowercase() {
-                        "cpctplus" => RecoveryKind::CPCTPlus,
-                        "none" => RecoveryKind::None,
+                    Value::try_from(match &*s {
+                        "CPCTPlus" => RecoveryKind::CPCTPlus,
+                        "None" => RecoveryKind::None,
                         _ => usage(prog, &format!("Unknown recoverer '{}'.", s)),
                     })
                     .expect("All these RecoveryKinds should convert without error"),
@@ -204,10 +204,10 @@ fn main() {
         Some(s) => {
             entry.insert_entry(HeaderValue(
                 Location::CommandLine,
-                Value::try_from(match &*s.to_lowercase() {
-                    "eco" => YaccKind::Eco,
-                    "grmtools" => YaccKind::Grmtools,
-                    "original" => YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
+                Value::try_from(match &*s {
+                    "Eco" => YaccKind::Eco,
+                    "Grmtools" => YaccKind::Grmtools,
+                    "Original" => YaccKind::Original(YaccOriginalActionKind::GenericParseTree),
                     _ => usage(prog, &format!("Unknown Yacc variant '{}'.", s)),
                 })
                 .expect("All these yacckinds should convert without error"),


### PR DESCRIPTION
This is a work in progress, it converts the `HeaderValue` into a simplified value type.
As of this time the conversion of the `RustLike` values (and their spans) is still largely untested.

User specified values will still trigger a `Unused entry` error. This is all I had time for today, will work on that tomorrow.