### PR TITLE
Simplify Header::Value

### DIFF
--- a/cfgrammar/src/lib/header.rs
+++ b/cfgrammar/src/lib/header.rs
@@ -90,57 +90,6 @@ impl fmt::Display for HeaderErrorKind {
     }
 }
 
-impl<T> HeaderError<T> {
-    /// Returns the [SpansKind] associated with this error.
-    pub fn spanskind(&self) -> SpansKind {
-        match self.kind {
-            HeaderErrorKind::DuplicateEntry => SpansKind::DuplicationError,
-            _ => SpansKind::Error,
-        }
-    }
-}
-
-/// Indicates a value prefixed by an optional namespace.
-/// `Foo::Bar` with optional `Foo` specified being
-/// ```rust,ignore
-/// Namespaced{
-///     namespace: Some(("Foo", ...)),
-///     member: ("Bar", ...)
-/// }
-/// ```
-///
-/// Alternately just `Bar` alone without a namespace is represented by :
-/// ```rust,ignore
-/// Namespaced{
-///     namespace: None,
-///     member: ("Bar", ...)
-/// }
-/// ```
-#[derive(Debug, Eq, PartialEq)]
-#[doc(hidden)]
-pub struct Namespaced<T> {
-    pub namespace: Option<(String, T)>,
-    pub member: (String, T),
-}
-
-#[derive(Debug, Eq, PartialEq)]
-#[doc(hidden)]
-pub enum Setting<T> {
-    /// A value like `YaccKind::Grmtools`
-    Unitary(Namespaced<T>),
-    /// A value like `YaccKind::Original(UserActions)`.
-    /// In that example the field ctor would be: `Namespaced { namespace: "YaccKind", member: "Original" }`.
-    /// The field would be `Namespaced{ None, UserActions }`.
-    Constructor {
-        ctor: Namespaced<T>,
-        arg: Namespaced<T>,
-    },
-    Num(u64, T),
-    String(String, T),
-    // The two `T` values are for the spans of the open and close brackets `[`, and `]`.
-    Array(Vec<Setting<T>>, T, T),
-}
-
 /// Parser for the `%grmtools` section
 #[doc(hidden)]
 pub struct GrmtoolsSectionParser<'input> {
@@ -150,89 +99,52 @@ pub struct GrmtoolsSectionParser<'input> {
 
 /// The value contained within a `Header`
 ///
-/// To be useful across diverse crates this types fields are limited to types derived from `core::` types.
-/// like booleans, numeric types, and string values.
-#[derive(Debug, Eq, PartialEq)]
-#[doc(hidden)]
+/// To be useful across diverse crates this types fields are largely limited to types derived from `core::` types.
+/// like booleans, numeric types, and string values. The exception to this is `Namespaced` which still must
+///  be able to be marshalled through a string value.
+///
+/// The generic parameter `T` indicates the source of the value, for values read from a `%grmtools` section
+/// this should be a `Span`. For other values which stem from command line arguments, or a programmatic interface
+/// this should be a `Location`.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum Value<T> {
-    Flag(bool, T),
-    Setting(Setting<T>),
-}
-
-impl From<Setting<Span>> for Setting<Location> {
-    fn from(s: Setting<Span>) -> Setting<Location> {
-        match s {
-            Setting::Unitary(Namespaced {
-                namespace,
-                member: (m, ml),
-            }) => Setting::Unitary(Namespaced {
-                namespace: namespace.map(|(n, nl)| (n, nl.into())),
-                member: (m, ml.into()),
-            }),
-            Setting::Constructor {
-                ctor:
-                    Namespaced {
-                        namespace: ctor_ns,
-                        member: (ctor_m, ctor_ml),
-                    },
-                arg:
-                    Namespaced {
-                        namespace: arg_ns,
-                        member: (arg_m, arg_ml),
-                    },
-            } => Setting::Constructor {
-                ctor: Namespaced {
-                    namespace: ctor_ns.map(|(ns, ns_l)| (ns, ns_l.into())),
-                    member: (ctor_m, ctor_ml.into()),
-                },
-                arg: Namespaced {
-                    namespace: arg_ns.map(|(ns, ns_l)| (ns, ns_l.into())),
-                    member: (arg_m, arg_ml.into()),
-                },
-            },
-            Setting::Num(num, num_loc) => Setting::Num(num, num_loc.into()),
-            Setting::String(s, str_loc) => Setting::String(s, str_loc.into()),
-            Setting::Array(mut xs, arr_open_loc, arr_close_loc) => Setting::Array(
-                xs.drain(..).map(|x| x.into()).collect(),
-                arr_open_loc.into(),
-                arr_close_loc.into(),
-            ),
-        }
-    }
+    String(String, T),
+    Num(u64, T),
+    Bool(bool, T),
+    Array(Vec<Value<T>>, T),
+    /// A Rust like value, with an optional type namespace.
+    /// For instance, you can omit the optional prefix `YaccKind::`
+    /// specifying `YaccKind::Grmtools` or `Grmtools`.
+    ///
+    /// Further examples of `Namespaced` values:
+    /// * YaccKind::Original(UserAction) or YaccKind::Original(YaccOriginalActionKind::UserAction)
+    /// * Original(UserAction) or Original(YaccOriginalActionKind::UserAction)
+    Namespaced(String, T),
 }
 
 impl From<Value<Span>> for Value<Location> {
-    fn from(v: Value<Span>) -> Value<Location> {
-        match v {
-            Value::Flag(flag, u) => Value::Flag(flag, u.into()),
-            Value::Setting(s) => Value::Setting(s.into()),
+    fn from(it: Value<Span>) -> Value<Location> {
+        use Value as GV;
+        match it {
+            GV::String(v, span) => GV::String(v, Location::Span(span)),
+            GV::Num(v, span) => GV::Num(v, Location::Span(span)),
+            GV::Bool(v, span) => GV::Bool(v, Location::Span(span)),
+            GV::Array(mut v, span) => GV::Array(
+                v.drain(..).map(|val| val.into()).collect::<Vec<_>>(),
+                Location::Span(span),
+            ),
+            GV::Namespaced(v, span) => GV::Namespaced(v, Location::Span(span)),
         }
     }
 }
 
-impl<T> Value<T> {
-    pub fn primary_location(&self) -> &T {
-        match self {
-            Value::Flag(_, loc) => loc,
-            Value::Setting(setting) => setting.primary_location(),
+impl<T> HeaderError<T> {
+    /// Returns the [SpansKind] associated with this error.
+    pub fn spanskind(&self) -> SpansKind {
+        match self.kind {
+            HeaderErrorKind::DuplicateEntry => SpansKind::DuplicationError,
+            _ => SpansKind::Error,
         }
-    }
-}
-
-impl<T> Setting<T> {
-    fn primary_location(&self) -> &T {
-        match self {
-            Self::Constructor { arg, .. } => arg.primary_location(),
-            Self::Unitary(ns) => ns.primary_location(),
-            Self::Array(_, start_loc, _) => start_loc,
-            Self::Num(_, loc) | Self::String(_, loc) => loc,
-        }
-    }
-}
-
-impl<T> Namespaced<T> {
-    fn primary_location(&self) -> &T {
-        &self.member.1
     }
 }
 
@@ -311,7 +223,7 @@ fn add_duplicate_occurrence<T: Eq + PartialEq + Clone>(
 }
 
 impl<'input> GrmtoolsSectionParser<'input> {
-    fn parse_setting(&'_ self, mut i: usize) -> Result<(Setting<Span>, usize), HeaderError<Span>> {
+    fn parse_value(&'_ self, mut i: usize) -> Result<(Value<Span>, usize), HeaderError<Span>> {
         i = self.parse_ws(i);
         match RE_DIGITS.find(&self.src[i..]) {
             Some(m) => {
@@ -319,7 +231,7 @@ impl<'input> GrmtoolsSectionParser<'input> {
                 let num_str = &self.src[num_span.start()..num_span.end()];
                 // If the above regex matches we expect this to succeed.
                 let num = str::parse::<u64>(num_str).unwrap();
-                let val = Setting::Num(num, num_span);
+                let val = Value::Num(num, num_span);
                 i = self.parse_ws(num_span.end());
                 Ok((val, i))
             }
@@ -329,7 +241,7 @@ impl<'input> GrmtoolsSectionParser<'input> {
                     // Trim the leading and trailing quotes.
                     let str_span = Span::new(i + m.start() + 1, end - 1);
                     let str = &self.src[str_span.start()..str_span.end()];
-                    let setting = Setting::String(str.to_string(), str_span);
+                    let setting = Value::String(str.to_string(), str_span);
                     // After the trailing quotes.
                     i = self.parse_ws(end);
                     Ok((setting, i))
@@ -337,21 +249,12 @@ impl<'input> GrmtoolsSectionParser<'input> {
                 None => {
                     if let Some(mut j) = self.lookahead_is("[", i) {
                         let mut vals = Vec::new();
-                        let open_pos = j;
-
                         loop {
                             j = self.parse_ws(j);
                             if let Some(end_pos) = self.lookahead_is("]", j) {
-                                return Ok((
-                                    Setting::Array(
-                                        vals,
-                                        Span::new(i, open_pos),
-                                        Span::new(j, end_pos),
-                                    ),
-                                    end_pos,
-                                ));
+                                return Ok((Value::Array(vals, Span::new(i, end_pos)), end_pos));
                             }
-                            if let Ok((val, k)) = self.parse_setting(j) {
+                            if let Ok((val, k)) = self.parse_value(j) {
                                 vals.push(val);
                                 j = self.parse_ws(k);
                             }
@@ -360,20 +263,15 @@ impl<'input> GrmtoolsSectionParser<'input> {
                             }
                         }
                     } else {
-                        let (path_val, j) = self.parse_namespaced(i)?;
+                        let ((path_val, path_span), j) = self.parse_namespaced(i)?;
                         i = self.parse_ws(j);
                         if let Some(j) = self.lookahead_is("(", i) {
-                            let (arg, j) = self.parse_namespaced(j)?;
+                            let ((arg, _), j) = self.parse_namespaced(j)?;
                             i = self.parse_ws(j);
                             if let Some(j) = self.lookahead_is(")", i) {
                                 i = self.parse_ws(j);
-                                Ok((
-                                    Setting::Constructor {
-                                        ctor: path_val,
-                                        arg,
-                                    },
-                                    i,
-                                ))
+                                let span = Span::new(path_span.start(), j);
+                                Ok(((Value::Namespaced(format!("{path_val}({arg})"), span)), i))
                             } else {
                                 Err(HeaderError {
                                     kind: HeaderErrorKind::ExpectedToken(')'),
@@ -381,7 +279,7 @@ impl<'input> GrmtoolsSectionParser<'input> {
                                 })
                             }
                         } else {
-                            Ok((Setting::Unitary(path_val), i))
+                            Ok((Value::Namespaced(path_val, path_span), i))
                         }
                     }
                 }
@@ -398,7 +296,7 @@ impl<'input> GrmtoolsSectionParser<'input> {
             Ok((
                 flag_name,
                 Span::new(j, k),
-                Value::Flag(false, Span::new(i, k)),
+                Value::Bool(false, Span::new(i, k)),
                 self.parse_ws(k),
             ))
         } else {
@@ -406,19 +304,16 @@ impl<'input> GrmtoolsSectionParser<'input> {
             let key_span = Span::new(i, j);
             i = self.parse_ws(j);
             if let Some(j) = self.lookahead_is(":", i) {
-                let (val, j) = self.parse_setting(j)?;
-                Ok((key_name, key_span, Value::Setting(val), j))
+                let (val, j) = self.parse_value(j)?;
+                Ok((key_name, key_span, val, j))
             } else {
-                Ok((key_name, key_span, Value::Flag(true, key_span), i))
+                Ok((key_name, key_span, Value::Bool(true, key_span), i))
             }
         }
     }
 
-    fn parse_namespaced(
-        &self,
-        mut i: usize,
-    ) -> Result<(Namespaced<Span>, usize), HeaderError<Span>> {
-        // Either a name alone, or a namespace which will be followed by a member.
+    fn parse_namespaced(&self, mut i: usize) -> Result<((String, Span), usize), HeaderError<Span>> {
+        // Either a name alone, or a type::name.
         let (name, j) = self.parse_name(i)?;
         let name_span = Span::new(i, j);
         i = self.parse_ws(j);
@@ -427,21 +322,10 @@ impl<'input> GrmtoolsSectionParser<'input> {
             let (member_val, j) = self.parse_name(i)?;
             let member_val_span = Span::new(i, j);
             i = self.parse_ws(j);
-            Ok((
-                Namespaced {
-                    namespace: Some((name, name_span)),
-                    member: (member_val, member_val_span),
-                },
-                i,
-            ))
+            let span = Span::new(name_span.start(), member_val_span.end());
+            Ok(((format!("{name}::{member_val}"), span), i))
         } else {
-            Ok((
-                Namespaced {
-                    namespace: None,
-                    member: (name, name_span),
-                },
-                i,
-            ))
+            Ok(((name, name_span), i))
         }
     }
 
@@ -552,10 +436,7 @@ impl<'input> GrmtoolsSectionParser<'input> {
         match RE_NAME.find(&self.src[i..]) {
             Some(m) => {
                 assert_eq!(m.start(), 0);
-                Ok((
-                    self.src[i..i + m.end()].to_string().to_lowercase(),
-                    i + m.end(),
-                ))
+                Ok((self.src[i..i + m.end()].to_string(), i + m.end()))
             }
             None => {
                 if self.src[i..].starts_with("*") {
@@ -600,134 +481,57 @@ impl TryFrom<YaccKind> for Value<Location> {
     type Error = HeaderError<Location>;
     fn try_from(kind: YaccKind) -> Result<Value<Location>, HeaderError<Location>> {
         let from_loc = Location::Other("From<YaccKind>".to_string());
-        Ok(match kind {
-            YaccKind::Grmtools => Value::Setting(Setting::Unitary(Namespaced {
-                namespace: Some(("yacckind".to_string(), from_loc.clone())),
-                member: ("grmtools".to_string(), from_loc),
-            })),
-            YaccKind::Eco => Value::Setting(Setting::Unitary(Namespaced {
-                namespace: Some(("yacckind".to_string(), from_loc.clone())),
-                member: ("eco".to_string(), from_loc),
-            })),
-            YaccKind::Original(action_kind) => Value::Setting(Setting::Constructor {
-                ctor: Namespaced {
-                    namespace: Some(("yacckind".to_string(), from_loc.clone())),
-                    member: ("original".to_string(), from_loc.clone()),
-                },
-                arg: match action_kind {
-                    YaccOriginalActionKind::NoAction => Namespaced {
-                        namespace: Some(("yaccoriginalactionkind".to_string(), from_loc.clone())),
-                        member: ("noaction".to_string(), from_loc),
-                    },
-                    YaccOriginalActionKind::UserAction => Namespaced {
-                        namespace: Some(("yaccoriginalactionkind".to_string(), from_loc.clone())),
-                        member: ("useraction".to_string(), from_loc),
-                    },
-                    YaccOriginalActionKind::GenericParseTree => Namespaced {
-                        namespace: Some(("yaccoriginalactionkind".to_string(), from_loc.clone())),
-                        member: ("genericparsetree".to_string(), from_loc),
-                    },
-                },
-            }),
-        })
+        Ok(Value::Namespaced(format!("YaccKind::{kind:?}"), from_loc))
     }
 }
 
 impl<T: Clone> TryFrom<&Value<T>> for YaccKind {
     type Error = HeaderError<T>;
     fn try_from(value: &Value<T>) -> Result<YaccKind, HeaderError<T>> {
-        let mut err_locs = Vec::new();
         match value {
-            Value::Setting(Setting::Unitary(Namespaced {
-                namespace,
-                member: (yk_value, yk_value_loc),
-            })) => {
-                if let Some((ns, ns_loc)) = namespace
-                    && ns != "yacckind"
-                {
-                    err_locs.push(ns_loc.clone());
+            Value::Namespaced(kind, loc) => match kind.as_str() {
+                "YaccKind::Grmtools" | "Grmtools" => Ok(YaccKind::Grmtools),
+                "YaccKind::Eco" | "Eco" => Ok(YaccKind::Eco),
+                "YaccKind::Original(UserAction)"
+                | "Original(UserAction)"
+                | "Original(YaccOriginalActionKind::UserAction)"
+                | "YaccKind::Original(YaccOriginalActionKind::UserAction)" => {
+                    Ok(YaccKind::Original(YaccOriginalActionKind::UserAction))
                 }
-                let yacckinds = [
-                    ("grmtools".to_string(), YaccKind::Grmtools),
-                    ("eco".to_string(), YaccKind::Eco),
-                ];
-                let yk_found = yacckinds
-                    .iter()
-                    .find_map(|(yk_str, yk)| (yk_str == yk_value).then_some(yk));
-                if let Some(yk) = yk_found {
-                    if err_locs.is_empty() {
-                        Ok(*yk)
-                    } else {
-                        Err(HeaderError {
-                            kind: HeaderErrorKind::InvalidEntry("yacckind"),
-                            locations: err_locs,
-                        })
-                    }
-                } else {
-                    err_locs.push(yk_value_loc.clone());
-                    Err(HeaderError {
-                        kind: HeaderErrorKind::InvalidEntry("yacckind"),
-                        locations: err_locs,
-                    })
+                "YaccKind::Original(NoAction)"
+                | "Original(NoAction)"
+                | "Original(YaccOriginalActionKind::NoAction)"
+                | "YaccKind::Original(YaccOriginalActionKind::NoAction)" => {
+                    Ok(YaccKind::Original(YaccOriginalActionKind::NoAction))
                 }
-            }
-            Value::Setting(Setting::Constructor {
-                ctor:
-                    Namespaced {
-                        namespace: yk_namespace,
-                        member: (yk_str, yk_loc),
-                    },
-                arg:
-                    Namespaced {
-                        namespace: ak_namespace,
-                        member: (ak_str, ak_loc),
-                    },
-            }) => {
-                if let Some((yk_ns, yk_ns_loc)) = yk_namespace
-                    && yk_ns != "yacckind"
-                {
-                    err_locs.push(yk_ns_loc.clone());
+                "YaccKind::Original(GenericParseTree)"
+                | "Original(GenericParseTree)"
+                | "Original(YaccOriginalActionKind::GenericParseTree)"
+                | "YaccKind::Original(YaccOriginalActionKind::GenericParseTree)" => {
+                    Ok(YaccKind::Original(YaccOriginalActionKind::GenericParseTree))
                 }
-
-                if yk_str != "original" {
-                    err_locs.push(yk_loc.clone());
-                }
-
-                if let Some((ak_ns, ak_ns_loc)) = ak_namespace
-                    && ak_ns != "yaccoriginalactionkind"
-                {
-                    err_locs.push(ak_ns_loc.clone());
-                }
-                let actionkinds = [
-                    ("noaction", YaccOriginalActionKind::NoAction),
-                    ("useraction", YaccOriginalActionKind::UserAction),
-                    ("genericparsetree", YaccOriginalActionKind::GenericParseTree),
-                ];
-                let yk_found = actionkinds.iter().find_map(|(actionkind_str, actionkind)| {
-                    (ak_str == actionkind_str).then_some(YaccKind::Original(*actionkind))
-                });
-
-                if let Some(yk) = yk_found {
-                    if err_locs.is_empty() {
-                        Ok(yk)
-                    } else {
-                        Err(HeaderError {
-                            kind: HeaderErrorKind::InvalidEntry("yacckind"),
-                            locations: err_locs,
-                        })
-                    }
-                } else {
-                    err_locs.push(ak_loc.clone());
-                    Err(HeaderError {
-                        kind: HeaderErrorKind::InvalidEntry("yacckind"),
-                        locations: err_locs,
-                    })
-                }
-            }
+                _ => Err(HeaderError {
+                    kind: HeaderErrorKind::InvalidEntry("cfgrammar.yacckind"),
+                    locations: vec![loc.clone()],
+                }),
+            },
             val => Err(HeaderError {
-                kind: HeaderErrorKind::InvalidEntry("yacckind"),
+                kind: HeaderErrorKind::InvalidEntry("cfgrammar.yacckind"),
                 locations: vec![val.primary_location().clone()],
             }),
+        }
+    }
+}
+
+impl<T> Value<T> {
+    #[doc(hidden)]
+    pub fn primary_location(&self) -> &T {
+        match self {
+            Self::Array(_, loc)
+            | Self::Bool(_, loc)
+            | Self::Num(_, loc)
+            | Self::Namespaced(_, loc)
+            | Self::String(_, loc) => loc,
         }
     }
 }

--- a/cfgrammar/src/lib/yacc/grammar.rs
+++ b/cfgrammar/src/lib/yacc/grammar.rs
@@ -1570,11 +1570,11 @@ mod test {
             "%grmtools{yacckind: YaccKind::Original(GenericParseTree)}
                  %%
                  Start: ;",
-            "%grmtools{yacckind: YaccKind::Original(yaccoriginalactionkind::useraction)}
+            "%grmtools{yacckind: YaccKind::Original(YaccOriginalActionKind::UserAction)}
                  %actiontype ()
                  %%
                  Start: {};",
-            "%grmtools{yacckind: Original(YACCOriginalActionKind::NoAction)}
+            "%grmtools{yacckind: Original(YaccOriginalActionKind::NoAction)}
                  %%
                  Start: ;",
             "%grmtools{yacckind: YaccKind::Grmtools}

--- a/lrlex/src/lib/ctbuilder.rs
+++ b/lrlex/src/lib/ctbuilder.rs
@@ -1,7 +1,7 @@
 //! Build grammars at run-time.
 
 use cfgrammar::{
-    header::{Header, HeaderError, HeaderErrorKind, HeaderValue, Namespaced, Setting, Value},
+    header::{Header, HeaderError, HeaderErrorKind, HeaderValue, Value},
     markmap::MergeBehavior,
     span::{Location, Span},
 };
@@ -51,75 +51,19 @@ impl<T: Clone> TryFrom<&Value<T>> for LexerKind {
     type Error = cfgrammar::header::HeaderError<T>;
     fn try_from(it: &Value<T>) -> Result<LexerKind, Self::Error> {
         match it {
-            Value::Flag(_, loc) => Err(HeaderError {
-                kind: HeaderErrorKind::ConversionError(
-                    "LexerKind",
-                    "Expected `LexerKind` found bool",
-                ),
-                locations: vec![loc.clone()],
-            }),
-            Value::Setting(Setting::Num(_, loc)) => Err(HeaderError {
-                kind: HeaderErrorKind::ConversionError(
-                    "LexerKind",
-                    "Expected `LexerKind` found numeric",
-                ),
-                locations: vec![loc.clone()],
-            }),
-            Value::Setting(Setting::String(_, loc)) => Err(HeaderError {
-                kind: HeaderErrorKind::ConversionError(
-                    "LexerKind",
-                    "Expected `LexerKind` found string",
-                ),
-                locations: vec![loc.clone()],
-            }),
-            Value::Setting(Setting::Constructor {
-                ctor:
-                    Namespaced {
-                        namespace: _,
-                        member: (_, loc),
-                    },
-                arg: _,
-            }) => Err(HeaderError {
-                kind: HeaderErrorKind::ConversionError(
-                    "LexerKind",
-                    "Expected `LexerKind` found constructor",
-                ),
-                locations: vec![loc.clone()],
-            }),
-            Value::Setting(Setting::Array(_, arr_loc, _)) => Err(HeaderError {
-                kind: HeaderErrorKind::ConversionError(
-                    "LexerKind",
-                    "Expected `LexerKind` found array",
-                ),
-                locations: vec![arr_loc.clone()],
-            }),
-            Value::Setting(Setting::Unitary(Namespaced {
-                namespace,
-                member: (member, member_loc),
-            })) => {
-                if let Some((ns, loc)) = namespace
-                    && ns.to_lowercase() != "lexerkind"
-                {
-                    return Err(HeaderError {
-                        kind: HeaderErrorKind::ConversionError(
-                            "LexerKind",
-                            "Expected namespace `LexerKind`",
-                        ),
-                        locations: vec![loc.clone()],
-                    });
+            Value::Namespaced(rs, loc) => match rs.as_str() {
+                "LexerKind::LRNonStreamingLexer" | "LRNonStreamingLexer" => {
+                    Ok(LexerKind::LRNonStreamingLexer)
                 }
-                if member.to_lowercase() != "lrnonstreaminglexer" {
-                    return Err(HeaderError {
-                        kind: HeaderErrorKind::ConversionError(
-                            "LexerKind",
-                            "Unknown `LexerKind` Variant",
-                        ),
-                        locations: vec![member_loc.clone()],
-                    });
-                }
-
-                Ok(LexerKind::LRNonStreamingLexer)
-            }
+                _ => Err(HeaderError {
+                    kind: HeaderErrorKind::ConversionError("LexerKind", "Expected `LexerKind`"),
+                    locations: vec![loc.clone()],
+                }),
+            },
+            val => Err(HeaderError {
+                kind: HeaderErrorKind::ConversionError("LexerKind", "Expected `LexerKind`"),
+                locations: vec![val.primary_location().clone()],
+            }),
         }
     }
 }
@@ -516,10 +460,10 @@ where
                         }
                     };
                     match test_glob {
-                        Some(HeaderValue(_, Value::Setting(Setting::Array(test_globs, _, _)))) => {
+                        Some(HeaderValue(_, Value::Array(test_globs, _))) => {
                             for setting in test_globs {
                                 match setting {
-                                    Setting::String(test_files, _) => {
+                                    Value::String(test_files, _) => {
                                         let path_joined = grm_path.parent().unwrap().join(test_files);
                                         let path_str = &path_joined.to_string_lossy();
                                         let mut glob_paths = glob(path_str).map_err(|e| e.to_string())?.peekable();
@@ -846,7 +790,7 @@ where
             key,
             HeaderValue(
                 Location::Other("CTLexerBuilder".to_string()),
-                Value::Flag(flag, Location::Other("CTLexerBuilder".to_string())),
+                Value::Bool(flag, Location::Other("CTLexerBuilder".to_string())),
             ),
         );
         self
@@ -862,7 +806,7 @@ where
             key,
             HeaderValue(
                 Location::Other("CTLexerBuilder".to_string()),
-                Value::Flag(flag, Location::Other("CTLexerBuilder".to_string())),
+                Value::Bool(flag, Location::Other("CTLexerBuilder".to_string())),
             ),
         );
         self
@@ -878,7 +822,7 @@ where
             key,
             HeaderValue(
                 Location::Other("CTLexerBuilder".to_string()),
-                Value::Flag(flag, Location::Other("CTLexerBuilder".to_string())),
+                Value::Bool(flag, Location::Other("CTLexerBuilder".to_string())),
             ),
         );
         self
@@ -894,7 +838,7 @@ where
             key,
             HeaderValue(
                 Location::Other("CTLexerBuilder".to_string()),
-                Value::Flag(flag, Location::Other("CTLexerBuilder".to_string())),
+                Value::Bool(flag, Location::Other("CTLexerBuilder".to_string())),
             ),
         );
         self
@@ -910,7 +854,7 @@ where
             key,
             HeaderValue(
                 Location::Other("CTLexerBuilder".to_string()),
-                Value::Flag(flag, Location::Other("CTLexerBuilder".to_string())),
+                Value::Bool(flag, Location::Other("CTLexerBuilder".to_string())),
             ),
         );
         self
@@ -926,7 +870,7 @@ where
             key,
             HeaderValue(
                 Location::Other("CTLexerBuilder".to_string()),
-                Value::Flag(flag, Location::Other("CTLexerBuilder".to_string())),
+                Value::Bool(flag, Location::Other("CTLexerBuilder".to_string())),
             ),
         );
         self
@@ -942,7 +886,7 @@ where
             key,
             HeaderValue(
                 Location::Other("CTLexerBuilder".to_string()),
-                Value::Flag(flag, Location::Other("CTLexerBuilder".to_string())),
+                Value::Bool(flag, Location::Other("CTLexerBuilder".to_string())),
             ),
         );
         self
@@ -958,7 +902,7 @@ where
             key,
             HeaderValue(
                 Location::Other("CTLexerBuilder".to_string()),
-                Value::Flag(flag, Location::Other("CTLexerBuilder".to_string())),
+                Value::Bool(flag, Location::Other("CTLexerBuilder".to_string())),
             ),
         );
         self
@@ -974,7 +918,7 @@ where
             key,
             HeaderValue(
                 Location::Other("CTLexerBuilder".to_string()),
-                Value::Flag(flag, Location::Other("CTLexerBuilder".to_string())),
+                Value::Bool(flag, Location::Other("CTLexerBuilder".to_string())),
             ),
         );
         self
@@ -990,10 +934,7 @@ where
             key,
             HeaderValue(
                 Location::Other("CTLexerBuilder".to_string()),
-                Value::Setting(Setting::Num(
-                    sz as u64,
-                    Location::Other("CTLexerBuilder".to_string()),
-                )),
+                Value::Num(sz as u64, Location::Other("CTLexerBuilder".to_string())),
             ),
         );
         self
@@ -1009,10 +950,7 @@ where
             key,
             HeaderValue(
                 Location::Other("CTLexerBuilder".to_string()),
-                Value::Setting(Setting::Num(
-                    sz as u64,
-                    Location::Other("CTLexerBuilder".to_string()),
-                )),
+                Value::Num(sz as u64, Location::Other("CTLexerBuilder".to_string())),
             ),
         );
         self
@@ -1028,10 +966,7 @@ where
             key,
             HeaderValue(
                 Location::Other("CTLexerBuilder".to_string()),
-                Value::Setting(Setting::Num(
-                    lim as u64,
-                    Location::Other("CTLexerBuilder".to_string()),
-                )),
+                Value::Num(lim as u64, Location::Other("CTLexerBuilder".to_string())),
             ),
         );
         self
@@ -1284,12 +1219,7 @@ mod test {
     use super::{CTLexerBuilder, LexerKind};
     #[test]
     fn test_grmtools_section_lexerkind() {
-        let lexerkinds = [
-            "LRNonStreamingLexer",
-            "lrnonstreaminglexer",
-            "LexerKind::lrnonstreaminglexer",
-            "lexerkind::LRNonStreamingLexer",
-        ];
+        let lexerkinds = ["LRNonStreamingLexer", "LexerKind::LRNonStreamingLexer"];
         for (i, kind) in lexerkinds.iter().enumerate() {
             let lex_src = format!(
                 "

--- a/lrlex/src/lib/lexer.rs
+++ b/lrlex/src/lib/lexer.rs
@@ -47,7 +47,6 @@ pub struct LexFlags {
 impl<T: Clone> TryFrom<&mut Header<T>> for LexFlags {
     type Error = HeaderError<T>;
     fn try_from(header: &mut Header<T>) -> Result<LexFlags, HeaderError<T>> {
-        use cfgrammar::header::Setting;
         let mut lex_flags = UNSPECIFIED_LEX_FLAGS;
         let LexFlags {
             dot_matches_new_line,
@@ -67,10 +66,10 @@ impl<T: Clone> TryFrom<&mut Header<T>> for LexFlags {
             ($prefix:ident, $it:ident) => {
                 header.mark_used(&stringify!($prefix.$it).to_string());
                 *$it = match header.get(stringify!($prefix.$it)) {
-                    Some(HeaderValue(_, Value::Flag(flag, _))) => Some(*flag),
-                    Some(HeaderValue(loc, _)) => Err(HeaderError {
+                    Some(HeaderValue(_, Value::Bool(flag, _))) => Some(*flag),
+                    Some(HeaderValue(_, val)) => Err(HeaderError {
                         kind: HeaderErrorKind::ConversionError("LexFlags", "Expected boolean"),
-                        locations: vec![loc.clone()],
+                        locations: vec![val.primary_location().clone()],
                     })?,
                     None => None,
                 }
@@ -89,10 +88,10 @@ impl<T: Clone> TryFrom<&mut Header<T>> for LexFlags {
             ($prefix:ident, $it:ident, $num_ty: ty) => {
                 header.mark_used(&stringify!($prefix.$it).to_string());
                 *$it = match header.get(stringify!($prefix.$it)) {
-                    Some(HeaderValue(_, Value::Setting(Setting::Num(n, _)))) => Some(*n as $num_ty),
-                    Some(HeaderValue(loc, _)) => Err(HeaderError {
+                    Some(HeaderValue(_, Value::Num(n, _))) => Some(*n as $num_ty),
+                    Some(HeaderValue(_, val)) => Err(HeaderError {
                         kind: HeaderErrorKind::ConversionError("LexFlags", "Expected numeric"),
-                        locations: vec![loc.clone()],
+                        locations: vec![val.primary_location().clone()],
                     })?,
                     None => None,
                 }
@@ -128,8 +127,8 @@ impl From<&LexFlags> for Header<Location> {
                     header.insert(
                         stringify!($it).to_string(),
                         HeaderValue(
-                            Location::Other("From<&LexFlags".to_string()),
-                            Value::Flag(x, Location::Other("From<&LexFlags>".to_string())),
+                            Location::Other("From<&LexFlags>".to_string()),
+                            Value::Bool(x, Location::Other("From<&LexFlags>".to_string())),
                         ),
                     )
                 });
@@ -148,15 +147,11 @@ impl From<&LexFlags> for Header<Location> {
         macro_rules! cvt_num {
             ($it: ident) => {
                 $it.map(|x| {
-                    use cfgrammar::header::Setting;
                     header.insert(
                         stringify!($it).to_string(),
                         HeaderValue(
-                            Location::Other("From<&LexFlags".to_string()),
-                            Value::Setting(Setting::Num(
-                                x as u64,
-                                Location::Other("From<&LexFlags>".to_string()),
-                            )),
+                            Location::Other("From<&LexFlags>".to_string()),
+                            Value::Num(x as u64, Location::Other("From<&LexFlags>".to_string())),
                         ),
                     )
                 });

--- a/lrpar/cttests/src/grmtools_section.test
+++ b/lrpar/cttests/src/grmtools_section.test
@@ -75,66 +75,70 @@ grammar: |
     }
     ;
 
-    namespaced -> Namespaced<Span>
+    namespaced -> (String, Span)
     : IDENT {
         let ident_span = $1.as_ref().unwrap().span();
-        let ident = $lexer.span_str(ident_span).to_string().to_lowercase();
-        Namespaced{
-            namespace: None,
-            member: (ident, ident_span)
-        }
+        let ident = $lexer.span_str(ident_span).to_string();
+        (ident, ident_span)
     }
     | IDENT '::' IDENT {
         let namespace_span = $1.as_ref().unwrap().span();
-        let namespace = $lexer.span_str(namespace_span).to_string().to_lowercase();
+        let namespace = $lexer.span_str(namespace_span).to_string();
 
         let ident_span = $3.as_ref().unwrap().span();
-        let ident = $lexer.span_str(ident_span).to_string().to_lowercase();
-        Namespaced {
-            namespace: Some((namespace, namespace_span)),
-            member: (ident, ident_span)
-        }
+        let ident = $lexer.span_str(ident_span).to_string();
+        let val = format!("{}::{}", namespace, ident);
+        let span = Span::new(namespace_span.start(), ident_span.end());
+        (val, span)
     }
     ;
 
     valbind -> ((String, Span), Value<Span>)
     : IDENT ':' val {
         let key_span = $1.as_ref().unwrap().span();
-        let key = $lexer.span_str(key_span).to_string().to_lowercase();
-        ((key, key_span), Value::Setting($3))
+        let key = $lexer.span_str(key_span).to_string();
+        ((key, key_span), $3)
     }
     | IDENT {
         let key_span = $1.as_ref().unwrap().span();
-        let key = $lexer.span_str(key_span).to_string().to_lowercase();
-        ((key, key_span), Value::Flag(true, key_span))
+        let key = $lexer.span_str(key_span).to_string();
+        ((key, key_span), Value::Bool(true, key_span))
     }
     | '!' IDENT {
         let bang_span = $1.as_ref().unwrap().span();
         let key_span = $2.as_ref().unwrap().span();
-        let key = $lexer.span_str(key_span).to_string().to_lowercase();
-        ((key, key_span), Value::Flag(false, Span::new(bang_span.start(), key_span.end())))
+        let key = $lexer.span_str(key_span).to_string();
+        ((key, key_span), Value::Bool(false, Span::new(bang_span.start(), key_span.end())))
     }
     ;
 
-    val -> Setting<Span>
-    : namespaced { Setting::Unitary($1) }
+    val -> Value<Span>
+    : namespaced { Value::Namespaced($1.0, $1.1) }
     | NUM  {
         let num_span = $1.as_ref().unwrap().span();
         let n = str::parse::<u64>($lexer.span_str(num_span));
-        Setting::Num(n.expect("convertible"), num_span)
+        Value::Num(n.expect("convertible"), num_span)
     }
     | STRING {
         let string_span = $1.as_ref().unwrap().span();
         // Trim the leading and trailing " characters.
         let string_span = Span::new(string_span.start() + 1, string_span.end() - 1);
         let s = $lexer.span_str(string_span).to_string();
-        Setting::String(s, string_span)
+        Value::String(s, string_span)
     }
-    | namespaced '(' namespaced ')' { Setting::Constructor{ctor: $1, arg: $3} }
-    | '[' array_seq ']' { Setting::Array($2, $1.as_ref().unwrap().span(), $3.as_ref().unwrap().span()) }
+    | namespaced '(' namespaced ')' {
+            let span = Span::new($1.1.start(), $4.as_ref().unwrap().span().end());
+            Value::Namespaced(format!("{}({})", $1.0, $3.0), span)
+        }
+    | '[' array_seq ']' {
+            let open_span = $1.as_ref().unwrap().span();
+            let close_span = $3.as_ref().unwrap().span();
+            let span = Span::new(open_span.start(), close_span.end());
+            Value::Array($2, span)
+        }
     ;
 
-    array_seq -> Vec<Setting<Span>>
+    array_seq -> Vec<Value<Span>>
     : %empty { Vec::new() }
     | val {
         vec![$1]
@@ -155,13 +159,11 @@ grammar: |
     use cfgrammar::{
         Span,
         header::{
-            Value,
-            Setting,
+            Header,
             HeaderError,
             HeaderErrorKind,
-            Namespaced,
-            Header,
             HeaderValue,
+            Value,
             CRATE_KEY_MAP,
             RE_CRATE_DOT,
         },

--- a/lrpar/src/lib/ctbuilder.rs
+++ b/lrpar/src/lib/ctbuilder.rs
@@ -27,7 +27,7 @@ use crate::unstable_api::UnstableApi;
 
 use cfgrammar::{
     Location,
-    header::{Header, HeaderError, HeaderErrorKind, HeaderValue, Namespaced, Setting, Value},
+    header::{Header, HeaderError, HeaderErrorKind, HeaderValue, Value},
     markmap::{Entry, MergeBehavior},
     yacc::{YaccGrammar, YaccKind, ast::ASTWithValidityInfo},
 };
@@ -139,73 +139,33 @@ impl TryFrom<SerialisationFormat> for Value<Location> {
     type Error = cfgrammar::header::HeaderError<Location>;
     fn try_from(kind: SerialisationFormat) -> Result<Value<Location>, HeaderError<Location>> {
         let from_loc = Location::Other("From<SerialisationFormat>".to_string());
-        Ok(match kind {
-            SerialisationFormat::FixedSizeInteger => Value::Setting(Setting::Unitary(Namespaced {
-                namespace: Some(("serialisationformat".to_string(), from_loc.clone())),
-                member: ("fixedsizeinteger".to_string(), from_loc),
-            })),
-            SerialisationFormat::VariableSizedInteger => {
-                Value::Setting(Setting::Unitary(Namespaced {
-                    namespace: Some(("serialisationformat".to_string(), from_loc.clone())),
-                    member: ("variablesizedinteger".to_string(), from_loc),
-                }))
-            }
-        })
+        Ok(Value::Namespaced(
+            format!("SerialisationFormat::{kind:?}"),
+            from_loc,
+        ))
     }
 }
 
 impl<T: Clone + Debug> TryFrom<&Value<T>> for SerialisationFormat {
     type Error = HeaderError<T>;
     fn try_from(value: &Value<T>) -> Result<SerialisationFormat, HeaderError<T>> {
-        let mut err_locs = Vec::new();
         match value {
-            // Finally handle enum values.
-            Value::Setting(Setting::Unitary(Namespaced {
-                namespace,
-                member: (enc_value, enc_value_loc),
-            })) => {
-                if let Some((ns, ns_loc)) = namespace
-                    && ns != "serialisationformat"
-                {
-                    err_locs.push(ns_loc.clone());
+            Value::Namespaced(serialisation_fmt, loc) => match serialisation_fmt.as_str() {
+                "SerialisationFormat::FixedSizeInteger" | "FixedSizeInteger" => {
+                    Ok(SerialisationFormat::FixedSizeInteger)
                 }
-                let encodings = [
-                    (
-                        "fixedsizeinteger".to_string(),
-                        SerialisationFormat::FixedSizeInteger,
-                    ),
-                    (
-                        "variablesizedinteger".to_string(),
-                        SerialisationFormat::VariableSizedInteger,
-                    ),
-                ];
-                let enc_found = encodings
-                    .iter()
-                    .find_map(|(enc_str, enc)| (enc_str == enc_value).then_some(enc));
-                if let Some(enc) = enc_found {
-                    if err_locs.is_empty() {
-                        Ok(*enc)
-                    } else {
-                        Err(HeaderError {
-                            kind: HeaderErrorKind::InvalidEntry("serialisation_format"),
-                            locations: err_locs,
-                        })
-                    }
-                } else {
-                    err_locs.push(enc_value_loc.clone());
-                    Err(HeaderError {
-                        kind: HeaderErrorKind::InvalidEntry("serialisation_format"),
-                        locations: err_locs,
-                    })
+                "SerialisationFormat::VariableSizedInteger" | "VariableSizedInteger" => {
+                    Ok(SerialisationFormat::VariableSizedInteger)
                 }
-            }
-            val => {
-                err_locs.push(val.primary_location().clone());
-                Err(HeaderError {
+                _ => Err(HeaderError {
                     kind: HeaderErrorKind::InvalidEntry("serialisation_format"),
-                    locations: err_locs,
-                })
-            }
+                    locations: vec![loc.clone()],
+                }),
+            },
+            val => Err(HeaderError {
+                kind: HeaderErrorKind::InvalidEntry("serialisation_format"),
+                locations: vec![val.primary_location().clone()],
+            }),
         }
     }
 }
@@ -577,7 +537,7 @@ where
             match header.entry("lrpar.recoverer".to_string()) {
                 Entry::Occupied(_) => unreachable!(),
                 Entry::Vacant(v) => {
-                    let rk_value: Value<Location> = Value::try_from(recoverer)?;
+                    let rk_value = Value::try_from(recoverer)?;
                     let mut o = v.insert_entry(HeaderValue(
                         Location::Other("CTParserBuilder".to_string()),
                         rk_value,
@@ -591,7 +551,7 @@ where
             match header.entry("lrpar.serialisation_format".to_string()) {
                 Entry::Occupied(_) => unreachable!(),
                 Entry::Vacant(v) => {
-                    let rk_value: Value<Location> = Value::try_from(encoding)?;
+                    let rk_value = Value::try_from(encoding)?;
                     let mut o = v.insert_entry(HeaderValue(
                         Location::Other("CTParserBuilder".to_string()),
                         rk_value,

--- a/lrpar/src/lib/parser.rs
+++ b/lrpar/src/lib/parser.rs
@@ -14,7 +14,12 @@ use std::time::{Duration, Instant};
 use web_time::{Duration, Instant};
 
 use cactus::Cactus;
-use cfgrammar::{RIdx, Span, TIdx, header::Value, span::Location, yacc::YaccGrammar};
+use cfgrammar::{
+    RIdx, Span, TIdx,
+    header::{HeaderError, HeaderErrorKind, Value},
+    span::Location,
+    yacc::YaccGrammar,
+};
 use lrtable::{Action, StIdx, StateTable};
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
 use proc_macro2::TokenStream;
@@ -638,55 +643,26 @@ pub enum RecoveryKind {
 impl TryFrom<RecoveryKind> for Value<Location> {
     type Error = cfgrammar::header::HeaderError<Location>;
     fn try_from(rk: RecoveryKind) -> Result<Value<Location>, Self::Error> {
-        use cfgrammar::{
-            Location,
-            header::{Namespaced, Setting},
-        };
         let from_loc = Location::Other("From<RecoveryKind>".to_string());
-        Ok(match rk {
-            RecoveryKind::CPCTPlus => Value::Setting(Setting::Unitary(Namespaced {
-                namespace: Some(("RecoveryKind".to_string(), from_loc.clone())),
-                member: ("CPCTPlus".to_string(), from_loc.clone()),
-            })),
-            RecoveryKind::None => Value::Setting(Setting::Unitary(Namespaced {
-                namespace: Some(("RecoveryKind".to_string(), from_loc.clone())),
-                member: ("None".to_string(), from_loc.clone()),
-            })),
-        })
+        Ok(Value::Namespaced(format!("RecoveryKind::{rk:?}"), from_loc))
     }
 }
 
 impl TryFrom<&Value<Location>> for RecoveryKind {
     type Error = cfgrammar::header::HeaderError<Location>;
     fn try_from(rk: &Value<Location>) -> Result<RecoveryKind, Self::Error> {
-        use cfgrammar::header::{HeaderError, HeaderErrorKind, Namespaced, Setting};
-
         match rk {
-            Value::Setting(Setting::Unitary(Namespaced {
-                namespace,
-                member: (kind, kind_loc),
-            })) => {
-                match namespace {
-                    Some((ns, loc)) if ns.to_lowercase() != "recoverykind" => {
-                        return Err(HeaderError {
-                            kind: HeaderErrorKind::ConversionError(
-                                "RecoveryKind",
-                                "Unknown namespace",
-                            ),
-                            locations: vec![loc.clone()],
-                        });
-                    }
-                    _ => {}
-                }
-                match kind.to_lowercase().as_ref() {
-                    "cpctplus" => Ok(RecoveryKind::CPCTPlus),
-                    "none" => Ok(RecoveryKind::None),
-                    _ => Err(HeaderError {
-                        kind: HeaderErrorKind::ConversionError("RecoveryKind", "Unknown variant"),
-                        locations: vec![kind_loc.clone()],
-                    }),
-                }
-            }
+            Value::Namespaced(rs, loc) => match rs.as_str() {
+                "RecoveryKind::CPCTPlus" | "CPCTPlus" => Ok(RecoveryKind::CPCTPlus),
+                "RecoveryKind::None" | "None" => Ok(RecoveryKind::None),
+                _ => Err(HeaderError {
+                    kind: HeaderErrorKind::ConversionError(
+                        "RecoveryKind",
+                        "Cannot convert to RecoveryKind",
+                    ),
+                    locations: vec![loc.clone()],
+                }),
+            },
             value => Err(HeaderError {
                 kind: HeaderErrorKind::ConversionError(
                     "RecoveryKind",
@@ -1367,7 +1343,7 @@ Call: 'ID' '(' ')';";
 \* '*'
 "#;
         let grammar_src = "
-%grmtools{YaccKind: Original(NoAction)}
+%grmtools{yacckind: Original(NoAction)}
 %start Expr
 %%
 Expr : Expr '+' Term | Term;

--- a/nimbleparse/src/main.rs
+++ b/nimbleparse/src/main.rs
@@ -1,6 +1,6 @@
 use cfgrammar::{
     Location, RIdx, Span, TIdx,
-    header::{GrmtoolsSectionParser, Header, HeaderError, HeaderValue, Setting, Value},
+    header::{GrmtoolsSectionParser, Header, HeaderError, HeaderValue, Value},
     markmap::Entry,
     yacc::{YaccGrammar, YaccKind, YaccOriginalActionKind, ast::ASTWithValidityInfo},
 };
@@ -552,10 +552,10 @@ where
         } else {
             // If given no input paths, try to find some with `test_files` in the header.
             match self.header.get("lrpar.test_files") {
-                Some(HeaderValue(_, Value::Setting(Setting::Array(test_globs, _, _)))) => {
+                Some(HeaderValue(_, Value::Array(test_globs, _))) => {
                     for setting in test_globs {
                         match setting {
-                            Setting::String(s, _) => {
+                            Value::String(s, _) => {
                                 if let Some(yacc_y_path_dir) = self.yacc_y_path.parent() {
                                     let joined = yacc_y_path_dir.join(s);
                                     let joined = joined.as_os_str().to_str();


### PR DESCRIPTION
This is an experiment to see if we can do away with `Value<T>` and all it's friends `Setting`, `Namespaced`, etc.
Replacing it with the much simpler `GrmtoolsSectionValue<T>`. This can lead to slightly worse error messages.
e.g. because we're checking `YaccKind` as a whole including `YaccOriginalActionKind`. But I think it is pretty much limited to that. We could do better, by attempting to parse the `RustLike(string)` rather than the simple matching I've done here. (As well as derive an inner span).

Sadly this patch has ended up kind of redoing some of the case-insensitivity migration in #665
This came up because when experimenting with integrading the lookup methods with the used value checking.
This involved changing the value owned by the `GrammarAST` from a `HashMap<GrmtoolsSectionValue>` to the `Header<T>`. Then the lookup methods would have to `clone` the value and return an owned `GrmtoolsSectionValue`, because there was none to borrow anymore.

It feels like this solves that borrowing issue, but *also* is a much simpler structure, and so cleans up the code a lot?